### PR TITLE
feat: add native Ollama client, OpenAI Responses API integration, and agent bundle framework

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*.sh]
+# like -i=4
+indent_style = space
+indent_size = 4
+
+binary_next_line   = true  # like -bn
+switch_case_indent = true  # like -ci
+space_redirects    = true  # like -sr
+keep_padding       = true  # like -kp

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
 
 jobs:
   goreleaser:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,7 +34,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.6
   PYTHON_VERSION: 3.13.3
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,9 +20,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.5
-  TASK_VERSION: 3.45.5
-  TASK_X_REMOTE_TASKFILES: 1
+  GO_VERSION: 1.25.6
 
 permissions:
   actions: read
@@ -54,27 +52,7 @@ jobs:
           bash .hooks/run-go-tests.sh coverage
 
       - name: Send the coverage output
-        uses: shogo82148/actions-goveralls@25f5320d970fb565100cf1993ada29be1bb196a1 # v1
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
         with:
-          path-to-profile: coverage-all.out
-
-  schema-validation:
-    name: Validate JSON schema is up to date
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout git repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Setup Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-
-      - name: Setup go-task
-        run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v${{ env.TASK_VERSION }}
-          task --version
-
-      - name: Validate schema is in sync with code
-        run: task -y schema:validate
+          files: coverage-all.out
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ TODO
 *.test
 test-results/
 testdata/tmp/
+
+.claude
+FIXME.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@ coverage.out
 dist/
 
 # Generated binaries (local development)
-wg
-/warpgate
-warpgate-linux
+/squad
 *.exe
 *.dll
 *.so
@@ -44,4 +42,3 @@ TODO
 *.test
 test-results/
 testdata/tmp/
-warpgate-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Code coverage output files
+coverage-all.out
+coverage.out
+
+# Distribution directory for binaries
+dist/
+
+# Generated binaries (local development)
+wg
+/warpgate
+warpgate-linux
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Generated directories
+builds/
+
+# Generated logs
+*.log
+
+# Custom attributes files created by macOS
+.DS_Store
+.secrets
+
+# Taskfile
+.task
+
+# Pre-commit artifacts
+node_modules
+
+# Packer artifacts
+manifest.json
+
+# Template discovery artifacts
+discovered-templates.json
+template-matrix.json
+
+# Development artifacts
+TODO
+
+# Test output files (but keep *_test.go files!)
+*.test
+test-results/
+testdata/tmp/
+warpgate-test

--- a/.hooks/go-copyright.sh
+++ b/.hooks/go-copyright.sh
@@ -2,7 +2,7 @@
 set -ex
 
 copyright_header='/*
-Copyright © 2025 Jayson Grace <jayson.e.grace@gmail.com>
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,7 @@ fi
 
 for file in $staged_files; do
     echo "Checking file: $file"
-    if grep -qF "Copyright © 2025 Jayson Grace" "$file"; then
+    if grep -qF "Copyright © 2026 Jayson Grace" "$file"; then
         echo "Current copyright header is up-to-date in $file"
     else
         echo "Updating copyright header in $file"

--- a/.hooks/go-copyright.sh
+++ b/.hooks/go-copyright.sh
@@ -30,7 +30,7 @@ update_copyright() {
     local temp_file
     temp_file=$(mktemp)
     echo "${copyright_header}" > "${temp_file}"
-    echo "" >> "${temp_file}"  # Add an empty line after the header
+    echo "" >> "${temp_file}" # Add an empty line after the header
     sed '/^\/\*/,/^\*\//d' "$file" | sed '/./,$!d' >> "${temp_file}"
     mv "${temp_file}" "${file}"
 }

--- a/.hooks/linters/markdownlint.json
+++ b/.hooks/linters/markdownlint.json
@@ -1,12 +1,14 @@
 {
   "default": true,
   "MD004": false,
-  "MD013": {
-    "code_blocks": false,
-    "line_length": false
-  },
+  "MD013": false,
   "MD029": false,
   "MD033": false,
   "MD034": false,
-  "MD041": false
+  "MD041": false,
+  "MD024": false,
+  "MD025": false,
+  "MD036": false,
+  "MD040": false,
+  "MD060": false
 }

--- a/.hooks/prettier.sh
+++ b/.hooks/prettier.sh
@@ -26,12 +26,12 @@ echo "Running Prettier on staged files..."
 # List all staged files, filter for the desired extensions, and run Prettier
 git diff --cached --name-only --diff-filter=d \
                                               | grep -E '\.(json|ya?ml)$' \
-                            | xargs -I {} prettier --write {}
+                           | xargs -I {} prettier --write {}
 
 # Add the files back to staging area as Prettier may have modified them
 git diff --name-only --diff-filter=d \
                                      | grep -E '\.(json|ya?ml)$' \
-                            | xargs git add
+                           | xargs git add
 
 echo "Prettier formatting completed."
 

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# Semgrep ignore rules
+# Printer monitor uses self-signed certificates intentionally
+dockerfiles/printer-monitor/monitor.py

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,59 @@
+# Goal
+
+Switch the Ollama provider from the OpenAI-compatible endpoint (`/v1/chat/completions`)
+to Ollama's native `/api/chat` endpoint so that:
+
+1. The full agent bundle is processed (not silently truncated to 4096 tokens).
+2. Tool definitions are visible to the model, enabling agentic tool-call loops
+   (Glob, Read, Edit, Grep, Bash).
+3. The context window size (`num_ctx`) is configurable per-request via `--num-ctx`.
+
+## Status
+
+- [x] Native Ollama client (`cmd/squad/ollama.go`) implementing `llms.Model`
+- [x] `--num-ctx` flag (default 32768)
+- [x] Taskfile updated to remove `/v1` from default `BASE_URL`
+- [x] Tool calls confirmed working (PromptTokens: 8654, multi-iteration loops)
+- [x] Model makes edits via Edit tool (`llama3.3:70b` confirmed working)
+
+## Completed
+
+All three goals are met:
+
+1. **Full bundle processing** — `llama3.3:70b` processes the complete go-review
+   agent bundle (system.md + agent.md + go-review-criteria.md + user prompt)
+   without truncation. `prompt_eval_count` values confirm full context ingestion.
+
+2. **Tool-call loops work** — `llama3.3:70b` successfully calls Read, Edit, and
+   Bash in a single iteration, then returns a structured review in subsequent
+   iterations. The agentic loop executes correctly.
+
+3. **`num_ctx` configurable** — `--num-ctx 32768` passes through to the native
+   `/api/chat` request and the model operates at full context width.
+
+### Key fixes applied
+
+- **`flexBool` type** (`cmd/squad/tools.go`): LLMs sometimes send boolean fields
+  as strings (`"false"` instead of `false`). Added a custom JSON unmarshaler that
+  accepts both, unblocking the Edit tool for `llama3.3:70b`.
+
+- **Taskfile default model** updated from `qwen3-coder:30b` to `llama3.3:70b`.
+
+### Model comparison
+
+| Model | Reads files | Generates review | Calls Edit tool |
+|-------|-------------|-----------------|-----------------|
+| `qwen3-coder:30b` | Yes | Yes | No |
+| `qwen3:32b` | Yes | Yes | No |
+| `llama3.3:70b` | Yes | Yes | **Yes** |
+
+### go-review agent verification
+
+The go-review agent (`agents/go-review/`) was tested end-to-end with `llama3.3:70b`:
+
+- Agent bundle builds correctly (system.md + agent.md + references)
+- Output follows the structured format from `system.md` (Summary, Critical Issues,
+  Improvements, Positive Observations, Recommendations)
+- All 12 review categories from `go-review-criteria.md` are available to the model
+- Severity classification (CRITICAL/HIGH/MEDIUM/LOW/INFO) is used in output
+- Tool loop: Read → Edit → Bash executed in a single iteration

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # squad
 
+[![codecov](https://codecov.io/gh/CowDogMoo/squad/graph/badge.svg?token=O74GTQA4J7)](https://codecov.io/gh/CowDogMoo/squad)
+
 Model-agnostic agent CLI built on LangChainGo.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Kubernetes ingress example:
 ```
 
 Notes:
+
 - Ollama does not require an API key; if your client requires one, use any non-empty string (e.g., `--api-key ollama`).
 - For OpenAI-compatible endpoints, `max_tokens` is used for Ollama; OpenAI defaults to `max_completion_tokens` unless you set `--openai-compat-max-tokens`.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# squad
+
+Model-agnostic agent CLI built on LangChainGo.
+
+## Install
+
+Build from source:
+
+```bash
+go build ./cmd/squad
+```
+
+## Quick start
+
+Run an agent:
+
+```bash
+./squad run --agent go-cobra "add a new cobra command"
+```
+
+## Providers
+
+Providers are OpenAI-compatible by default. Configure with flags, env vars, or config:
+
+- base_url
+- api_key
+- model
+
+### Provider matrix
+
+| Provider | Status | API surface | Base URL | API key | Notes |
+| --- | --- | --- | --- | --- | --- |
+| openai | supported | OpenAI-compatible | `https://api.openai.com/v1` (default) | required | Supports `--api-type azure` + `--api-version` for Azure OpenAI. |
+| ollama | supported | OpenAI-compatible | `http://localhost:11434/v1` (default) | optional | Uses `max_tokens` for compatibility; supply any non-empty key if required. |
+| anthropic | planned | — | — | — | Not yet implemented in this CLI. |
+| gemini | planned | — | — | — | Not yet implemented in this CLI. |
+
+### OpenAI (default)
+
+```bash
+./squad run --agent go-cobra --provider openai --model gpt-4.1-mini
+```
+
+### Ollama (OpenAI-compatible)
+
+Ollama is supported via the OpenAI-compatible API surface.
+
+Local Ollama:
+
+```bash
+./squad run --agent go-cobra \
+  --provider ollama \
+  --base-url http://localhost:11434/v1 \
+  --model qwen2.5-coder:7b-instruct
+```
+
+Kubernetes ingress example:
+
+```bash
+./squad run --agent go-cobra \
+  --provider ollama \
+  --base-url https://ollama.techvomit.xyz/v1 \
+  --model qwen2.5-coder:7b-instruct
+```
+
+Notes:
+- Ollama does not require an API key; if your client requires one, use any non-empty string (e.g., `--api-key ollama`).
+- For OpenAI-compatible endpoints, `max_tokens` is used for Ollama; OpenAI defaults to `max_completion_tokens` unless you set `--openai-compat-max-tokens`.
+
+## Configuration
+
+Initialize a config file:
+
+```bash
+./squad config init
+```
+
+Set defaults:
+
+```bash
+./squad config set provider.default ollama
+./squad config set provider.base_url https://ollama.techvomit.xyz/v1
+./squad config set model.default qwen2.5-coder:7b-instruct
+```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  # Provider configuration
+  PROVIDER: '{{.PROVIDER | default "ollama"}}'
+  BASE_URL: '{{.BASE_URL | default "https://ollama.techvomit.xyz/v1"}}'
+  MODEL: '{{.MODEL | default "qwen2.5-coder:3b-instruct"}}'
+  API_KEY: '{{.API_KEY | default "ollama"}}'
+
+  # Agent configuration
+  AGENT: '{{.AGENT | default "go-cobra"}}'
+  WORKING_DIR: '{{.WORKING_DIR | default "."}}'
+  OUT: '{{.OUT | default "/tmp/squad-response.txt"}}'
+
+tasks:
+  default:
+    desc: List all available tasks
+    silent: true
+    cmds:
+      - task --list --sort none
+
+  build:
+    desc: Build the squad binary
+    cmds:
+      - go build -o squad ./cmd/squad/
+
+  run:
+    desc: "Run an agent with a prompt (usage: task run PROMPT='your prompt here')"
+    silent: true
+    vars:
+      PROMPT: '{{.PROMPT | default ""}}'
+    preconditions:
+      - sh: test -n "{{.PROMPT}}"
+        msg: "PROMPT is required. Usage: task run PROMPT='your prompt here'"
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "{{.PROMPT}}" \
+          --agent {{.AGENT}} \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          --base-url {{.BASE_URL}} \
+          --model {{.MODEL}} \
+          --out {{.OUT}}
+
+  run:review-cobra:
+    desc: Run the go-cobra agent to review and fix Cobra/Viper best practices
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Search cmd/squad/*.go for these specific issues and fix them using Edit tool:
+        1. Find any cmd.Flags().Get* calls that should use Viper instead
+        2. Find any cobra.Command without Args validators
+        3. Find any flags without descriptions (empty string after flag name)
+        4. Add missing error wrapping with fmt.Errorf and %w
+
+        List each file you modify and what you changed." \
+          --agent {{.AGENT}} \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          --base-url {{.BASE_URL}} \
+          --model {{.MODEL}} \
+          --out {{.OUT}}
+
+  run:review-cobra:gpt:
+    desc: Review Cobra/Viper best practices using OpenAI GPT
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Review this repo for Cobra/Viper best practices. Apply fixes and describe changes. After making any edits, run 'go build ./...' to verify the code compiles and fix any errors." \
+          --agent go-cobra \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key "$(op item get Openai --fields dreadnode-api-key --reveal)" \
+          --provider openai \
+          --model {{.GPT_MODEL}} \
+          --out {{.OUT}}
+      - echo "Verifying build..."
+      - go build ./...
+    vars:
+      GPT_MODEL: '{{.GPT_MODEL | default "gpt-4o-mini"}}'
+
+  run:review-cobra:ollama:
+    desc: Review Cobra/Viper best practices using Ollama
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Review this repo for Cobra/Viper best practices. Apply fixes and describe changes. After making any edits, run 'go build ./...' to verify the code compiles and fix any errors." \
+          --agent go-cobra \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key ollama \
+          --provider ollama \
+          --base-url {{.BASE_URL}} \
+          --model {{.OLLAMA_MODEL}} \
+          --out {{.OUT}}
+      - echo "Verifying build..."
+      - go build ./...
+    vars:
+      OLLAMA_MODEL: '{{.OLLAMA_MODEL | default "qwen2.5-coder:3b-instruct"}}'
+
+  test:
+    desc: Run tests
+    cmds:
+      - go test -v ./...
+
+  lint:
+    desc: Run linters
+    cmds:
+      - golangci-lint run ./...
+
+  clean:
+    desc: Clean build artifacts
+    cmds:
+      - rm -f squad
+      - rm -f /tmp/squad-*.txt

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,7 +5,7 @@ version: "3"
 vars:
   # Provider configuration
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
-  BASE_URL: '{{.BASE_URL | default "http://localhost:11434"}}'
+  BASE_URL: '{{.BASE_URL | default ""}}'
   MODEL: '{{.MODEL | default "qwen3-coder:30b"}}'
   API_KEY: '{{.API_KEY | default "ollama"}}'
 
@@ -17,6 +17,9 @@ vars:
   # Judge pipeline configuration
   NUM_WORKERS: '{{.NUM_WORKERS | default "3"}}'
   REVIEW_TARGET: '{{.REVIEW_TARGET | default "cmd/squad/tools.go"}}'
+
+  # Internal: conditionally include --base-url flag
+  _BASE_URL_FLAG: '{{if .BASE_URL}}--base-url {{.BASE_URL}}{{end}}'
 
 tasks:
   default:
@@ -46,7 +49,7 @@ tasks:
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
           --provider {{.PROVIDER}} \
-          --base-url {{.BASE_URL}} \
+          {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --out {{.OUT}}
 
@@ -67,7 +70,7 @@ tasks:
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
           --provider {{.PROVIDER}} \
-          --base-url {{.BASE_URL}} \
+          {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --out {{.OUT}}
 
@@ -82,7 +85,7 @@ tasks:
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
           --provider {{.PROVIDER}} \
-          --base-url {{.BASE_URL}} \
+          {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --out /tmp/squad-go-review.txt
       - echo "Review written to /tmp/squad-go-review.txt"
@@ -143,7 +146,7 @@ tasks:
               --working-dir {{.WORKING_DIR}} \
               --api-key {{.API_KEY}} \
               --provider {{.PROVIDER}} \
-              --base-url {{.BASE_URL}} \
+              {{._BASE_URL_FLAG}} \
               --model {{.MODEL}} \
               --require-actionable=false \
               --temperature 0.7 \
@@ -196,7 +199,7 @@ tasks:
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
           --provider {{.PROVIDER}} \
-          --base-url {{.BASE_URL}} \
+          {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --num-ctx 32768 \
           --temperature 0.2 \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,7 +6,7 @@ vars:
   # Provider configuration
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
   BASE_URL: '{{.BASE_URL | default "http://localhost:11434"}}'
-  MODEL: '{{.MODEL | default "llama3.3:70b"}}'
+  MODEL: '{{.MODEL | default "devstral-small-2"}}'
   API_KEY: '{{.API_KEY | default "ollama"}}'
 
   # Agent configuration
@@ -80,8 +80,7 @@ tasks:
           --provider {{.PROVIDER}} \
           --base-url {{.BASE_URL}} \
           --model {{.MODEL}} \
-          --out /tmp/squad-go-review.txt \
-          --require-actionable=false
+          --out /tmp/squad-go-review.txt
       - echo "Review written to /tmp/squad-go-review.txt"
 
   test:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -210,7 +210,9 @@ tasks:
 
         ${WORKER_CONTENT}
 
-        Now read {{.REVIEW_TARGET}} yourself, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report." \
+        Now read {{.REVIEW_TARGET}} yourself, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
+
+        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them. Only fix functional bugs, error handling, resource leaks, concurrency issues, and security problems." \
           --agent go-review-judge \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -278,11 +278,11 @@ tasks:
 
         Start by running Glob with pattern '**/*.go' to discover all Go source files. Then Read each file (skip *_test.go files).
 
-        For each file, check for functional issues against your review criteria. Cross-reference between files — check that types, functions, and interfaces are used correctly across package boundaries.
+        For each file, check for Cobra/Viper best‑practice violations and functional issues against your review criteria. Cross-reference between files — check that types, functions, and interfaces are used correctly across package boundaries.
 
         Report every finding with: severity, category, file, line number, description, and suggested fix. If a file has no issues, skip it silently.
 
-        Do NOT report cosmetic issues (missing doc comments, import ordering, naming style, magic numbers). Only report functional problems.
+        Report structural and UX issues from the cobra‑viper best practices (e.g., flags not bound to Viper, MarkFlagRequired missing, Args validators, command aliases, dynamic completions, signal handling, business logic in cmd/, global flag state). Do NOT report cosmetic issues (missing doc comments, import ordering, naming style, magic numbers).
         Do NOT edit any files. Do NOT use the Edit or Write tools." \
               --agent {{.AGENT}} --mode readonly \
               --working-dir {{.WORKING_DIR}} \
@@ -340,13 +340,12 @@ tasks:
 
         Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, and produce your judge report.
 
-        Your response MUST be ONLY one of:
-        - a valid unified diff in a ```diff``` block, OR
-        - the exact line: "No changes"
+        Use the Edit tool for every fix. If you make any edits, include a "Files Touched" section. If no edits are made, include a "No changes" section.
+        Large refactors are allowed if required to fix consensus findings. You may create new files/packages or move code when needed, but keep changes idiomatic and ensure the build passes.
 
         IMPORTANT: Doc comments, import ordering, and pure whitespace changes are NOT eligible — skip those. Everything else the workers flagged is fair game if you can verify it and the fix compiles. Apply idiomatic refactors — that is the whole point of this review.
 
-        If a fix would require creating new files, adding dependencies, or writing 50+ lines of new code, skip it as too large." \
+        Do not skip a fix solely because it is large if it is required to address consensus findings." \
           --agent go-review-judge \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
@@ -356,7 +355,6 @@ tasks:
           --num-ctx 32768 \
           --temperature 0.2 \
           --require-actionable=true \
-          --apply \
           --out /tmp/squad-judge.txt
         echo "Judge output written to /tmp/squad-judge.txt"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -223,7 +223,8 @@ tasks:
           --model {{.MODEL}} \
           --num-ctx 32768 \
           --temperature 0.2 \
-          --require-actionable=false \
+          --require-actionable=true \
+          --apply \
           --out /tmp/squad-judge.txt
         echo "Judge output written to /tmp/squad-judge.txt"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,6 +28,11 @@ tasks:
     cmds:
       - task --list --sort none
 
+  pre-commit:run-pre-commit:
+    desc: Run pre-commit hooks on all files
+    cmds:
+      - pre-commit run --all-files
+
   build:
     desc: Build the squad binary
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -200,6 +200,7 @@ tasks:
           --model {{.MODEL}} \
           --num-ctx 131072 \
           --temperature 0.2 \
+          --require-actionable=false \
           --out /tmp/squad-judge.txt
         echo "Judge output written to /tmp/squad-judge.txt"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,6 +14,10 @@ vars:
   WORKING_DIR: '{{.WORKING_DIR | default "."}}'
   OUT: '{{.OUT | default "/tmp/squad-response.txt"}}'
 
+  # Judge pipeline configuration
+  NUM_WORKERS: '{{.NUM_WORKERS | default "3"}}'
+  REVIEW_TARGET: '{{.REVIEW_TARGET | default "cmd/squad/tools.go"}}'
+
 tasks:
   default:
     desc: List all available tasks
@@ -92,6 +96,112 @@ tasks:
     desc: Run linters
     cmds:
       - golangci-lint run ./...
+
+  run:judge-review:
+    desc: "Multi-run judge pipeline: N workers review in parallel, judge applies consensus fixes"
+    silent: true
+    cmds:
+      - rm -f /tmp/squad-worker-*.txt /tmp/squad-judge.txt /tmp/squad-workers-combined.txt
+      - task: _run-workers
+      - |
+        # Check quorum: at least 2 workers must have produced output
+        count=0
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            count=$((count + 1))
+          fi
+        done
+        if [ "$count" -lt 2 ]; then
+          echo "ERROR: Only ${count} worker(s) produced output. Need at least 2 for quorum."
+          exit 1
+        fi
+        echo "Quorum met: ${count}/{{.NUM_WORKERS}} workers produced output."
+      - task: _run-judge
+      - |
+        echo ""
+        echo "=== Pipeline complete ==="
+        echo "Worker outputs: /tmp/squad-worker-{1..{{.NUM_WORKERS}}}.txt"
+        echo "Judge output:   /tmp/squad-judge.txt"
+        echo ""
+        echo "Running build verification..."
+      - go build ./...
+      - echo "go build ./... PASSED"
+
+  _run-workers:
+    desc: "Internal: spawn N review workers in parallel"
+    internal: true
+    silent: true
+    cmds:
+      - |
+        echo "Starting {{.NUM_WORKERS}} review workers in parallel..."
+        pids=""
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          (
+            go run ./cmd/squad run \
+              "Review {{.REVIEW_TARGET}} for Go best practices. Use Read to inspect the file, then provide a structured review with findings. Do NOT edit any files." \
+              --agent go-review --mode readonly \
+              --working-dir {{.WORKING_DIR}} \
+              --api-key {{.API_KEY}} \
+              --provider {{.PROVIDER}} \
+              --base-url {{.BASE_URL}} \
+              --model {{.MODEL}} \
+              --require-actionable=false \
+              --temperature 0.7 \
+              --out "/tmp/squad-worker-${i}.txt" \
+              --print=false \
+              2>/dev/null
+            echo "Worker ${i} finished."
+          ) &
+          pids="${pids} $!"
+        done
+        echo "Waiting for all workers to complete..."
+        for pid in ${pids}; do
+          wait ${pid} 2>/dev/null || true
+        done
+        echo "All workers complete."
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            echo "  Worker ${i}: $(wc -l < /tmp/squad-worker-${i}.txt) lines"
+          else
+            echo "  Worker ${i}: EMPTY (failed)"
+          fi
+        done
+
+  _run-judge:
+    desc: "Internal: combine worker outputs and run judge agent"
+    internal: true
+    silent: true
+    cmds:
+      - |
+        echo "Combining worker outputs for judge..."
+        > /tmp/squad-workers-combined.txt
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            echo "--- WORKER ${i} ---" >> /tmp/squad-workers-combined.txt
+            cat "/tmp/squad-worker-${i}.txt" >> /tmp/squad-workers-combined.txt
+            echo "" >> /tmp/squad-workers-combined.txt
+          fi
+        done
+        echo "Running judge agent..."
+        WORKER_CONTENT=$(cat /tmp/squad-workers-combined.txt)
+        go run ./cmd/squad run \
+          "You are judging {{.NUM_WORKERS}} independent reviews of {{.REVIEW_TARGET}}.
+
+        Here are the worker outputs:
+
+        ${WORKER_CONTENT}
+
+        Now read {{.REVIEW_TARGET}} yourself, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report." \
+          --agent go-review-judge \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          --base-url {{.BASE_URL}} \
+          --model {{.MODEL}} \
+          --num-ctx 131072 \
+          --temperature 0.2 \
+          --out /tmp/squad-judge.txt
+        echo "Judge output written to /tmp/squad-judge.txt"
 
   clean:
     desc: Clean build artifacts

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,7 +6,7 @@ vars:
   # Provider configuration
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
   BASE_URL: '{{.BASE_URL | default "http://localhost:11434"}}'
-  MODEL: '{{.MODEL | default "devstral-small-2"}}'
+  MODEL: '{{.MODEL | default "qwen3-coder:30b"}}'
   API_KEY: '{{.API_KEY | default "ollama"}}'
 
   # Agent configuration
@@ -137,7 +137,7 @@ tasks:
         pids=""
         for i in $(seq 1 {{.NUM_WORKERS}}); do
           (
-            go run ./cmd/squad run \
+            go run ./cmd/squad run -v \
               "Review {{.REVIEW_TARGET}} for Go best practices. Use Read to inspect the file, then provide a structured review with findings. Do NOT edit any files." \
               --agent go-review --mode readonly \
               --working-dir {{.WORKING_DIR}} \
@@ -149,12 +149,12 @@ tasks:
               --temperature 0.7 \
               --out "/tmp/squad-worker-${i}.txt" \
               --print=false \
-              2>/dev/null
+              2>"/tmp/squad-worker-${i}.log"
             echo "Worker ${i} finished."
           ) &
           pids="${pids} $!"
         done
-        echo "Waiting for all workers to complete..."
+        echo "Waiting for all workers to complete... (logs: /tmp/squad-worker-{1..{{.NUM_WORKERS}}}.log)"
         for pid in ${pids}; do
           wait ${pid} 2>/dev/null || true
         done
@@ -184,7 +184,7 @@ tasks:
         done
         echo "Running judge agent..."
         WORKER_CONTENT=$(cat /tmp/squad-workers-combined.txt)
-        go run ./cmd/squad run \
+        go run ./cmd/squad run -v \
           "You are judging {{.NUM_WORKERS}} independent reviews of {{.REVIEW_TARGET}}.
 
         Here are the worker outputs:
@@ -198,7 +198,7 @@ tasks:
           --provider {{.PROVIDER}} \
           --base-url {{.BASE_URL}} \
           --model {{.MODEL}} \
-          --num-ctx 131072 \
+          --num-ctx 32768 \
           --temperature 0.2 \
           --require-actionable=false \
           --out /tmp/squad-judge.txt

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,7 +6,7 @@ vars:
   # Provider configuration
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
   BASE_URL: '{{.BASE_URL | default "http://localhost:11434"}}'
-  MODEL: '{{.MODEL | default "qwen3-coder:30b"}}'
+  MODEL: '{{.MODEL | default "llama3.3:70b"}}'
   API_KEY: '{{.API_KEY | default "ollama"}}'
 
   # Agent configuration
@@ -67,43 +67,22 @@ tasks:
           --model {{.MODEL}} \
           --out {{.OUT}}
 
-  run:review-cobra:gpt:
-    desc: Review Cobra/Viper best practices using OpenAI GPT
+  run:go-review:
+    desc: Run the go-review agent to review Go code quality
     silent: true
     cmds:
       - |
         go run ./cmd/squad run -v \
-          "Review this repo for Cobra/Viper best practices. Apply fixes and describe changes. After making any edits, run 'go build ./...' to verify the code compiles and fix any errors." \
-          --agent go-cobra \
+          "Review cmd/squad/tools.go for Go best practices. Use Read to inspect the file, then provide a structured review. If you find issues, use the Edit tool to fix them. Run 'go build ./...' after edits to verify." \
+          --agent go-review \
           --working-dir {{.WORKING_DIR}} \
-          --api-key "$(op item get Openai --fields dreadnode-api-key --reveal)" \
-          --provider openai \
-          --model {{.GPT_MODEL}} \
-          --out {{.OUT}}
-      - echo "Verifying build..."
-      - go build ./...
-    vars:
-      GPT_MODEL: '{{.GPT_MODEL | default "gpt-4o-mini"}}'
-
-  run:review-cobra:ollama:
-    desc: Review Cobra/Viper best practices using Ollama
-    silent: true
-    cmds:
-      - |
-        go run ./cmd/squad run -v \
-          "Review this repo for Cobra/Viper best practices. Apply fixes and describe changes. After making any edits, run 'go build ./...' to verify the code compiles and fix any errors." \
-          --agent go-cobra \
-          --working-dir {{.WORKING_DIR}} \
-          --api-key ollama \
-          --provider ollama \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
           --base-url {{.BASE_URL}} \
-          --model {{.OLLAMA_MODEL}} \
-          --out {{.OUT}} \
+          --model {{.MODEL}} \
+          --out /tmp/squad-go-review.txt \
           --require-actionable=false
-      - echo "Verifying build..."
-      - go build ./...
-    vars:
-      OLLAMA_MODEL: '{{.OLLAMA_MODEL | default "qwen3-coder:30b"}}'
+      - echo "Review written to /tmp/squad-go-review.txt"
 
   test:
     desc: Run tests

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,22 +266,22 @@ tasks:
     silent: true
     cmds:
       - |
-        echo "Starting {{.NUM_WORKERS}} codebase review workers in parallel..."
+        echo "Starting {{.NUM_WORKERS}} codebase review workers (agent={{.AGENT}}) in parallel..."
         pids=""
         for i in $(seq 1 {{.NUM_WORKERS}}); do
           (
             go run ./cmd/squad run -v \
-              "Review the ENTIRE Go codebase using ALL 12 review categories from go-review-criteria.md.
+              "Review the ENTIRE Go codebase.
 
         Start by running Glob with pattern '**/*.go' to discover all Go source files. Then Read each file (skip *_test.go files).
 
-        For each file, check for functional issues: error handling bugs, resource leaks, concurrency problems, security issues, incorrect logic, and API misuse. Cross-reference between files — check that types, functions, and interfaces are used correctly across package boundaries.
+        For each file, check for functional issues against your review criteria. Cross-reference between files — check that types, functions, and interfaces are used correctly across package boundaries.
 
         Report every finding with: severity, category, file, line number, description, and suggested fix. If a file has no issues, skip it silently.
 
         Do NOT report cosmetic issues (missing doc comments, import ordering, naming style, magic numbers). Only report functional problems.
         Do NOT edit any files. Do NOT use the Edit or Write tools." \
-              --agent go-review --mode readonly \
+              --agent {{.AGENT}} --mode readonly \
               --working-dir {{.WORKING_DIR}} \
               --api-key {{.API_KEY}} \
               --provider {{.PROVIDER}} \
@@ -337,7 +337,17 @@ tasks:
 
         Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
 
-        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them. Only fix functional bugs, error handling, resource leaks, concurrency issues, and security problems." \
+        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them.
+
+        These categories ARE eligible for fixes in this Cobra/Viper review:
+        - Using Run instead of RunE (fix: change to RunE and return nil)
+        - Reading flags directly instead of using Viper (fix: replace cmd.Flags().Get* with v.Get*)
+        - Missing Args validation on commands (fix: add appropriate cobra.ExactArgs/NoArgs/etc)
+        - Missing error wrapping (fix: wrap with fmt.Errorf and %%w)
+        - Ignored errors from BindPFlag (fix: check error return)
+        - Functional bugs, error handling, resource leaks, concurrency issues, and security problems
+
+        Findings about project structure, config validation architecture, global Viper refactoring, or adding entirely new features (graceful shutdown, shell completions) require too much new code — skip those." \
           --agent go-review-judge \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,8 +5,8 @@ version: "3"
 vars:
   # Provider configuration
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
-  BASE_URL: '{{.BASE_URL | default "https://ollama.techvomit.xyz/v1"}}'
-  MODEL: '{{.MODEL | default "qwen2.5-coder:3b-instruct"}}'
+  BASE_URL: '{{.BASE_URL | default "http://localhost:11434"}}'
+  MODEL: '{{.MODEL | default "qwen3-coder:30b"}}'
   API_KEY: '{{.API_KEY | default "ollama"}}'
 
   # Agent configuration
@@ -98,11 +98,12 @@ tasks:
           --provider ollama \
           --base-url {{.BASE_URL}} \
           --model {{.OLLAMA_MODEL}} \
-          --out {{.OUT}}
+          --out {{.OUT}} \
+          --require-actionable=false
       - echo "Verifying build..."
       - go build ./...
     vars:
-      OLLAMA_MODEL: '{{.OLLAMA_MODEL | default "qwen2.5-coder:3b-instruct"}}'
+      OLLAMA_MODEL: '{{.OLLAMA_MODEL | default "qwen3-coder:30b"}}'
 
   test:
     desc: Run tests

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -338,7 +338,11 @@ tasks:
 
         ${WORKER_CONTENT}
 
-        Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
+        Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, and produce your judge report.
+
+        Your response MUST be ONLY one of:
+        - a valid unified diff in a ```diff``` block, OR
+        - the exact line: "No changes"
 
         IMPORTANT: Doc comments, import ordering, and pure whitespace changes are NOT eligible — skip those. Everything else the workers flagged is fair game if you can verify it and the fix compiles. Apply idiomatic refactors — that is the whole point of this review.
 
@@ -351,7 +355,8 @@ tasks:
           --model {{.MODEL}} \
           --num-ctx 32768 \
           --temperature 0.2 \
-          --require-actionable=false \
+          --require-actionable=true \
+          --apply \
           --out /tmp/squad-judge.txt
         echo "Judge output written to /tmp/squad-judge.txt"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -212,7 +212,9 @@ tasks:
 
         Now read {{.REVIEW_TARGET}} yourself, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
 
-        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them. Only fix functional bugs, error handling, resource leaks, concurrency issues, and security problems." \
+        IMPORTANT: Doc comments, import ordering, and pure whitespace changes are NOT eligible — skip those. Everything else the workers flagged is fair game if you can verify it and the fix compiles. Apply idiomatic refactors — that is the whole point of this review.
+
+        If a fix would require creating new files, adding dependencies, or writing 50+ lines of new code, skip it as too large." \
           --agent go-review-judge \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
@@ -337,17 +339,9 @@ tasks:
 
         Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
 
-        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them.
+        IMPORTANT: Doc comments, import ordering, and pure whitespace changes are NOT eligible — skip those. Everything else the workers flagged is fair game if you can verify it and the fix compiles. Apply idiomatic refactors — that is the whole point of this review.
 
-        These categories ARE eligible for fixes in this Cobra/Viper review:
-        - Using Run instead of RunE (fix: change to RunE and return nil)
-        - Reading flags directly instead of using Viper (fix: replace cmd.Flags().Get* with v.Get*)
-        - Missing Args validation on commands (fix: add appropriate cobra.ExactArgs/NoArgs/etc)
-        - Missing error wrapping (fix: wrap with fmt.Errorf and %%w)
-        - Ignored errors from BindPFlag (fix: check error return)
-        - Functional bugs, error handling, resource leaks, concurrency issues, and security problems
-
-        Findings about project structure, config validation architecture, global Viper refactoring, or adding entirely new features (graceful shutdown, shell completions) require too much new code — skip those." \
+        If a fix would require creating new files, adding dependencies, or writing 50+ lines of new code, skip it as too large." \
           --agent go-review-judge \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -225,6 +225,131 @@ tasks:
           --out /tmp/squad-judge.txt
         echo "Judge output written to /tmp/squad-judge.txt"
 
+  run:judge-codebase:
+    desc: "Run judge-review pipeline across the entire Go codebase"
+    silent: true
+    cmds:
+      - rm -f /tmp/squad-worker-*.txt /tmp/squad-judge.txt /tmp/squad-workers-combined.txt
+      - task: _run-codebase-workers
+      - |
+        # Check quorum: at least 2 workers must have produced usable output
+        count=0
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            findings=$(grep -c '^\*\*Severity:\*\*\|^### ' "/tmp/squad-worker-${i}.txt" 2>/dev/null || echo 0)
+            if [ "$findings" -ge 2 ]; then
+              count=$((count + 1))
+            else
+              echo "WARNING: Worker ${i} output has fewer than 2 findings — excluding from quorum."
+            fi
+          fi
+        done
+        if [ "$count" -lt 2 ]; then
+          echo "ERROR: Only ${count} worker(s) produced usable output. Need at least 2 for quorum."
+          exit 1
+        fi
+        echo "Quorum met: ${count}/{{.NUM_WORKERS}} workers produced usable output."
+      - task: _run-codebase-judge
+      - |
+        echo ""
+        echo "=== Codebase Review Complete ==="
+        echo "Worker outputs: /tmp/squad-worker-{1..{{.NUM_WORKERS}}}.txt"
+        echo "Judge output:   /tmp/squad-judge.txt"
+        echo ""
+        echo "Running build verification..."
+      - go build ./...
+      - echo "go build ./... PASSED"
+
+  _run-codebase-workers:
+    desc: "Internal: spawn N workers to review entire codebase"
+    internal: true
+    silent: true
+    cmds:
+      - |
+        echo "Starting {{.NUM_WORKERS}} codebase review workers in parallel..."
+        pids=""
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          (
+            go run ./cmd/squad run -v \
+              "Review the ENTIRE Go codebase using ALL 12 review categories from go-review-criteria.md.
+
+        Start by running Glob with pattern '**/*.go' to discover all Go source files. Then Read each file (skip *_test.go files).
+
+        For each file, check for functional issues: error handling bugs, resource leaks, concurrency problems, security issues, incorrect logic, and API misuse. Cross-reference between files — check that types, functions, and interfaces are used correctly across package boundaries.
+
+        Report every finding with: severity, category, file, line number, description, and suggested fix. If a file has no issues, skip it silently.
+
+        Do NOT report cosmetic issues (missing doc comments, import ordering, naming style, magic numbers). Only report functional problems.
+        Do NOT edit any files. Do NOT use the Edit or Write tools." \
+              --agent go-review --mode readonly \
+              --working-dir {{.WORKING_DIR}} \
+              --api-key {{.API_KEY}} \
+              --provider {{.PROVIDER}} \
+              {{._BASE_URL_FLAG}} \
+              --model {{.MODEL}} \
+              --require-actionable=false \
+              --temperature 0.7 \
+              --out "/tmp/squad-worker-${i}.txt" \
+              --print=false \
+              2>"/tmp/squad-worker-${i}.log"
+            echo "Worker ${i} finished."
+          ) &
+          pids="${pids} $!"
+        done
+        echo "Waiting for all workers to complete... (logs: /tmp/squad-worker-{1..{{.NUM_WORKERS}}}.log)"
+        for pid in ${pids}; do
+          wait ${pid} 2>/dev/null || true
+        done
+        echo "All workers complete."
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            lines=$(wc -l < "/tmp/squad-worker-${i}.txt")
+            findings=$(grep -c '^\*\*Severity:\*\*\|^### ' "/tmp/squad-worker-${i}.txt" 2>/dev/null || echo 0)
+            echo "  Worker ${i}: ${lines} lines, ${findings} findings"
+          else
+            echo "  Worker ${i}: EMPTY (failed)"
+          fi
+        done
+
+  _run-codebase-judge:
+    desc: "Internal: combine codebase worker outputs and run judge agent"
+    internal: true
+    silent: true
+    cmds:
+      - |
+        echo "Combining worker outputs for judge..."
+        > /tmp/squad-workers-combined.txt
+        for i in $(seq 1 {{.NUM_WORKERS}}); do
+          if [ -s "/tmp/squad-worker-${i}.txt" ]; then
+            echo "--- WORKER ${i} ---" >> /tmp/squad-workers-combined.txt
+            cat "/tmp/squad-worker-${i}.txt" >> /tmp/squad-workers-combined.txt
+            echo "" >> /tmp/squad-workers-combined.txt
+          fi
+        done
+        echo "Running judge agent..."
+        WORKER_CONTENT=$(cat /tmp/squad-workers-combined.txt)
+        go run ./cmd/squad run -v \
+          "You are judging {{.NUM_WORKERS}} independent reviews of the ENTIRE Go codebase.
+
+        Here are the worker outputs:
+
+        ${WORKER_CONTENT}
+
+        Now use Glob to discover all Go files, Read each one the workers referenced, tally findings across workers, validate each finding against the actual code, apply consensus fixes per your severity gating rules, verify with 'go build ./...', and produce your judge report.
+
+        IMPORTANT: Doc comments, cosmetic changes, magic number extraction, and style fixes are NOT eligible for the Edit tool — skip them even if workers flagged them. Only fix functional bugs, error handling, resource leaks, concurrency issues, and security problems." \
+          --agent go-review-judge \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          {{._BASE_URL_FLAG}} \
+          --model {{.MODEL}} \
+          --num-ctx 32768 \
+          --temperature 0.2 \
+          --require-actionable=false \
+          --out /tmp/squad-judge.txt
+        echo "Judge output written to /tmp/squad-judge.txt"
+
   clean:
     desc: Clean build artifacts
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -107,18 +107,23 @@ tasks:
       - rm -f /tmp/squad-worker-*.txt /tmp/squad-judge.txt /tmp/squad-workers-combined.txt
       - task: _run-workers
       - |
-        # Check quorum: at least 2 workers must have produced output
+        # Check quorum: at least 2 workers must have produced usable output
         count=0
         for i in $(seq 1 {{.NUM_WORKERS}}); do
           if [ -s "/tmp/squad-worker-${i}.txt" ]; then
-            count=$((count + 1))
+            findings=$(grep -c '^\*\*Severity:\*\*\|^### ' "/tmp/squad-worker-${i}.txt" 2>/dev/null || echo 0)
+            if [ "$findings" -ge 2 ]; then
+              count=$((count + 1))
+            else
+              echo "WARNING: Worker ${i} output has fewer than 2 findings — excluding from quorum."
+            fi
           fi
         done
         if [ "$count" -lt 2 ]; then
-          echo "ERROR: Only ${count} worker(s) produced output. Need at least 2 for quorum."
+          echo "ERROR: Only ${count} worker(s) produced usable output. Need at least 2 for quorum."
           exit 1
         fi
-        echo "Quorum met: ${count}/{{.NUM_WORKERS}} workers produced output."
+        echo "Quorum met: ${count}/{{.NUM_WORKERS}} workers produced usable output."
       - task: _run-judge
       - |
         echo ""
@@ -141,7 +146,13 @@ tasks:
         for i in $(seq 1 {{.NUM_WORKERS}}); do
           (
             go run ./cmd/squad run -v \
-              "Review {{.REVIEW_TARGET}} for Go best practices. Use Read to inspect the file, then provide a structured review with findings. Do NOT edit any files." \
+              "Review {{.REVIEW_TARGET}} using ALL 12 review categories from go-review-criteria.md.
+
+        For each category, Read the file and check for issues. You MUST use the Read tool and Grep tool to inspect the actual code — do not guess.
+
+        Report every finding with: severity, category, file, line number, description, and suggested fix. If a category has no issues, skip it.
+
+        Do NOT edit any files. Do NOT use the Edit or Write tools." \
               --agent go-review --mode readonly \
               --working-dir {{.WORKING_DIR}} \
               --api-key {{.API_KEY}} \
@@ -164,7 +175,12 @@ tasks:
         echo "All workers complete."
         for i in $(seq 1 {{.NUM_WORKERS}}); do
           if [ -s "/tmp/squad-worker-${i}.txt" ]; then
-            echo "  Worker ${i}: $(wc -l < /tmp/squad-worker-${i}.txt) lines"
+            lines=$(wc -l < "/tmp/squad-worker-${i}.txt")
+            findings=$(grep -c '^\*\*Severity:\*\*\|^### ' "/tmp/squad-worker-${i}.txt" 2>/dev/null || echo 0)
+            echo "  Worker ${i}: ${lines} lines, ${findings} findings"
+            if [ "$findings" -lt 2 ]; then
+              echo "  Worker ${i}: WARNING — fewer than 2 findings, output may be low quality"
+            fi
           else
             echo "  Worker ${i}: EMPTY (failed)"
           fi

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ModeOverride represents an override for agent mode configuration in the manifest.
+type ModeOverride struct {
+	EntryPoint string   `yaml:"entrypoint,omitempty"`
+	Wrapper    string   `yaml:"wrapper,omitempty"`
+	References []string `yaml:"references,omitempty"`
+}
+
+// Manifest represents the structure of an agent's manifest file.
+type Manifest struct {
+	Name       string                  `yaml:"name"`
+	Version    string                  `yaml:"version"`
+	EntryPoint string                  `yaml:"entrypoint"`
+	Wrapper    string                  `yaml:"wrapper"`
+	References []string                `yaml:"references"`
+	Modes      map[string]ModeOverride `yaml:"modes,omitempty"`
+}
+
+// Bundle contains the assembled system, user, and combined prompt content for an agent run.
+type Bundle struct {
+	System   string // wrapper + system prompt + references
+	User     string // user request only
+	Combined []byte // concatenated for --print-bundle/--bundle-out
+	WorkDir  string
+}
+
+// BuildBundle assembles the agent bundle from manifest, system prompt, wrapper, and references.
+func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string) (*Bundle, error) {
+	agentPath := filepath.Join(agentsDir, agentName)
+	manifestPath := filepath.Join(agentPath, "agent.yaml")
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read agent manifest: %w", err)
+	}
+
+	var manifest Manifest
+	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
+	}
+
+	if mode != "" {
+		override, ok := manifest.Modes[mode]
+		if !ok {
+			return nil, fmt.Errorf("agent %q has no mode %q", agentName, mode)
+		}
+		if override.EntryPoint != "" {
+			manifest.EntryPoint = override.EntryPoint
+		}
+		if override.Wrapper != "" {
+			manifest.Wrapper = override.Wrapper
+		}
+		if len(override.References) > 0 {
+			manifest.References = override.References
+		}
+	}
+
+	entryPath := filepath.Join(agentPath, manifest.EntryPoint)
+	systemData, err := os.ReadFile(entryPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read system prompt: %w", err)
+	}
+
+	wrapperPath := filepath.Join(agentPath, manifest.Wrapper)
+	wrapperData, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read agent wrapper: %w", err)
+	}
+
+	var refs []string
+	for _, ref := range manifest.References {
+		if strings.TrimSpace(ref) == "" {
+			continue
+		}
+		refPath := filepath.Join(agentPath, ref)
+		refData, err := os.ReadFile(refPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read reference %s: %w", ref, err)
+		}
+		refs = append(refs, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(string(refData))))
+	}
+
+	// Build the system message content (wrapper + system prompt + references).
+	var sys bytes.Buffer
+	sys.WriteString("# Squad Agent Bundle\n\n")
+	sys.WriteString(fmt.Sprintf("Agent: %s (%s)\n", manifest.Name, manifest.Version))
+	sys.WriteString(fmt.Sprintf("Working Directory: %s\n\n", workingDir))
+	sys.WriteString("## Agent Wrapper\n\n")
+	sys.Write(wrapperData)
+	sys.WriteString("\n\n## System Prompt\n\n")
+	sys.Write(systemData)
+
+	if len(refs) > 0 {
+		sys.WriteString("\n\n## References\n\n")
+		for _, ref := range refs {
+			sys.WriteString(ref)
+			sys.WriteString("\n")
+		}
+	}
+
+	// Build the combined output for --print-bundle/--bundle-out.
+	var combined bytes.Buffer
+	combined.Write(sys.Bytes())
+	combined.WriteString("\n\n## User Request\n\n")
+	combined.WriteString(prompt)
+	combined.WriteString("\n")
+
+	return &Bundle{
+		System:   sys.String(),
+		User:     prompt,
+		Combined: combined.Bytes(),
+		WorkDir:  workingDir,
+	}, nil
+}

--- a/agents/ansible-review/README.md
+++ b/agents/ansible-review/README.md
@@ -126,6 +126,7 @@ Run the test script to validate the pattern:
 ```
 
 This will:
+
 1. Test against a playbook with common anti-patterns
 2. Test against a well-structured playbook
 3. Validate the filter script functionality

--- a/agents/ansible-review/agent.yaml
+++ b/agents/ansible-review/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: ansible-review
 version: 0.1.0
 description: Review Ansible playbooks/roles for best practices and apply fixes.

--- a/agents/ansible-review/references/ansible-standards.md
+++ b/agents/ansible-review/references/ansible-standards.md
@@ -24,7 +24,7 @@ for the ansible-review pattern.
 
 ## The Zen of Ansible
 
-> *By Tim Appnel*
+> _By Tim Appnel_
 
 Before diving into specifics, understand the guiding philosophy:
 
@@ -82,22 +82,22 @@ The `galaxy.yml` file is required at the collection root:
 ```yaml
 ---
 # Required fields
-namespace: my_namespace              # lowercase, alphanumeric, underscores
-name: my_collection                  # lowercase, alphanumeric, underscores
-version: "1.0.0"                     # semantic versioning
-readme: README.md                    # path to markdown readme
+namespace: my_namespace # lowercase, alphanumeric, underscores
+name: my_collection # lowercase, alphanumeric, underscores
+version: "1.0.0" # semantic versioning
+readme: README.md # path to markdown readme
 authors:
   - "Your Name <email@example.com>"
 
 # Recommended fields
 description: "Brief description of the collection"
 license:
-  - MIT                              # SPDX license identifier
-license_file: LICENSE                # Alternative to license list
+  - MIT # SPDX license identifier
+license_file: LICENSE # Alternative to license list
 
 # Discovery and linking
 tags:
-  - networking                       # lowercase, max 20 tags, 64 chars each
+  - networking # lowercase, max 20 tags, 64 chars each
   - automation
   - infrastructure
 repository: "https://github.com/org/collection"
@@ -205,7 +205,7 @@ roles/my_role/
    ```yaml
    # meta/main.yml - minimize dependencies
    ---
-   dependencies: []  # Prefer explicit role inclusion in playbooks
+   dependencies: [] # Prefer explicit role inclusion in playbooks
    ```
 
 3. **Fail fast with argument specs** - Validate inputs at role start
@@ -233,18 +233,18 @@ roles/my_role/
    - name: Get service status
      ansible.builtin.command: systemctl status nginx
      register: nginx_status
-     changed_when: false  # Read-only command
-     check_mode: false    # Run even in check mode
+     changed_when: false # Read-only command
+     check_mode: false # Run even in check mode
    ```
 
 ### Variable Management
 
 **Defaults vs Vars:**
 
-| Location | Precedence | Use Case |
-|----------|------------|----------|
-| `defaults/main.yml` | Lowest | User-configurable values |
-| `vars/main.yml` | Higher | Internal constants, magic values |
+| Location            | Precedence | Use Case                         |
+| ------------------- | ---------- | -------------------------------- |
+| `defaults/main.yml` | Lowest     | User-configurable values         |
+| `vars/main.yml`     | Higher     | Internal constants, magic values |
 
 **Naming conventions:**
 
@@ -355,7 +355,7 @@ roles:
     tags:
       - nginx
       - web
-      - never  # Skip unless explicitly called
+      - never # Skip unless explicitly called
 ```
 
 **Tag best practices:**
@@ -392,7 +392,7 @@ Roles must produce the same result on repeated runs:
 - name: Check application version
   ansible.builtin.command: /opt/app/version.sh
   register: app_version
-  changed_when: false  # Read-only, never changed
+  changed_when: false # Read-only, never changed
 
 - name: Update configuration
   ansible.builtin.template:
@@ -406,16 +406,16 @@ Roles must produce the same result on repeated runs:
 
 ## Naming Conventions
 
-| Element | Convention | Example |
-|---------|------------|---------|
-| Collections | `namespace.collection_name` | `acme.networking` |
-| Roles | lowercase, underscores | `nginx_reverse_proxy` |
-| Variables | lowercase, underscores, role prefix | `nginx_worker_count` |
-| Internal vars | double underscore prefix | `__nginx_internal_flag` |
-| Tasks | Start with verb, descriptive | `Ensure nginx is running` |
-| Handlers | Describe action | `Restart nginx` |
-| Tags | lowercase, hyphenated | `web-server`, `database` |
-| Files | lowercase, descriptive | `nginx.conf.j2` |
+| Element       | Convention                          | Example                   |
+| ------------- | ----------------------------------- | ------------------------- |
+| Collections   | `namespace.collection_name`         | `acme.networking`         |
+| Roles         | lowercase, underscores              | `nginx_reverse_proxy`     |
+| Variables     | lowercase, underscores, role prefix | `nginx_worker_count`      |
+| Internal vars | double underscore prefix            | `__nginx_internal_flag`   |
+| Tasks         | Start with verb, descriptive        | `Ensure nginx is running` |
+| Handlers      | Describe action                     | `Restart nginx`           |
+| Tags          | lowercase, hyphenated               | `web-server`, `database`  |
+| Files         | lowercase, descriptive              | `nginx.conf.j2`           |
 
 ---
 
@@ -470,16 +470,16 @@ Always use Fully Qualified Collection Names:
 - name: Set file permissions
   ansible.builtin.file:
     path: /etc/app/config.yml
-    mode: "0644"  # Quoted to prevent octal interpretation
+    mode: "0644" # Quoted to prevent octal interpretation
 
 - name: Enable service
   ansible.builtin.service:
     name: nginx
-    enabled: true  # Use true/false, not yes/no
+    enabled: true # Use true/false, not yes/no
 
 - name: Template configuration
   ansible.builtin.template:
-    src: "{{ config_template }}"  # Quoted Jinja2
+    src: "{{ config_template }}" # Quoted Jinja2
     dest: /etc/app/config.yml
 ```
 
@@ -701,7 +701,7 @@ platforms:
 ```yaml
 # .ansible-lint
 ---
-profile: production  # min, basic, moderate, safety, shared, production
+profile: production # min, basic, moderate, safety, shared, production
 
 # Enable optional rules
 enable_list:
@@ -712,7 +712,7 @@ enable_list:
 
 # Skip specific rules (use sparingly)
 skip_list:
-  - role-name[path]  # When role path doesn't match name
+  - role-name[path] # When role path doesn't match name
 
 # Exclude paths
 exclude_paths:
@@ -730,14 +730,14 @@ offline: false
 
 ### Common Rules
 
-| Rule | Description |
-|------|-------------|
-| `yaml[line-length]` | Lines should be <=160 chars |
-| `name[casing]` | Task names should be capitalized |
-| `fqcn[action-core]` | Use FQCN for builtin modules |
-| `no-changed-when` | Commands should have `changed_when` |
-| `risky-shell-pipe` | Shell pipes can hide failures |
-| `package-latest` | Avoid `state: latest` |
+| Rule                | Description                         |
+| ------------------- | ----------------------------------- |
+| `yaml[line-length]` | Lines should be <=160 chars         |
+| `name[casing]`      | Task names should be capitalized    |
+| `fqcn[action-core]` | Use FQCN for builtin modules        |
+| `no-changed-when`   | Commands should have `changed_when` |
+| `risky-shell-pipe`  | Shell pipes can hide failures       |
+| `package-latest`    | Avoid `state: latest`               |
 
 ### YAML Style
 
@@ -826,40 +826,40 @@ ansible-playbook site.yml --ask-vault-pass
 
 ### Collection Anti-Patterns
 
-| Anti-Pattern | Problem | Solution |
-|--------------|---------|----------|
+| Anti-Pattern       | Problem                 | Solution                        |
+| ------------------ | ----------------------- | ------------------------------- |
 | Short module names | Ambiguous, may conflict | Use FQCN: `ansible.builtin.apt` |
-| Missing galaxy.yml | Cannot distribute | Add required metadata |
-| Plugins in roles | Hard to share, test | Centralize in `plugins/` |
-| No runtime.yml | Version mismatches | Specify `requires_ansible` |
+| Missing galaxy.yml | Cannot distribute       | Add required metadata           |
+| Plugins in roles   | Hard to share, test     | Centralize in `plugins/`        |
+| No runtime.yml     | Version mismatches      | Specify `requires_ansible`      |
 
 ### Role Anti-Patterns
 
-| Anti-Pattern | Problem | Solution |
-|--------------|---------|----------|
-| Monolithic roles | Hard to test, reuse | Single responsibility |
-| Hardcoded values | Not reusable | Use defaults/vars |
-| No argument specs | Silent failures | Add validation |
+| Anti-Pattern           | Problem             | Solution              |
+| ---------------------- | ------------------- | --------------------- |
+| Monolithic roles       | Hard to test, reuse | Single responsibility |
+| Hardcoded values       | Not reusable        | Use defaults/vars     |
+| No argument specs      | Silent failures     | Add validation        |
 | Excessive dependencies | Coupling, conflicts | Minimize dependencies |
 
 ### Task Anti-Patterns
 
-| Anti-Pattern | Problem | Solution |
-|--------------|---------|----------|
-| `command`/`shell` without guards | Not idempotent | Use `creates`/`removes` |
-| Missing `changed_when` | False positives | Set explicit conditions |
-| `state: latest` | Non-deterministic | Pin versions |
-| Unnamed tasks | Hard to debug | Descriptive names |
-| Complex Jinja2 in playbooks | Hard to read | Use filters or variables |
+| Anti-Pattern                     | Problem           | Solution                 |
+| -------------------------------- | ----------------- | ------------------------ |
+| `command`/`shell` without guards | Not idempotent    | Use `creates`/`removes`  |
+| Missing `changed_when`           | False positives   | Set explicit conditions  |
+| `state: latest`                  | Non-deterministic | Pin versions             |
+| Unnamed tasks                    | Hard to debug     | Descriptive names        |
+| Complex Jinja2 in playbooks      | Hard to read      | Use filters or variables |
 
 ### Testing Anti-Patterns
 
-| Anti-Pattern | Problem | Solution |
-|--------------|---------|----------|
-| No Molecule tests | Untested code | Add default scenario |
-| Missing verify.yml | No validation | Add verification tasks |
-| Single platform tests | Hidden bugs | Test multiple platforms |
-| No idempotence check | Not idempotent | Include in test sequence |
+| Anti-Pattern          | Problem        | Solution                 |
+| --------------------- | -------------- | ------------------------ |
+| No Molecule tests     | Untested code  | Add default scenario     |
+| Missing verify.yml    | No validation  | Add verification tasks   |
+| Single platform tests | Hidden bugs    | Test multiple platforms  |
+| No idempotence check  | Not idempotent | Include in test sequence |
 
 ---
 
@@ -935,4 +935,4 @@ ansible-playbook site.yml --ask-vault-pass
 
 ---
 
-*Last updated: 2025-01-15*
+_Last updated: 2026-01-15_

--- a/agents/ansible-review/system.md
+++ b/agents/ansible-review/system.md
@@ -95,12 +95,14 @@ Structure your review with clear sections:
 **Impact:** [Why it matters]
 
 **Problem:**
+
 ```yaml
 # Current code
 [problematic code snippet]
 ```
 
 **Solution:**
+
 ```yaml
 # Suggested fix
 [improved code snippet]
@@ -118,11 +120,13 @@ Structure your review with clear sections:
 **Category:** [category]
 
 **Current:**
+
 ```yaml
 [current approach]
 ```
 
 **Suggested:**
+
 ```yaml
 [better approach]
 ```

--- a/agents/ansible-review/system.md
+++ b/agents/ansible-review/system.md
@@ -1,7 +1,7 @@
 # IDENTITY and PURPOSE
 
 You are an expert Ansible code reviewer with deep knowledge of idiomatic Ansible
-patterns, best practices, and modern ecosystem standards (2025). Your role is to
+patterns, best practices, and modern ecosystem standards (2026). Your role is to
 analyze Ansible collections, roles, playbooks, and Molecule tests to provide
 constructive feedback focused on improving code quality, maintainability, and
 adherence to Ansible community conventions.

--- a/agents/go-cobra/README.md
+++ b/agents/go-cobra/README.md
@@ -1,22 +1,21 @@
-# Go Cobra Pattern
+# Go Cobra Agent
 
-A comprehensive fabric pattern for reviewing Go CLI applications built with Cobra and Viper against industry best practices and idiomatic patterns. This pattern analyzes CLI code and provides constructive, actionable feedback with severity-based findings.
+An agent for reviewing Go CLI applications built with Cobra and Viper against industry best practices and idiomatic patterns. The agent analyzes CLI code and provides constructive, actionable feedback with severity-based findings.
 
-## Pattern Structure
+## Agent Structure
 
-This pattern includes:
-- **`system.md`** - The review framework and prompt engineering for LLM
-- **`cobra-viper-best-practices.md`** - Comprehensive reference document with detailed criteria (source of truth)
-- **`filter.sh`** - Post-processing to clean up output formatting
+This agent includes:
+- **`agent.yaml`** - Minimal manifest for metadata and references
+- **`agent.md`** - Agent-mode wrapper instructions
+- **`system.md`** - The review framework and prompt
+- **`references/cobra-viper-best-practices.md`** - Comprehensive reference document with detailed criteria (source of truth)
 - **`README.md`** - This documentation
-- **`test-cli-issues.go`** - Sample CLI code with various issues for testing
-- **`test-pattern.sh`** - Automated testing script
 
-The pattern is designed with **separation of concerns**: the `cobra-viper-best-practices.md` contains the comprehensive knowledge base (what to look for), while `system.md` contains the review framework (how to analyze and report). This makes the pattern easier to maintain and customize.
+The agent is designed with **separation of concerns**: the `cobra-viper-best-practices.md` contains the comprehensive knowledge base (what to look for), while `system.md` contains the review framework (how to analyze and report). This keeps the agent maintainable and easy to customize.
 
 ## Purpose
 
-This pattern helps you:
+This agent helps you:
 - **Review CLI code quality** against established Cobra/Viper best practices
 - **Identify issues** with severity classification (Critical, High, Medium, Low, Info)
 - **Provide constructive feedback** with specific examples and fixes
@@ -47,24 +46,6 @@ This pattern helps you:
 9. **Shell Completions** - Static, dynamic, flag completions
 10. **Production Readiness** - Version, graceful shutdown, secrets
 
-## Installation
-
-This pattern is part of the fabric-patterns-hub. Ensure you have fabric installed:
-
-```bash
-# Install fabric if you haven't already
-pip install fabric-ai
-
-# Add this patterns repository to fabric
-fabric --add-pattern-source /path/to/fabric-patterns-hub/patterns
-```
-
-Or use it directly by pointing to the pattern directory:
-
-```bash
-fabric --pattern /path/to/fabric-patterns-hub/patterns/go-cobra
-```
-
 ## Usage
 
 ### Single File Review
@@ -72,7 +53,7 @@ fabric --pattern /path/to/fabric-patterns-hub/patterns/go-cobra
 Review a single Go CLI file:
 
 ```bash
-cat cmd/root.go | fabric --pattern go-cobra > review.md
+cat cmd/root.go | squad run --agent go-cobra > review.md
 ```
 
 ### Review from Clipboard
@@ -80,7 +61,7 @@ cat cmd/root.go | fabric --pattern go-cobra > review.md
 Review code from clipboard (macOS):
 
 ```bash
-pbpaste | fabric --pattern go-cobra
+pbpaste | squad run --agent go-cobra
 ```
 
 ### Review Multiple Command Files
@@ -88,7 +69,7 @@ pbpaste | fabric --pattern go-cobra
 Review all command files in a project:
 
 ```bash
-cat cmd/*.go | fabric --pattern go-cobra > review.md
+cat cmd/*.go | squad run --agent go-cobra > review.md
 ```
 
 ### Review Pull Request Changes
@@ -98,7 +79,7 @@ Review changed CLI files in a PR:
 ```bash
 git diff main...HEAD --name-only | grep 'cmd/.*\.go$' | while read file; do
   echo "## Review: $file"
-  cat "$file" | fabric --pattern go-cobra
+  cat "$file" | squad run --agent go-cobra
   echo ""
 done > pr-review.md
 ```
@@ -114,7 +95,7 @@ Use as a pre-commit hook for CLI code review:
 staged_files=$(git diff --cached --name-only | grep 'cmd/.*\.go$')
 if [ -n "$staged_files" ]; then
   for file in $staged_files; do
-    review=$(cat "$file" | fabric --pattern go-cobra)
+    review=$(cat "$file" | squad run --agent go-cobra)
     if echo "$review" | grep -q "CRITICAL"; then
       echo "Critical issues found in $file:"
       echo "$review" | grep -A 10 "CRITICAL"
@@ -134,7 +115,7 @@ Use in your CI pipeline:
 
 for file in $(git diff --name-only HEAD~1 | grep 'cmd/.*\.go$'); do
   echo "Reviewing $file..."
-  REVIEW=$(cat "$file" | fabric --pattern go-cobra)
+  REVIEW=$(cat "$file" | squad run --agent go-cobra)
 
   if echo "$REVIEW" | grep -q "## Critical Issues"; then
     echo "Critical issues found in $file!"
@@ -148,7 +129,7 @@ echo "CLI code review passed!"
 
 ## Output Format
 
-The pattern generates a structured markdown report with:
+The agent generates a structured markdown report with:
 
 ### Summary
 - 2-3 sentence overview of CLI code quality
@@ -284,30 +265,29 @@ Edit the `# OUTPUT FORMAT` section in `system.md` to customize the report struct
 
 **Solution:** Focus on critical and high severity issues first:
 ```bash
-cat cmd/root.go | fabric --pattern go-cobra | grep -A 20 "## Critical Issues"
+cat cmd/root.go | squad run --agent go-cobra | grep -A 20 "## Critical Issues"
 ```
 
 ### Issue: Missing context in review
 
-**Solution:** Provide more code context. The pattern works best with complete command files rather than snippets. Consider reviewing multiple files together:
+**Solution:** Provide more code context. The agent works best with complete command files rather than snippets. Consider reviewing multiple files together:
 ```bash
-cat cmd/*.go | fabric --pattern go-cobra
+cat cmd/*.go | squad run --agent go-cobra
 ```
 
 ### Issue: Review seems incomplete
 
 **Solution:** Ensure the full file is being passed. Large codebases may need to be reviewed in sections.
 
-## Related Patterns
+## Related Agents
 
 - **go-review** - General Go code review (non-CLI specific)
 - **go-refactor** - Transform code (action, not analysis)
 - **go-tests** - Generate tests for Go code
-- **go-doc-comments** - Generate documentation comments
 
 ## References
 
-### Pattern Documentation
+### Agent Documentation
 
 - **`cobra-viper-best-practices.md`** - Comprehensive best practices reference
 
@@ -325,10 +305,10 @@ Contributions are welcome! If you have ideas for improving review criteria or ad
 
 ## License
 
-This pattern is part of the fabric-patterns-hub and follows the same license as the parent repository.
+See `LICENSE` at the repository root.
 
 ---
 
 **Version:** 1.0.0
-**Last Updated:** 2026-01-13
-**Maintainer:** fabric-patterns-hub contributors
+**Last Updated:** 2026-01-31
+**Maintainer:** squad contributors

--- a/agents/go-cobra/README.md
+++ b/agents/go-cobra/README.md
@@ -5,6 +5,7 @@ An agent for reviewing Go CLI applications built with Cobra and Viper against in
 ## Agent Structure
 
 This agent includes:
+
 - **`agent.yaml`** - Minimal manifest for metadata and references
 - **`agent.md`** - Agent-mode wrapper instructions
 - **`system.md`** - The review framework and prompt
@@ -16,6 +17,7 @@ The agent is designed with **separation of concerns**: the `cobra-viper-best-pra
 ## Purpose
 
 This agent helps you:
+
 - **Review CLI code quality** against established Cobra/Viper best practices
 - **Identify issues** with severity classification (Critical, High, Medium, Low, Info)
 - **Provide constructive feedback** with specific examples and fixes
@@ -132,24 +134,29 @@ echo "CLI code review passed!"
 The agent generates a structured markdown report with:
 
 ### Summary
+
 - 2-3 sentence overview of CLI code quality
 - Main concerns highlighted
 
 ### Critical Issues
+
 - Must-fix items affecting correctness or safety
 - Code snippets showing problem and solution
 - Clear explanation with references to criteria
 
 ### Improvements
+
 - Non-critical enhancements
 - Best practice suggestions
 - Pattern recommendations
 
 ### Positive Observations
+
 - Good practices already implemented
 - Recognition of well-written code
 
 ### Recommendations
+
 - General suggestions for improvement
 - Tooling recommendations
 
@@ -179,6 +186,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 ```
 
 **Solution:**
+
 ```go
 func runServe(cmd *cobra.Command, args []string) error {
     port := v.GetInt("server.port")
@@ -203,6 +211,7 @@ from Viper after binding flags per cobra-viper-best-practices.md.
 No completion command available.
 
 **Suggested:**
+
 ```go
 var completionCmd = &cobra.Command{
     Use:   "completion [bash|zsh|fish|powershell]",
@@ -227,6 +236,7 @@ in production CLIs per Production Readiness guidelines.
 
 - Add a version command with build info
 - Consider using functional options for complex configuration
+
 ```
 
 ## Customization
@@ -264,6 +274,7 @@ Edit the `# OUTPUT FORMAT` section in `system.md` to customize the report struct
 ### Issue: Too many findings
 
 **Solution:** Focus on critical and high severity issues first:
+
 ```bash
 cat cmd/root.go | squad run --agent go-cobra | grep -A 20 "## Critical Issues"
 ```
@@ -271,6 +282,7 @@ cat cmd/root.go | squad run --agent go-cobra | grep -A 20 "## Critical Issues"
 ### Issue: Missing context in review
 
 **Solution:** Provide more code context. The agent works best with complete command files rather than snippets. Consider reviewing multiple files together:
+
 ```bash
 cat cmd/*.go | squad run --agent go-cobra
 ```

--- a/agents/go-cobra/agent-readonly.md
+++ b/agents/go-cobra/agent-readonly.md
@@ -1,0 +1,15 @@
+# AGENT MODE
+
+You are a read-only review agent. You inspect the codebase for Cobra/Viper best practice violations and report findings. You do NOT modify any files.
+
+# EXECUTION RULES
+
+- Use Glob to discover all Go files in the codebase.
+- Read each file that uses Cobra or Viper.
+- Cross-reference between files to find integration issues.
+- Report all findings with severity, category, file, line number, and suggested fix.
+- Do NOT use the Edit or Write tools. Do NOT modify any files.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/go-cobra/agent.md
+++ b/agents/go-cobra/agent.md
@@ -15,7 +15,8 @@ If you skip tests, say why.
 # OUTPUT REQUIREMENTS (MANDATORY)
 
 Provide actionable output. Include **at least one** of:
-- A unified diff block (```diff ... ```), OR
+
+- A unified diff block (```diff ...```), OR
 - A "Files Touched" section with concrete file paths and exact change descriptions, OR
 - A "No changes" section explaining why no changes are needed.
 

--- a/agents/go-cobra/agent.md
+++ b/agents/go-cobra/agent.md
@@ -1,7 +1,8 @@
 # AGENT MODE
 
 You are a codebase agent. Use repository context, inspect relevant files, and apply changes directly.
-Prefer minimal, targeted edits that preserve behavior unless the user requests changes.
+When reviewing code, identify ALL violations of Cobra/Viper best practices, not just the most critical ones.
+Apply fixes for all identified issues unless they would break existing behavior.
 Run the most relevant lightweight validations (formatters, linters, tests) when practical.
 If you skip tests, say why.
 

--- a/agents/go-cobra/agent.yaml
+++ b/agents/go-cobra/agent.yaml
@@ -6,3 +6,7 @@ entrypoint: system.md
 wrapper: agent.md
 references:
   - references/cobra-viper-best-practices.md
+modes:
+  readonly:
+    entrypoint: system-readonly.md
+    wrapper: agent-readonly.md

--- a/agents/go-cobra/agent.yaml
+++ b/agents/go-cobra/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-cobra
 version: 0.1.0
 description: Build or refactor Go CLIs using Cobra + Viper best practices.

--- a/agents/go-cobra/references/cobra-viper-best-practices.md
+++ b/agents/go-cobra/references/cobra-viper-best-practices.md
@@ -31,6 +31,7 @@ APPNAME COMMAND ARG --FLAG
 ```
 
 **Good Examples:**
+
 ```bash
 git clone URL --depth 1
 kubectl get pods --namespace kube-system
@@ -39,6 +40,7 @@ myapp deploy production --dry-run
 ```
 
 **Bad Examples:**
+
 ```bash
 myapp --deploy production           # Flag instead of command
 myapp production-deploy             # Hyphenated compound
@@ -47,13 +49,13 @@ myapp do_deployment --env=prod      # Underscores, verbose
 
 ### Command Hierarchy
 
-| Level | Purpose | Example |
-|-------|---------|---------|
-| Root | Application entry point | `myapp` |
-| Command | Primary action | `myapp serve` |
-| Subcommand | Action refinement | `myapp config set` |
-| Arguments | Required input | `myapp deploy prod` |
-| Flags | Optional modifiers | `--verbose`, `--port 8080` |
+| Level      | Purpose                 | Example                    |
+| ---------- | ----------------------- | -------------------------- |
+| Root       | Application entry point | `myapp`                    |
+| Command    | Primary action          | `myapp serve`              |
+| Subcommand | Action refinement       | `myapp config set`         |
+| Arguments  | Required input          | `myapp deploy prod`        |
+| Flags      | Optional modifiers      | `--verbose`, `--port 8080` |
 
 ### Naming Conventions
 
@@ -84,16 +86,17 @@ myapp/
 
 ### Critical Rules
 
-| Rule | Severity | Rationale |
-|------|----------|-----------|
-| Minimal main.go | HIGH | Entry point only initializes and executes |
-| One command per file | MEDIUM | Maintainability and clarity |
-| Business logic in internal/ | HIGH | Separation of concerns, testability |
-| Config structs separate | MEDIUM | Reusable, type-safe configuration |
+| Rule                        | Severity | Rationale                                 |
+| --------------------------- | -------- | ----------------------------------------- |
+| Minimal main.go             | HIGH     | Entry point only initializes and executes |
+| One command per file        | MEDIUM   | Maintainability and clarity               |
+| Business logic in internal/ | HIGH     | Separation of concerns, testability       |
+| Config structs separate     | MEDIUM   | Reusable, type-safe configuration         |
 
 ### Minimal main.go
 
 **Good:**
+
 ```go
 package main
 
@@ -111,6 +114,7 @@ func main() {
 ```
 
 **Bad:**
+
 ```go
 package main
 
@@ -152,16 +156,17 @@ var exampleCmd = &cobra.Command{
 
 ### Critical Checks
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| Use RunE not Run | HIGH | Proper error propagation |
-| Args validation | MEDIUM | User feedback before execution |
-| Short description | MEDIUM | Help readability |
-| Example usage | LOW | User guidance |
+| Check             | Severity | Rationale                      |
+| ----------------- | -------- | ------------------------------ |
+| Use RunE not Run  | HIGH     | Proper error propagation       |
+| Args validation   | MEDIUM   | User feedback before execution |
+| Short description | MEDIUM   | Help readability               |
+| Example usage     | LOW      | User guidance                  |
 
 ### RunE vs Run
 
 **Good - RunE:**
+
 ```go
 RunE: func(cmd *cobra.Command, args []string) error {
     if err := doSomething(); err != nil {
@@ -172,6 +177,7 @@ RunE: func(cmd *cobra.Command, args []string) error {
 ```
 
 **Bad - Run:**
+
 ```go
 Run: func(cmd *cobra.Command, args []string) {
     doSomething()  // Errors are swallowed
@@ -181,6 +187,7 @@ Run: func(cmd *cobra.Command, args []string) {
 ### Argument Validation
 
 **Built-in validators:**
+
 ```go
 Args: cobra.NoArgs              // No arguments allowed
 Args: cobra.ExactArgs(2)        // Exactly 2 arguments
@@ -191,6 +198,7 @@ Args: cobra.OnlyValidArgs       // Only from ValidArgs list
 ```
 
 **Custom validation:**
+
 ```go
 Args: func(cmd *cobra.Command, args []string) error {
     if len(args) < 1 {
@@ -206,6 +214,7 @@ Args: func(cmd *cobra.Command, args []string) error {
 ### Command Lifecycle Hooks
 
 Execution order:
+
 1. `PersistentPreRun` (inherited by children)
 2. `PreRun`
 3. `Run` / `RunE`
@@ -213,6 +222,7 @@ Execution order:
 5. `PersistentPostRun` (inherited by children)
 
 **Good - Use PersistentPreRunE for initialization:**
+
 ```go
 var rootCmd = &cobra.Command{
     Use:   "myapp",
@@ -248,15 +258,15 @@ func init() {
 
 ### Flag Types Reference
 
-| Type | Method | Example |
-|------|--------|---------|
-| String | `StringVarP` | `--name value` |
-| Int | `IntVarP` | `--port 8080` |
-| Bool | `BoolVarP` | `--verbose` |
-| Duration | `DurationVarP` | `--timeout 30s` |
-| StringSlice | `StringSliceVarP` | `--tag a,b --tag c` |
+| Type        | Method            | Example                              |
+| ----------- | ----------------- | ------------------------------------ |
+| String      | `StringVarP`      | `--name value`                       |
+| Int         | `IntVarP`         | `--port 8080`                        |
+| Bool        | `BoolVarP`        | `--verbose`                          |
+| Duration    | `DurationVarP`    | `--timeout 30s`                      |
+| StringSlice | `StringSliceVarP` | `--tag a,b --tag c`                  |
 | StringArray | `StringArrayVarP` | `--tag a,b --tag c` (no comma split) |
-| Count | `CountVarP` | `-v`, `-vv`, `-vvv` |
+| Count       | `CountVarP`       | `-v`, `-vv`, `-vvv`                  |
 
 ### Required Flags
 
@@ -315,12 +325,13 @@ func init() {
 
 ### Avoid the Global Instance
 
-| Pattern | Severity | Status |
-|---------|----------|--------|
-| Use dedicated Viper instance | HIGH | Recommended |
-| Global viper singleton | MEDIUM | Avoid |
+| Pattern                      | Severity | Status      |
+| ---------------------------- | -------- | ----------- |
+| Use dedicated Viper instance | HIGH     | Recommended |
+| Global viper singleton       | MEDIUM   | Avoid       |
 
 **Good - Explicit instance:**
+
 ```go
 func NewConfig() (*Config, error) {
     v := viper.New()
@@ -331,6 +342,7 @@ func NewConfig() (*Config, error) {
 ```
 
 **Bad - Global singleton:**
+
 ```go
 func init() {
     viper.SetConfigName("config")  // Hard to test
@@ -504,6 +516,7 @@ func initConfig() {
 ### Reading Values in Commands
 
 **Good - Read from Viper:**
+
 ```go
 func runServe(cmd *cobra.Command, args []string) error {
     // Read from Viper (respects precedence: flag > env > file > default)
@@ -515,6 +528,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 ```
 
 **Bad - Read directly from flags:**
+
 ```go
 func runServe(cmd *cobra.Command, args []string) error {
     // Bypasses precedence - ignores env vars and config file
@@ -556,11 +570,13 @@ func init() {
 ### Actionable Error Messages
 
 **Good:**
+
 ```go
 return fmt.Errorf("config file not found at %s (create one or use --config)", path)
 ```
 
 **Bad:**
+
 ```go
 return errors.New("config not found")
 ```
@@ -775,9 +791,9 @@ func init() {
         func(cmd *cobra.Command, args []string, toComplete string) (
             []string, cobra.ShellCompDirective) {
             return []string{
-                "us-east-1\tN. Virginia",
-                "us-west-2\tOregon",
-                "eu-west-1\tIreland",
+                "us-east-1  N. Virginia",
+                "us-west-2  Oregon",
+                "eu-west-1  Ireland",
             }, cobra.ShellCompDirectiveNoFileComp
         })
 }
@@ -893,22 +909,23 @@ func initLogger(v *viper.Viper) *slog.Logger {
 
 ### Common Mistakes to Avoid
 
-| Anti-Pattern | Severity | Why It's Bad |
-|--------------|----------|--------------|
-| Using Run instead of RunE | HIGH | Errors are silently ignored |
-| Reading flags directly in commands | HIGH | Bypasses config precedence |
-| Global Viper singleton | MEDIUM | Hard to test |
-| Business logic in cmd/ | HIGH | Tight coupling, hard to test |
-| Complex main.go | MEDIUM | Entry point should be minimal |
-| Goroutines in init() | HIGH | Unpredictable startup |
-| Ignoring errors from BindPFlag | MEDIUM | Silent configuration issues |
-| Hardcoded config paths | MEDIUM | Inflexible deployment |
-| Missing shell completions | LOW | Reduced UX |
-| Missing version command | LOW | Deployment debugging difficulty |
+| Anti-Pattern                       | Severity | Why It's Bad                    |
+| ---------------------------------- | -------- | ------------------------------- |
+| Using Run instead of RunE          | HIGH     | Errors are silently ignored     |
+| Reading flags directly in commands | HIGH     | Bypasses config precedence      |
+| Global Viper singleton             | MEDIUM   | Hard to test                    |
+| Business logic in cmd/             | HIGH     | Tight coupling, hard to test    |
+| Complex main.go                    | MEDIUM   | Entry point should be minimal   |
+| Goroutines in init()               | HIGH     | Unpredictable startup           |
+| Ignoring errors from BindPFlag     | MEDIUM   | Silent configuration issues     |
+| Hardcoded config paths             | MEDIUM   | Inflexible deployment           |
+| Missing shell completions          | LOW      | Reduced UX                      |
+| Missing version command            | LOW      | Deployment debugging difficulty |
 
 ### Anti-Pattern Examples
 
 **Bad - Complex main.go:**
+
 ```go
 func main() {
     initLogging()      // Don't do setup here
@@ -919,6 +936,7 @@ func main() {
 ```
 
 **Good - Minimal main.go:**
+
 ```go
 func main() {
     if err := cmd.Execute(); err != nil {
@@ -928,6 +946,7 @@ func main() {
 ```
 
 **Bad - Flags bypass config:**
+
 ```go
 func runServe(cmd *cobra.Command, args []string) error {
     port, _ := cmd.Flags().GetInt("port")  // Ignores env/config
@@ -935,6 +954,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 ```
 
 **Good - Use Viper:**
+
 ```go
 func runServe(cmd *cobra.Command, args []string) error {
     port := v.GetInt("server.port")  // Respects precedence
@@ -948,6 +968,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 ### CRITICAL
 
 Issues that affect correctness, security, or cause crashes:
+
 - Using Run instead of RunE with important error handling
 - Missing argument validation that could cause panics
 - Secrets stored in config files
@@ -956,6 +977,7 @@ Issues that affect correctness, security, or cause crashes:
 ### HIGH
 
 Significant issues affecting reliability or maintainability:
+
 - Reading flags directly instead of using Viper
 - Business logic in cmd/ package
 - Global Viper singleton
@@ -965,6 +987,7 @@ Significant issues affecting reliability or maintainability:
 ### MEDIUM
 
 Best practice violations:
+
 - Missing shell completions
 - Missing version command
 - Complex main.go
@@ -974,6 +997,7 @@ Best practice violations:
 ### LOW
 
 Minor improvements:
+
 - Missing command aliases
 - Missing Long descriptions
 - Missing Example in commands
@@ -982,6 +1006,7 @@ Minor improvements:
 ### INFO
 
 Suggestions for optimization:
+
 - Live config reload
 - Dynamic completions
 - Structured logging integration
@@ -1008,14 +1033,14 @@ Suggestions for optimization:
 
 ### Common Patterns Summary
 
-| Pattern | Location | Purpose |
-|---------|----------|---------|
-| Root command | cmd/root.go | Global config, PersistentPreRunE |
-| Subcommand | cmd/[name].go | One command per file |
-| Config struct | config/config.go | Type-safe configuration |
-| Business logic | internal/app/ | Testable, CLI-independent |
-| Flag binding | init() | Bind flags to Viper |
-| Config loading | PersistentPreRunE | Before any command runs |
+| Pattern        | Location          | Purpose                          |
+| -------------- | ----------------- | -------------------------------- |
+| Root command   | cmd/root.go       | Global config, PersistentPreRunE |
+| Subcommand     | cmd/[name].go     | One command per file             |
+| Config struct  | config/config.go  | Type-safe configuration          |
+| Business logic | internal/app/     | Testable, CLI-independent        |
+| Flag binding   | init()            | Bind flags to Viper              |
+| Config loading | PersistentPreRunE | Before any command runs          |
 
 ---
 
@@ -1029,4 +1054,4 @@ Suggestions for optimization:
 
 ---
 
-*Last updated: 2026-01-13*
+_Last updated: 2026-01-13_

--- a/agents/go-cobra/system-readonly.md
+++ b/agents/go-cobra/system-readonly.md
@@ -1,0 +1,72 @@
+# IDENTITY and PURPOSE
+
+You are an expert Go developer specializing in building idiomatic CLI applications using Cobra and Viper (2026). Your role is to review Go CLI code and provide a detailed report of Cobra/Viper best practice violations. You do NOT apply fixes — you only report findings.
+
+# KNOWLEDGE BASE
+
+You have access to a comprehensive best practices reference document (`cobra-viper-best-practices.md`). Apply ALL relevant criteria from that document.
+
+# STEPS
+
+1. Use Glob with `**/*.go` to discover all Go source files in the codebase
+2. Read each file that contains Cobra commands, Viper configuration, or CLI setup
+3. Analyze for Cobra/Viper usage patterns against the reference document
+4. Check project structure alignment with recommendations
+5. Evaluate command implementation (RunE vs Run, Args validation)
+6. Review flag management and Viper binding
+7. Assess configuration loading and precedence handling
+8. Check error handling patterns
+9. Identify anti-patterns and common mistakes
+
+# REVIEW CATEGORIES
+
+1. **Command Design** - Natural syntax, hierarchy, naming conventions
+2. **Project Structure** - Minimal main.go, one command per file, separation
+3. **Command Implementation** - RunE, Args validation, lifecycle hooks
+4. **Flag Management** - Persistent vs local, groups, types
+5. **Viper Configuration** - Precedence, type-safe structs, validation
+6. **Integration** - Flag binding, reading from Viper, initialization
+7. **Error Handling** - Wrapped errors, actionable messages
+8. **Testing** - Command execution, dependency injection, table-driven
+9. **Shell Completions** - Static, dynamic, flag completions
+10. **Production Readiness** - Version, graceful shutdown, secrets
+
+# SEVERITY LEVELS
+
+- **CRITICAL**: Affects correctness, security, or causes crashes
+- **HIGH**: Significant reliability or maintainability issues
+- **MEDIUM**: Best practice violations with real impact
+- **LOW**: Minor improvements
+- **INFO**: Suggestions for optimization
+
+# OUTPUT FORMAT
+
+Report every finding with the following structure. Only report functional issues — skip cosmetic-only findings (doc comments, import ordering, naming style).
+
+## [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
+
+**What is wrong:**
+[1-2 sentences describing the issue]
+
+**Suggested fix:**
+[1-2 sentences or code snippet showing how to fix it]
+
+---
+
+If a category has no issues, skip it silently.
+
+# RULES
+
+- You MUST use the Read tool and Grep tool to inspect actual code — do not guess
+- Do NOT edit any files. Do NOT use the Edit or Write tools
+- Do NOT report cosmetic issues (missing doc comments, import ordering, naming style, magic numbers)
+- Only report functional Cobra/Viper issues
+
+# INPUT
+
+Go CLI code to review:

--- a/agents/go-cobra/system.md
+++ b/agents/go-cobra/system.md
@@ -62,8 +62,8 @@ Reference the cobra-viper-best-practices.md document for detailed criteria. Brie
 When asked to review and apply fixes:
 
 1. Analyze the codebase for Cobra/Viper best practice violations
-2. Apply fixes directly to the code files
-3. Provide a summary of changes made
+2. **Use the Edit tool** to apply fixes directly to the code files
+3. Provide a summary of changes made using the "Files Touched" format
 
 When asked to only review (without applying fixes):
 
@@ -72,11 +72,11 @@ When asked to only review (without applying fixes):
 
 # OUTPUT FORMAT
 
-**CRITICAL**: You MUST include one of the following:
+**CRITICAL**: When applying fixes, you MUST:
 
-- A unified diff block showing changes made (```diff ...```)
-- A "Files Touched" section listing exact file paths and changes made
-- A "No changes" section if no changes are needed or if only reviewing
+- Use the Edit tool to make changes directly to files
+- List all files touched with specific changes in the "Files Touched" section
+- Do NOT output unified diff blocks - make actual edits instead
 
 ## Changes Summary
 

--- a/agents/go-cobra/system.md
+++ b/agents/go-cobra/system.md
@@ -1,6 +1,6 @@
 # IDENTITY and PURPOSE
 
-You are an expert Go developer specializing in building idiomatic CLI applications using Cobra and Viper (2025). Your role is to review Go CLI code and provide constructive feedback focused on improving adherence to Cobra/Viper best practices, proper configuration management, and CLI design patterns.
+You are an expert Go developer specializing in building idiomatic CLI applications using Cobra and Viper (2026). Your role is to review Go CLI code and provide constructive feedback focused on improving adherence to Cobra/Viper best practices, proper configuration management, and CLI design patterns.
 
 # KNOWLEDGE BASE
 

--- a/agents/go-cobra/system.md
+++ b/agents/go-cobra/system.md
@@ -73,7 +73,8 @@ When asked to only review (without applying fixes):
 # OUTPUT FORMAT
 
 **CRITICAL**: You MUST include one of the following:
-- A unified diff block showing changes made (```diff ... ```)
+
+- A unified diff block showing changes made (```diff ...```)
 - A "Files Touched" section listing exact file paths and changes made
 - A "No changes" section if no changes are needed or if only reviewing
 

--- a/agents/go-cobra/system.md
+++ b/agents/go-cobra/system.md
@@ -59,76 +59,63 @@ Reference the cobra-viper-best-practices.md document for detailed criteria. Brie
 
 # OUTPUT INSTRUCTIONS
 
-Structure your review with clear sections:
+When asked to review and apply fixes:
 
-1. **Summary** - High-level assessment (2-3 sentences)
-2. **Critical Issues** - Must-fix items affecting correctness or safety
-3. **Improvements** - Non-critical enhancements for better patterns
-4. **Positive Observations** - What the code does well (1-2 items)
-5. **Recommendations** - General suggestions for codebase improvement
+1. Analyze the codebase for Cobra/Viper best practice violations
+2. Apply fixes directly to the code files
+3. Provide a summary of changes made
+
+When asked to only review (without applying fixes):
+
+1. Provide a detailed review with specific code examples
+2. Include a "No changes" section explaining that this was review-only
 
 # OUTPUT FORMAT
 
-## Summary
+**CRITICAL**: You MUST include one of the following:
+- A unified diff block showing changes made (```diff ... ```)
+- A "Files Touched" section listing exact file paths and changes made
+- A "No changes" section if no changes are needed or if only reviewing
 
-[2-3 sentence overview of CLI code quality and main concerns]
+## Changes Summary
 
-## Critical Issues
+[Brief overview of what was changed and why]
+
+## Files Touched
+
+- `path/to/file1.go` - [Specific change description]
+- `path/to/file2.go` - [Specific change description]
+
+## Diff
+
+```diff
+--- a/path/to/file.go
++++ b/path/to/file.go
+@@ -10,5 +10,5 @@
+-[old code]
++[new code]
+```
+
+## Issues Found and Fixed
 
 ### [Issue Title]
 
-**Severity:** CRITICAL/HIGH
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW
 **Category:** [category from review categories]
-**Impact:** [Why it matters]
+**File:** [file path]
+**Line:** [line number if applicable]
 
-**Problem:**
-```go
-// Current code
-[problematic code snippet]
-```
+**What was changed:**
+[Description of the change]
 
-**Solution:**
-```go
-// Suggested fix
-[improved code snippet]
-```
-
-**Explanation:** [Why this change is needed - reference criteria]
+**Why:**
+[Explanation referencing best practices]
 
 ---
 
-## Improvements
+## Testing
 
-### [Improvement Title]
-
-**Severity:** MEDIUM/LOW
-**Category:** [category]
-
-**Current:**
-```go
-[current approach]
-```
-
-**Suggested:**
-```go
-[better approach]
-```
-
-**Why:** [Explanation referencing cobra-viper-best-practices.md]
-
----
-
-## Positive Observations
-
-- [Good practice observed with specific example]
-- [Another good practice]
-
----
-
-## Recommendations
-
-- [General suggestion 1]
-- [General suggestion 2]
+[List any tests run or why tests were skipped]
 
 # TONE AND APPROACH
 

--- a/agents/go-doc-comments/README.md
+++ b/agents/go-doc-comments/README.md
@@ -1,0 +1,104 @@
+# go-doc-comments
+
+Generate or improve Go documentation comments following the official Go Doc Comments specification.
+
+## Overview
+
+This agent specializes in creating high-quality Go documentation comments that follow:
+
+- Official [Go Doc Comments specification](https://go.dev/doc/comment)
+- Go community conventions and idioms
+- Modern doc comment features (Go 1.19+)
+- 80-character line length limit
+
+## Capabilities
+
+- **Add missing documentation** for all exported declarations
+- **Improve existing comments** to follow Go conventions
+- **Use modern features** like headings, links, lists, and code blocks
+- **Document concurrency**, error conditions, and cleanup requirements
+- **Preserve code logic** - only modifies comments
+
+## Usage
+
+```bash
+# Document a single file
+squad run go-doc-comments path/to/file.go
+
+# Document multiple files
+squad run go-doc-comments path/to/*.go
+
+# Document entire package
+squad run go-doc-comments path/to/package/
+```
+
+## What Gets Documented
+
+The agent documents all exported (capitalized) declarations:
+
+- **Packages** - Overview and usage
+- **Functions** - Behavior, parameters, returns
+- **Types** - Purpose and zero value behavior
+- **Methods** - Receiver methods
+- **Constants** - Purpose and value
+- **Variables** - Purpose and usage
+
+## Documentation Standards
+
+The agent follows these key principles:
+
+1. **Complete sentences** starting with the declared name
+2. **User focus** - explain what, not how
+3. **Concurrency safety** - document thread safety when relevant
+4. **Error conditions** - document when errors are returned
+5. **Cleanup requirements** - document resource management
+6. **Modern syntax** - uses Go 1.19+ features appropriately
+
+## Examples
+
+### Before
+
+```go
+type Config struct {
+    Timeout int
+}
+
+func NewConfig() *Config {
+    return &Config{Timeout: 30}
+}
+```
+
+### After
+
+```go
+// Config holds connection configuration settings.
+// A Config must not be copied after first use.
+type Config struct {
+    // Timeout specifies the maximum wait time in seconds.
+    Timeout int
+}
+
+// NewConfig creates a Config with sensible defaults.
+// The default timeout is 30 seconds.
+func NewConfig() *Config {
+    return &Config{Timeout: 30}
+}
+```
+
+## Reference
+
+The agent uses a comprehensive knowledge base covering:
+
+- Package, function, type, constant, and variable documentation
+- Modern doc comment features (headings, links, lists, code blocks)
+- Concurrency, error, and cleanup documentation patterns
+- Common mistakes and anti-patterns
+- Quality checklist
+
+See [references/go-documentation-standards.md](references/go-documentation-standards.md) for the complete reference.
+
+## Related Agents
+
+- **go-review** - Review Go code for best practices
+- **go-refactor** - Refactor Go code to idiomatic patterns
+- **go-tests** - Generate Go tests

--- a/agents/go-doc-comments/agent.md
+++ b/agents/go-doc-comments/agent.md
@@ -1,0 +1,17 @@
+# AGENT MODE
+
+You are a codebase agent. Use repository context, inspect relevant files, and apply changes directly.
+Prefer minimal, targeted edits that preserve behavior unless the user requests changes.
+Run the most relevant lightweight validations (formatters, linters, tests) when practical.
+If you skip tests, say why.
+
+# EXECUTION RULES
+
+- Discover context before changing files.
+- Follow existing repo conventions.
+- Make changes in-place and keep diffs focused.
+- Summarize changes, list files touched, and list tests run.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/go-doc-comments/agent.yaml
+++ b/agents/go-doc-comments/agent.yaml
@@ -1,0 +1,8 @@
+---
+name: go-doc-comments
+version: 0.1.0
+description: Generate or improve Go documentation comments following official Go Doc Comments specification.
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - references/go-documentation-standards.md

--- a/agents/go-doc-comments/references/go-documentation-standards.md
+++ b/agents/go-doc-comments/references/go-documentation-standards.md
@@ -1,0 +1,516 @@
+# Go Documentation Standards
+
+A comprehensive guide to Go documentation comments following the official "Go Doc Comments" specification and community best practices. This document serves as the knowledge base for the go-doc-comments pattern.
+
+## Table of Contents
+
+1. [Core Principles](#core-principles)
+2. [Syntax by Declaration Type](#syntax-by-declaration-type)
+3. [Modern Doc Comment Features](#modern-doc-comment-features)
+4. [What to Document](#what-to-document)
+5. [Common Mistakes](#common-mistakes)
+6. [Quality Checklist](#quality-checklist)
+
+---
+
+## Core Principles
+
+### The Golden Rule
+
+Doc comments appear **immediately before** top-level declarations with **no intervening blank lines**. All exported (capitalized) names must have doc comments.
+
+### Philosophy
+
+| Principle | Description |
+|-----------|-------------|
+| Complete sentences | Start with the declared name |
+| Explain what | Not how it works internally |
+| User focus | Focus on user needs, not implementation |
+| Searchable | Clear, explicit, searchable text |
+| No redundancy | Avoid "ProcessData processes the data" |
+| Add value | Provide info beyond the function signature |
+
+### Line Length
+
+All comment lines should stay within **80 characters** for readability.
+
+---
+
+## Syntax by Declaration Type
+
+### Package Comments
+
+```go
+// Package regexp implements regular expression search.
+//
+// The syntax of the regular expressions accepted is the same
+// general syntax used by Perl, Python, and other languages.
+package regexp
+```
+
+**Rules:**
+
+- Start with "Package [name]"
+- Only include in ONE file of multi-file packages
+- Directly adjacent to package clause (no blank line)
+- For commands, describe program behavior
+
+### Functions and Methods
+
+```go
+// Join concatenates the elements of paths to create a single path.
+// Any empty strings are ignored.
+func Join(paths ...string) string
+
+// Open reports whether the file is currently open for reading.
+func (f *File) Open() bool
+```
+
+**Rules:**
+
+- Start with function/method name
+- For boolean returns: "reports whether [condition]" (omit "or not")
+- Reference parameters/results without special syntax
+- Describe return values and side effects
+
+**Boolean Functions:**
+
+```go
+// IsValid reports whether the configuration is valid.
+func (c *Config) IsValid() bool
+
+// Contains reports whether s contains the substring substr.
+func Contains(s, substr string) bool
+```
+
+### Types
+
+```go
+// A Request represents an HTTP request received by a server
+// or to be sent by a client.
+//
+// The field semantics differ slightly between client and server
+// usage. All exported fields are safe for concurrent use.
+type Request struct {
+    Method string // HTTP method (GET, POST, PUT, etc.)
+    URL    *url.URL
+}
+```
+
+**Rules:**
+
+- Use "A [Type] represents..." or "[Type] is..."
+- Document concurrency safety if relevant
+- Explain zero value behavior if non-obvious
+- Document exported fields (in type comment or per-field)
+
+### Constants and Variables
+
+**Grouped constants:**
+
+```go
+const (
+    // MaxSize is the maximum allowed file size in bytes.
+    MaxSize = 1024 * 1024
+
+    StatusOK    = 200 // Request succeeded
+    StatusError = 500 // Server error occurred
+)
+```
+
+**Ungrouped:**
+
+```go
+// ErrNotFound is returned when a resource cannot be located.
+var ErrNotFound = errors.New("not found")
+```
+
+**Rules:**
+
+- Grouped: single doc comment + end-of-line comments
+- Ungrouped: full doc comments with complete sentences
+
+---
+
+## Modern Doc Comment Features
+
+### Headings (Go 1.19+)
+
+Use `#` (with space) on single unindented line, surrounded by blank lines:
+
+```go
+// Package strings provides UTF-8 string manipulation.
+//
+// # Numeric Conversions
+//
+// The most common conversions are...
+```
+
+### Doc Links (to Go identifiers)
+
+```go
+// Parse returns a [Time] value or returns an error if parsing fails.
+// See [time.RFC3339] for the expected format.
+// Use [*Time.Format] to convert back to strings.
+```
+
+**Syntax:**
+
+| Pattern | Description |
+|---------|-------------|
+| `[Name]` | Local identifier |
+| `[Name.Method]` | Method of local type |
+| `[pkg.Name]` | Identifier in another package |
+| `[*Type]` | Pointer to type |
+
+### URL Links
+
+```go
+// See [RFC 7159] for details.
+//
+// [RFC 7159]: https://tools.ietf.org/html/rfc7159
+```
+
+### Lists
+
+**Bullet lists** (indent 2 spaces before marker, 4 for continuation):
+
+```go
+// Features:
+//   - Fast performance
+//   - Memory efficient
+//   - Thread safe
+```
+
+**Numbered lists:**
+
+```go
+// Usage:
+//  1. Initialize the client
+//  2. Configure options
+//  3. Call Execute
+```
+
+**Rules:**
+
+- Use `-` for bullets (gofmt normalizes)
+- No nested lists (not supported)
+- Only paragraphs allowed in lists
+
+### Code Blocks
+
+Indent lines that aren't list markers:
+
+```go
+// Example usage:
+//
+// client := NewClient()
+// err := client.Connect("localhost:8080")
+// if err != nil {
+//  log.Fatal(err)
+// }
+```
+
+---
+
+## What to Document
+
+### Concurrency Safety
+
+Document when non-obvious or when stronger guarantees than default:
+
+```go
+// Cache provides thread-safe access to cached data.
+// All methods are safe for concurrent use by multiple goroutines.
+type Cache struct { ... }
+
+// Buffer provides efficient byte slice manipulation.
+// A Buffer must not be copied after first use.
+type Buffer struct { ... }
+```
+
+### Error Values
+
+```go
+// ErrTimeout is returned when an operation exceeds its deadline.
+// Callers can use [errors.Is] to check for this error.
+var ErrTimeout = errors.New("operation timeout")
+```
+
+### Cleanup Requirements
+
+```go
+// Close closes the file and releases associated resources.
+// The client must call Close when done to prevent resource leaks.
+func (f *File) Close() error
+```
+
+### Context Behavior
+
+Document when non-standard:
+
+```go
+// Execute runs the command with the given context.
+// Unlike most context-aware functions, Execute may return
+// errors other than ctx.Err() even when the context is cancelled.
+func (c *Command) Execute(ctx context.Context) error
+```
+
+### Parameter Constraints
+
+```go
+// NewClient creates a client with the given options.
+// The timeout value must be positive; zero means no timeout.
+// The retryCount controls automatic retries on network errors.
+func NewClient(timeout time.Duration, retryCount int) *Client
+```
+
+### Return Values
+
+```go
+// Find searches for the pattern in text and returns the index
+// of the first match, or -1 if no match is found.
+func Find(text, pattern string) int
+```
+
+### Side Effects
+
+```go
+// Shutdown gracefully stops the server and waits for all
+// active connections to complete. It blocks until shutdown
+// is complete or the context is cancelled.
+func (s *Server) Shutdown(ctx context.Context) error
+```
+
+---
+
+## Common Mistakes
+
+### Redundant Comments
+
+**Bad:**
+
+```go
+// Process processes the data
+func Process(data []byte) error
+```
+
+**Good:**
+
+```go
+// Process validates and transforms the input data according
+// to the configured rules, returning an error if validation fails.
+func Process(data []byte) error
+```
+
+### Implementation Details
+
+**Bad:**
+
+```go
+// GetUser queries the database using a prepared statement
+func GetUser(id int) (*User, error)
+```
+
+**Good:**
+
+```go
+// GetUser returns the user with the given ID or returns
+// an error if the user doesn't exist.
+func GetUser(id int) (*User, error)
+```
+
+### Missing Declared Name
+
+**Bad:**
+
+```go
+// Returns the current time in UTC format
+func Now() time.Time
+```
+
+**Good:**
+
+```go
+// Now returns the current time in UTC.
+func Now() time.Time
+```
+
+### Improper Indentation
+
+**Bad (breaks list):**
+
+```go
+// Uses:
+//   - Feature one. This wraps
+// to the next line  // ← Breaks list!
+```
+
+**Good:**
+
+```go
+// Uses:
+//   - Feature one. This wraps
+//     to the next line with proper indentation
+```
+
+### Blank Line Between Comment and Declaration
+
+**Bad:**
+
+```go
+// GetUser returns the user with the given ID.
+
+func GetUser(id int) (*User, error)
+```
+
+**Good:**
+
+```go
+// GetUser returns the user with the given ID.
+func GetUser(id int) (*User, error)
+```
+
+---
+
+## Special Syntax
+
+### Deprecation
+
+```go
+// Deprecated: Use [NewClient] instead. This function doesn't
+// properly handle context cancellation and will be removed in v2.0.
+func OldClient() *Client
+```
+
+Start paragraph with `Deprecated:` - tools warn on usage.
+
+### TODO/BUG/FIXME
+
+```go
+// TODO(username): refactor to use generics
+// BUG(username): doesn't handle Unicode properly
+```
+
+Format: `MARKER(uid): description`
+
+### Directives
+
+```go
+// Op represents a regex operator.
+//
+//go:generate stringer -type Op
+type Op uint8
+```
+
+**Rules:**
+
+- gofmt moves directives after blank line at end of comment
+- Not part of godoc output
+- Common directives: `//go:generate`, `//go:embed`, `//go:build`
+
+---
+
+## Tools and Automation
+
+### gofmt
+
+Automatically formats doc comments:
+
+- Normalizes list indentation (converts `*`, `+`, `•` to `-`)
+- Converts backticks and quotes to Unicode
+- Removes common indentation prefix
+- Adds blank lines around code blocks
+- Moves link definitions and directives to end of comment
+
+```bash
+gofmt -w .
+```
+
+### go doc
+
+View formatted documentation in terminal:
+
+```bash
+go doc pkgname           # Package documentation
+go doc pkgname.TypeName  # Type documentation
+go doc pkgname.FuncName  # Function documentation
+```
+
+### godoc-lint
+
+Linter for doc comment consistency (validates against Go Doc Comments spec):
+
+```bash
+go install golang.org/x/tools/cmd/godoc-lint@latest
+godoc-lint ./...
+```
+
+### pkg.go.dev
+
+Online documentation rendering at https://pkg.go.dev - automatically extracts and renders doc comments for public packages.
+
+---
+
+## Signal Boosting Comments
+
+From Google Style Guide: add clarifying comments for unusual patterns that might confuse readers.
+
+**Example - unusual condition:**
+
+```go
+if err == nil {
+    // if NO error, proceed with cleanup
+    return cleanup()
+}
+```
+
+**When to add signal boosting:**
+
+- Unusual control flow (checking for success instead of failure)
+- Non-obvious side effects
+- Intentionally empty blocks
+- Counter-intuitive logic
+
+---
+
+## Quality Checklist
+
+### Before Submitting
+
+- [ ] All exported names have doc comments
+- [ ] Comments start with the declared name
+- [ ] Complete sentences with proper punctuation
+- [ ] No blank line between comment and declaration
+- [ ] Lines within 80 characters
+- [ ] Modern doc features used when beneficial (links, lists)
+- [ ] Concurrency safety documented when relevant
+- [ ] Error conditions documented
+- [ ] Cleanup requirements documented
+- [ ] gofmt compatible
+
+### Common Patterns
+
+| Declaration | Pattern |
+|-------------|---------|
+| Function returning value | "[Name] returns..." |
+| Function returning bool | "[Name] reports whether..." |
+| Function with side effects | "[Name] [action]s..." |
+| Type | "A [Type] represents..." or "[Type] is..." |
+| Error variable | "[Name] is returned when..." |
+| Constant | "[Name] is the..." |
+
+---
+
+## References
+
+- [Go Doc Comments Specification](https://go.dev/doc/comment)
+- [Effective Go - Commentary](https://go.dev/doc/effective_go#commentary)
+- [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments#doc-comments)
+- [Go Blog - Godoc](https://go.dev/blog/godoc)
+- [Google Go Style Guide](https://google.github.io/styleguide/go/)
+- [Google Go Best Practices](https://google.github.io/styleguide/go/best-practices)
+
+---
+
+*Last updated: 2026-01-10*

--- a/agents/go-doc-comments/system.md
+++ b/agents/go-doc-comments/system.md
@@ -1,0 +1,86 @@
+# IDENTITY and PURPOSE
+
+You are an expert Go documentation specialist with deep knowledge of Go's official documentation standards and community conventions. Your role is to analyze Go code and generate or improve documentation comments following the official "Go Doc Comments" specification and best practices.
+
+# KNOWLEDGE BASE
+
+You have access to a comprehensive documentation standards reference in the same directory as this pattern (`go-documentation-standards.md`). This document contains:
+
+- Core principles (golden rule, philosophy, line length)
+- Syntax by declaration type (packages, functions, types, constants)
+- Modern doc comment features (headings, links, lists, code blocks)
+- What to document (concurrency, errors, cleanup, context, constraints)
+- Common mistakes to avoid
+- Quality checklist
+
+**CRITICAL**: Apply ALL standards from the go-documentation-standards.md document when generating documentation. Use the full depth of knowledge in that reference document.
+
+# STEPS
+
+1. Analyze the provided Go code to identify all exported declarations
+2. Identify missing or inadequate documentation comments
+3. Generate complete, clear doc comments following Go conventions
+4. Ensure proper syntax for modern Go doc comment features (Go 1.19+)
+5. Focus on user needs, not implementation details
+6. Verify all comments follow the 80-character line limit
+
+# DOCUMENTATION CATEGORIES
+
+Reference the go-documentation-standards.md for detailed standards. Brief overview:
+
+1. **Package Comments** - "Package [name]" format, one per package
+2. **Function Comments** - Start with function name, describe behavior
+3. **Type Comments** - "A [Type] represents..." or "[Type] is..."
+4. **Constant/Variable Comments** - Purpose and usage
+5. **Method Comments** - Start with method name
+6. **Concurrency Safety** - Document thread safety
+7. **Error Documentation** - Document error conditions
+8. **Cleanup Requirements** - Document resource release needs
+
+# OUTPUT INSTRUCTIONS
+
+- Generate documentation comments for ALL exported declarations
+- Use complete sentences starting with the declared name
+- No blank lines between comment and declaration
+- Keep all lines within 80 characters (break lines appropriately)
+- Use modern doc comment features (headings, links, lists) when beneficial
+- Focus on clarity and user needs
+- Include concurrency, error, and cleanup documentation when relevant
+- Use proper indentation for lists and code blocks
+- Reference related functions/types using `[Name]` syntax
+
+# OUTPUT FORMAT
+
+Provide the complete Go code with improved/added documentation comments. Preserve the original code structure and only modify or add comments. Ensure gofmt compatibility.
+
+## Documented Code
+
+```go
+[Complete Go code with documentation comments]
+```
+
+## Documentation Summary
+
+- **Added:** [count] new doc comments
+- **Improved:** [count] existing doc comments
+- **Key changes:**
+  - [Description of major documentation additions]
+  - [Description of improvements]
+
+## Notes
+
+[Any important notes about documentation decisions or suggestions for further improvement]
+
+# IMPORTANT CONSTRAINTS
+
+- **Never modify code logic** - only add or improve comments
+- **Preserve all existing code** exactly as provided
+- **Start comments with declared name** - follow Go conventions
+- **Keep lines under 80 characters** - break appropriately
+- **No blank lines** between comment and declaration
+- **Focus on users** - explain what, not how
+- **Reference the knowledge base** - use standards from go-documentation-standards.md
+
+# INPUT
+
+Go code to document:

--- a/agents/go-refactor/README.md
+++ b/agents/go-refactor/README.md
@@ -5,6 +5,7 @@ A comprehensive fabric pattern for refactoring Go code to be more idiomatic, mai
 ## Pattern Structure
 
 This pattern includes:
+
 - **`system.md`** - The refactoring framework and prompt engineering for LLM
 - **`go-best-practices.md`** - Comprehensive reference document with detailed patterns (source of truth)
 - **`filter.sh`** - Post-processing to clean up output formatting
@@ -18,6 +19,7 @@ The pattern is designed with **separation of concerns**: the `go-best-practices.
 ## Purpose
 
 This pattern helps you:
+
 - **Identify anti-patterns** in Go code (deep nesting, poor error handling, etc.)
 - **Apply idiomatic patterns** following official Go guidelines
 - **Improve code quality** without changing behavior
@@ -125,16 +127,19 @@ done
 The pattern generates output with:
 
 ### Refactored Code
+
 - Complete, runnable Go code
 - All improvements applied
 - Proper formatting (gofmt-compatible)
 
 ### Changes Made
+
 - Numbered list of changes
 - Explanation of why each change was made
 - Reference to pattern from knowledge base
 
 ### Notes
+
 - Important assumptions made
 - Potential follow-up improvements
 - Behavior-preserving guarantees
@@ -196,6 +201,7 @@ func GetUser(id int) (*User, error) {
 ### When to Use This Pattern
 
 **Good use cases:**
+
 - Refactoring legacy Go code
 - Code review preparation
 - Learning idiomatic Go patterns
@@ -203,6 +209,7 @@ func GetUser(id int) (*User, error) {
 - Pre-commit code improvements
 
 **Not ideal for:**
+
 - Large-scale architectural changes
 - Adding new functionality
 - Performance-critical optimizations (use profiling instead)
@@ -210,6 +217,7 @@ func GetUser(id int) (*User, error) {
 ### Preserving Functionality
 
 The pattern is designed to:
+
 - Never change the public API
 - Maintain exact behavior
 - Preserve backwards compatibility
@@ -218,6 +226,7 @@ The pattern is designed to:
 ### Iterative Refactoring
 
 For large files, consider:
+
 1. Refactor one function at a time
 2. Review and test each change
 3. Commit incrementally
@@ -236,6 +245,7 @@ To add or modify refactoring patterns, edit the `go-best-practices.md` file:
 ### Adjusting Output Format
 
 To modify the output structure, edit the `# OUTPUT FORMAT` section in `system.md`:
+
 - Add new sections
 - Change formatting
 - Adjust detail level
@@ -245,6 +255,7 @@ To modify the output structure, edit the `# OUTPUT FORMAT` section in `system.md
 ### Issue: Pattern changes too much
 
 **Solution:** The pattern tries to be comprehensive. For targeted changes, provide specific instructions:
+
 ```bash
 echo "// Only fix error handling\n$(cat myfile.go)" | fabric --pattern go-refactor
 ```
@@ -252,6 +263,7 @@ echo "// Only fix error handling\n$(cat myfile.go)" | fabric --pattern go-refact
 ### Issue: Output isn't gofmt-compatible
 
 **Solution:** Run gofmt on the output:
+
 ```bash
 cat myfile.go | fabric --pattern go-refactor | gofmt
 ```

--- a/agents/go-refactor/agent.yaml
+++ b/agents/go-refactor/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-refactor
 version: 0.1.0
 description: Refactor Go code to idiomatic, maintainable Go while preserving behavior.

--- a/agents/go-refactor/references/go-best-practices.md
+++ b/agents/go-refactor/references/go-best-practices.md
@@ -56,6 +56,7 @@ Key principles from Rob Pike's Go Proverbs:
 Deep nesting reduces readability. Use guard clauses to handle edge cases first.
 
 **Anti-pattern:**
+
 ```go
 func GetUser(id int) (*User, error) {
     if id > 0 {
@@ -76,6 +77,7 @@ func GetUser(id int) (*User, error) {
 ```
 
 **Idiomatic:**
+
 ```go
 func GetUser(id int) (*User, error) {
     if id <= 0 {
@@ -102,6 +104,7 @@ func GetUser(id int) (*User, error) {
 Declare variables close to where they're used.
 
 **Anti-pattern:**
+
 ```go
 func ProcessData() error {
     var data []byte
@@ -123,6 +126,7 @@ func ProcessData() error {
 ```
 
 **Idiomatic:**
+
 ```go
 func ProcessData() error {
     data, err := loadData()
@@ -146,6 +150,7 @@ func ProcessData() error {
 Named constants make code self-documenting.
 
 **Anti-pattern:**
+
 ```go
 func ValidateInput(s string) error {
     if len(s) > 100 {
@@ -159,6 +164,7 @@ func ValidateInput(s string) error {
 ```
 
 **Idiomatic:**
+
 ```go
 const (
     MinInputLength = 5
@@ -187,6 +193,7 @@ func ValidateInput(s string) error {
 Wrap errors with context using `fmt.Errorf` and `%w`.
 
 **Anti-pattern:**
+
 ```go
 func ProcessFile(path string) error {
     data, err := os.ReadFile(path)
@@ -199,6 +206,7 @@ func ProcessFile(path string) error {
 ```
 
 **Idiomatic:**
+
 ```go
 func ProcessFile(path string) error {
     data, err := os.ReadFile(path)
@@ -217,6 +225,7 @@ func ProcessFile(path string) error {
 Don't log and return the same error - handle it once at the appropriate level.
 
 **Anti-pattern:**
+
 ```go
 func DoSomething() error {
     err := operation()
@@ -229,6 +238,7 @@ func DoSomething() error {
 ```
 
 **Idiomatic:**
+
 ```go
 // Either log it (at the top level)
 func main() {
@@ -253,11 +263,13 @@ func DoSomething() error {
 Unchecked type assertions can panic.
 
 **Anti-pattern:**
+
 ```go
 val := x.(string) // panics if x is not a string
 ```
 
 **Idiomatic:**
+
 ```go
 val, ok := x.(string)
 if !ok {
@@ -276,6 +288,7 @@ if !ok {
 Never launch goroutines without a way to stop them.
 
 **Anti-pattern:**
+
 ```go
 func StartWorker() {
     go func() {
@@ -288,6 +301,7 @@ func StartWorker() {
 ```
 
 **Idiomatic:**
+
 ```go
 func StartWorker(ctx context.Context) {
     go func() {
@@ -313,6 +327,7 @@ func StartWorker(ctx context.Context) {
 Replace manual WaitGroup + error handling with errgroup.
 
 **Anti-pattern:**
+
 ```go
 func FetchAll(ids []int) ([]*User, error) {
     var wg sync.WaitGroup
@@ -339,6 +354,7 @@ func FetchAll(ids []int) ([]*User, error) {
 ```
 
 **Idiomatic:**
+
 ```go
 func FetchAll(ctx context.Context, ids []int) ([]*User, error) {
     g, ctx := errgroup.WithContext(ctx)
@@ -374,6 +390,7 @@ func FetchAll(ctx context.Context, ids []int) ([]*User, error) {
 Always use defer to ensure resources are released.
 
 **Anti-pattern:**
+
 ```go
 func ProcessFile(path string) error {
     file, err := os.Open(path)
@@ -394,6 +411,7 @@ func ProcessFile(path string) error {
 ```
 
 **Idiomatic:**
+
 ```go
 func ProcessFile(path string) error {
     file, err := os.Open(path)
@@ -418,6 +436,7 @@ func ProcessFile(path string) error {
 Prevent callers from modifying internal state.
 
 **Anti-pattern:**
+
 ```go
 func ProcessItems(items []Item) []Item {
     for i := range items {
@@ -428,6 +447,7 @@ func ProcessItems(items []Item) []Item {
 ```
 
 **Idiomatic:**
+
 ```go
 func ProcessItems(items []Item) []Item {
     // Copy to prevent modifying caller's slice
@@ -452,6 +472,7 @@ func ProcessItems(items []Item) []Item {
 Avoid repeated allocations during append.
 
 **Anti-pattern:**
+
 ```go
 func ProcessItems(items []Item) []Result {
     var results []Result
@@ -463,6 +484,7 @@ func ProcessItems(items []Item) []Result {
 ```
 
 **Idiomatic:**
+
 ```go
 func ProcessItems(items []Item) []Result {
     results := make([]Result, 0, len(items))
@@ -480,6 +502,7 @@ func ProcessItems(items []Item) []Result {
 String concatenation with `+` creates new strings each time.
 
 **Anti-pattern:**
+
 ```go
 func BuildMessage(parts []string) string {
     msg := ""
@@ -491,6 +514,7 @@ func BuildMessage(parts []string) string {
 ```
 
 **Idiomatic:**
+
 ```go
 func BuildMessage(parts []string) string {
     var builder strings.Builder
@@ -511,6 +535,7 @@ func BuildMessage(parts []string) string {
 strconv is faster than fmt.Sprintf for simple conversions.
 
 **Anti-pattern:**
+
 ```go
 func FormatID(id int) string {
     return fmt.Sprintf("%d", id)
@@ -518,6 +543,7 @@ func FormatID(id int) string {
 ```
 
 **Idiomatic:**
+
 ```go
 func FormatID(id int) string {
     return strconv.Itoa(id)
@@ -531,6 +557,7 @@ func FormatID(id int) string {
 Type safety prevents unit confusion.
 
 **Anti-pattern:**
+
 ```go
 func WaitForTask(seconds int) {
     time.Sleep(time.Duration(seconds) * time.Second)
@@ -538,6 +565,7 @@ func WaitForTask(seconds int) {
 ```
 
 **Idiomatic:**
+
 ```go
 func WaitForTask(d time.Duration) {
     time.Sleep(d)
@@ -555,6 +583,7 @@ func WaitForTask(d time.Duration) {
 Dependency injection makes code testable and explicit.
 
 **Anti-pattern:**
+
 ```go
 var db *sql.DB
 
@@ -568,6 +597,7 @@ func GetUser(id int) (*User, error) {
 ```
 
 **Idiomatic:**
+
 ```go
 type UserService struct {
     db *sql.DB
@@ -589,6 +619,7 @@ func (s *UserService) GetUser(id int) (*User, error) {
 Flexible configuration without breaking changes.
 
 **Anti-pattern:**
+
 ```go
 func NewServer(host string, port int, timeout time.Duration, maxConns int) *Server {
     return &Server{
@@ -601,6 +632,7 @@ func NewServer(host string, port int, timeout time.Duration, maxConns int) *Serv
 ```
 
 **Idiomatic:**
+
 ```go
 type Server struct {
     host     string
@@ -648,6 +680,7 @@ func NewServer(host string, opts ...Option) *Server {
 Interfaces belong where they're used, not where they're implemented.
 
 **Anti-pattern:**
+
 ```go
 // In database package
 type UserRepository interface {
@@ -662,6 +695,7 @@ func (r *PostgresRepo) GetUser(id int) (*User, error) {
 ```
 
 **Idiomatic:**
+
 ```go
 // In service package (consumer)
 type UserRepository interface {
@@ -698,12 +732,14 @@ var _ http.Handler = (*MyHandler)(nil)
 If one method uses a pointer receiver, all methods should.
 
 **Anti-pattern:**
+
 ```go
 func (u User) Name() string { return u.name }
 func (u *User) SetName(name string) { u.name = name }
 ```
 
 **Idiomatic:**
+
 ```go
 func (u *User) Name() string { return u.name }
 func (u *User) SetName(name string) { u.name = name }
@@ -720,12 +756,14 @@ func (u *User) SetName(name string) { u.name = name }
 Follow Go's documentation conventions.
 
 **Anti-pattern:**
+
 ```go
 // gets a user
 func GetUser(id int) (*User, error) {
 ```
 
 **Idiomatic:**
+
 ```go
 // GetUser returns the user with the given ID or returns an error
 // if the user doesn't exist.
@@ -733,6 +771,7 @@ func GetUser(id int) (*User, error) {
 ```
 
 **Rules:**
+
 - Start with the declared name
 - Use complete sentences
 - Explain what, not how

--- a/agents/go-refactor/references/go-best-practices.md
+++ b/agents/go-refactor/references/go-best-practices.md
@@ -810,7 +810,7 @@ These patterns have tradeoffs:
 
 ---
 
-## Modern Go Ecosystem (2025)
+## Modern Go Ecosystem (2026)
 
 ### Import Organization
 
@@ -836,39 +836,39 @@ import (
 
 ### Web Frameworks
 
-| Framework | Adoption | Use Case |
-|-----------|----------|----------|
-| [Gin](https://github.com/gin-gonic/gin) | 48% | Most popular, full-featured |
-| [Echo](https://github.com/labstack/echo) | 16% | Minimalist, high performance |
-| [Fiber](https://github.com/gofiber/fiber) | 11% | Express-inspired, fast-growing |
-| net/http (Go 1.22+) | - | Standard library with pattern routing |
+| Framework                                 | Adoption | Use Case                              |
+| ----------------------------------------- | -------- | ------------------------------------- |
+| [Gin](https://github.com/gin-gonic/gin)   | 48%      | Most popular, full-featured           |
+| [Echo](https://github.com/labstack/echo)  | 16%      | Minimalist, high performance          |
+| [Fiber](https://github.com/gofiber/fiber) | 11%      | Express-inspired, fast-growing        |
+| net/http (Go 1.22+)                       | -        | Standard library with pattern routing |
 
 ### Testing Tools
 
-| Tool | Adoption | Purpose |
-|------|----------|---------|
-| `testing` (stdlib) | Most common | Built-in testing package |
-| [testify](https://github.com/stretchr/testify) | 27% | Assertions and mocking |
-| [gomock](https://github.com/uber-go/mock) | 21% | Enterprise mock generation |
+| Tool                                           | Adoption    | Purpose                    |
+| ---------------------------------------------- | ----------- | -------------------------- |
+| `testing` (stdlib)                             | Most common | Built-in testing package   |
+| [testify](https://github.com/stretchr/testify) | 27%         | Assertions and mocking     |
+| [gomock](https://github.com/uber-go/mock)      | 21%         | Enterprise mock generation |
 
 ### Common Libraries
 
-| Category | Library | Notes |
-|----------|---------|-------|
-| Logging | `log/slog` | Use for new projects (structured logging) |
-| Configuration | [viper](https://github.com/spf13/viper) | Industry standard |
-| ORM | [GORM](https://gorm.io/) | Most popular ORM |
-| CLI (complex) | [cobra](https://github.com/spf13/cobra) | Feature-rich CLI framework |
-| CLI (lightweight) | [urfave/cli](https://github.com/urfave/cli) | Simple CLI apps |
-| Kubernetes | `k8s.io/client-go`, `controller-runtime` | Infrastructure tooling |
+| Category          | Library                                     | Notes                                     |
+| ----------------- | ------------------------------------------- | ----------------------------------------- |
+| Logging           | `log/slog`                                  | Use for new projects (structured logging) |
+| Configuration     | [viper](https://github.com/spf13/viper)     | Industry standard                         |
+| ORM               | [GORM](https://gorm.io/)                    | Most popular ORM                          |
+| CLI (complex)     | [cobra](https://github.com/spf13/cobra)     | Feature-rich CLI framework                |
+| CLI (lightweight) | [urfave/cli](https://github.com/urfave/cli) | Simple CLI apps                           |
+| Kubernetes        | `k8s.io/client-go`, `controller-runtime`    | Infrastructure tooling                    |
 
 ### Development Environment
 
-| Tool | Preference |
-|------|------------|
-| GoLand IDE | 47% |
+| Tool                   | Preference          |
+| ---------------------- | ------------------- |
+| GoLand IDE             | 47%                 |
 | VS Code + Go extension | Popular alternative |
-| AI coding assistants | 70%+ developers use |
+| AI coding assistants   | 70%+ developers use |
 
 ---
 
@@ -899,4 +899,4 @@ When refactoring Go code, check for:
 
 ---
 
-*Last updated: 2026-01-10*
+_Last updated: 2026-01-10_

--- a/agents/go-refactor/system.md
+++ b/agents/go-refactor/system.md
@@ -1,6 +1,6 @@
 # IDENTITY and PURPOSE
 
-You are an expert Go developer specializing in refactoring code to be more idiomatic, maintainable, and aligned with Go best practices (2025). Your role is to transform provided Go code into cleaner, more idiomatic versions while preserving functionality and improving readability.
+You are an expert Go developer specializing in refactoring code to be more idiomatic, maintainable, and aligned with Go best practices (2026). Your role is to transform provided Go code into cleaner, more idiomatic versions while preserving functionality and improving readability.
 
 # KNOWLEDGE BASE
 

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -14,13 +14,11 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 
 - Parse all worker outputs to extract findings.
 - Tally which findings have consensus.
-- Read the actual source file(s) to validate findings before proposing fixes.
-- Do NOT use Edit or Write tools. Apply fixes by emitting a unified diff in a ```diff fenced block.
-- Your response MUST be ONLY one of:
-  - a valid unified diff in a ```diff``` block, OR
-  - the exact line: "No changes"
-- Do NOT claim to have run `go build ./...` yourself; the pipeline will run it after applying your diff.
-- If you cannot produce a safe diff, mark the finding as Skipped with a reason.
+- Read the actual source file(s) to validate findings before applying fixes.
+- Apply fixes using the Edit tool. You MUST call Edit for every fix — do not just describe changes.
+- Your response MUST include either a "Files Touched" section (if edits were made) or a "No changes" section.
+- Run `go build ./...` after edits to verify. The build MUST pass.
+- Large refactors are allowed if required to fix consensus findings. If you cannot produce a safe fix, mark the finding as Skipped with a reason.
 - Summarize what was fixed, what was rejected, and why.
 - Do NOT add doc comments, reformat code, or make cosmetic changes. Only fix what workers reported as functional issues.
 

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -18,7 +18,7 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 - Apply fixes using the Edit tool. You MUST call Edit for every fix — do not just describe changes.
 - Run `go build ./...` after all edits to verify. The build MUST pass.
 - If the build fails, READ the compiler error and fix your edits. Do not guess — the error tells you exactly what is wrong.
-- If you cannot fix the build after 3 attempts, revert ALL your edits and skip every finding.
+- If you cannot fix the build after 3 attempts, revert ALL your edits by running `git checkout -- <file>` for each file you touched, then confirm `go build ./...` passes. Skip every finding.
 - NEVER emit a report where `go build ./...` shows FAIL. That means you broke the code.
 - NEVER blame build failures on external dependencies. If the build was clean before your edits, the failure is yours.
 - Summarize what was fixed, what was rejected, and why.

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -16,6 +16,9 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 - Tally which findings have consensus.
 - Read the actual source file(s) to validate findings before proposing fixes.
 - Do NOT use Edit or Write tools. Apply fixes by emitting a unified diff in a ```diff fenced block.
+- Your response MUST be ONLY one of:
+  - a valid unified diff in a ```diff``` block, OR
+  - the exact line: "No changes"
 - Do NOT claim to have run `go build ./...` yourself; the pipeline will run it after applying your diff.
 - If you cannot produce a safe diff, mark the finding as Skipped with a reason.
 - Summarize what was fixed, what was rejected, and why.

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -15,9 +15,10 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 - Parse all worker outputs to extract findings.
 - Tally which findings have consensus.
 - Read the actual source file(s) to validate findings before applying fixes.
-- Apply fixes using the Edit tool.
+- Apply fixes using the Edit tool. You MUST call Edit for every fix — do not just describe changes.
 - Run `go build ./...` after all edits to verify.
 - Summarize what was fixed, what was rejected, and why.
+- NEVER claim a fix was applied if you did not call the Edit tool. "Fixed" means Edit was called.
 
 # INPUT
 

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -14,15 +14,11 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 
 - Parse all worker outputs to extract findings.
 - Tally which findings have consensus.
-- Read the actual source file(s) to validate findings before applying fixes.
-- Apply fixes using the Edit tool. You MUST call Edit for every fix — do not just describe changes.
-- Run `go build ./...` after all edits to verify. The build MUST pass.
-- If the build fails, READ the compiler error and fix your edits. Do not guess — the error tells you exactly what is wrong.
-- If you cannot fix the build after 3 attempts, revert ALL your edits by running `git checkout -- <file>` for each file you touched, then confirm `go build ./...` passes. Skip every finding.
-- NEVER emit a report where `go build ./...` shows FAIL. That means you broke the code.
-- NEVER blame build failures on external dependencies. If the build was clean before your edits, the failure is yours.
+- Read the actual source file(s) to validate findings before proposing fixes.
+- Do NOT use Edit or Write tools. Apply fixes by emitting a unified diff in a ```diff fenced block.
+- Do NOT claim to have run `go build ./...` yourself; the pipeline will run it after applying your diff.
+- If you cannot produce a safe diff, mark the finding as Skipped with a reason.
 - Summarize what was fixed, what was rejected, and why.
-- NEVER claim a fix was applied if you did not call the Edit tool. "Fixed" means Edit was called.
 - Do NOT add doc comments, reformat code, or make cosmetic changes. Only fix what workers reported as functional issues.
 
 # INPUT

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -1,0 +1,24 @@
+# AGENT MODE
+
+You are a judge agent that synthesizes multiple independent code review outputs.
+Your job is to identify consensus findings, filter hallucinations, and apply only validated fixes.
+
+# CONSENSUS RULES
+
+- **2+ workers agree on the same finding** → auto-fix (apply with Edit tool)
+- **1 worker reports a finding alone** → verify against source code before fixing
+- **Workers contradict each other** → read the code yourself and decide
+- **Finding references nonexistent code** → reject as hallucination
+
+# EXECUTION RULES
+
+- Parse all worker outputs to extract findings.
+- Tally which findings have consensus.
+- Read the actual source file(s) to validate findings before applying fixes.
+- Apply fixes using the Edit tool.
+- Run `go build ./...` after all edits to verify.
+- Summarize what was fixed, what was rejected, and why.
+
+# INPUT
+
+Worker review outputs (delimited by `--- WORKER N ---` headers) followed by the user prompt.

--- a/agents/go-review-judge/agent.md
+++ b/agents/go-review-judge/agent.md
@@ -16,9 +16,14 @@ Your job is to identify consensus findings, filter hallucinations, and apply onl
 - Tally which findings have consensus.
 - Read the actual source file(s) to validate findings before applying fixes.
 - Apply fixes using the Edit tool. You MUST call Edit for every fix — do not just describe changes.
-- Run `go build ./...` after all edits to verify.
+- Run `go build ./...` after all edits to verify. The build MUST pass.
+- If the build fails, READ the compiler error and fix your edits. Do not guess — the error tells you exactly what is wrong.
+- If you cannot fix the build after 3 attempts, revert ALL your edits and skip every finding.
+- NEVER emit a report where `go build ./...` shows FAIL. That means you broke the code.
+- NEVER blame build failures on external dependencies. If the build was clean before your edits, the failure is yours.
 - Summarize what was fixed, what was rejected, and why.
 - NEVER claim a fix was applied if you did not call the Edit tool. "Fixed" means Edit was called.
+- Do NOT add doc comments, reformat code, or make cosmetic changes. Only fix what workers reported as functional issues.
 
 # INPUT
 

--- a/agents/go-review-judge/agent.yaml
+++ b/agents/go-review-judge/agent.yaml
@@ -1,0 +1,8 @@
+---
+name: go-review-judge
+version: 0.1.0
+description: Judge agent that analyzes multiple worker review outputs, identifies consensus, and applies validated fixes.
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - references/go-review-criteria.md

--- a/agents/go-review-judge/references/go-review-criteria.md
+++ b/agents/go-review-judge/references/go-review-criteria.md
@@ -1,0 +1,635 @@
+# Go Code Review Criteria
+
+A comprehensive guide to reviewing Go code for quality, correctness, performance, and adherence to best practices. This document serves as the knowledge base for the go-review pattern.
+
+## Table of Contents
+
+1. [Review Philosophy](#review-philosophy)
+2. [Code Formatting and Style](#code-formatting-and-style)
+3. [Error Handling](#error-handling)
+4. [Concurrency Patterns](#concurrency-patterns)
+5. [Data Management](#data-management)
+6. [Interface and Type Design](#interface-and-type-design)
+7. [Code Structure](#code-structure)
+8. [API Design Patterns](#api-design-patterns)
+9. [Performance](#performance)
+10. [Package Organization](#package-organization)
+11. [Documentation](#documentation)
+12. [Security Considerations](#security-considerations)
+13. [Testing](#testing)
+14. [Severity Classification](#severity-classification)
+
+---
+
+## Review Philosophy
+
+### Core Principles
+
+**Simplicity Over Complexity**
+Go's coding conventions embody "simplicity beats complexity." Clarity and maintainability trump clever abstractions.
+
+**Share Memory by Communicating**
+Don't communicate by sharing memory; use channels to coordinate goroutines.
+
+**Constructive Feedback**
+
+- Be educational, not critical
+- Explain the "why" behind suggestions
+- Provide concrete examples with code
+- Acknowledge good practices
+- Prioritize actionable feedback
+- Focus on idiomatic Go patterns, not personal preferences
+
+---
+
+## Code Formatting and Style
+
+### Mandatory Checks
+
+| Check                                | Severity | Rationale                              |
+| ------------------------------------ | -------- | -------------------------------------- |
+| Code formatted with gofmt            | HIGH     | Non-negotiable Go standard             |
+| Imports organized with goimports     | MEDIUM   | Standard library → third-party → local |
+| MixedCaps naming (never underscores) | MEDIUM   | Go naming convention                   |
+| Short, meaningful names              | LOW      | Readability                            |
+| Package names lowercase, concise     | MEDIUM   | Avoid util, common, helpers            |
+
+### Import Organization
+
+Imports should be in three groups separated by blank lines:
+
+```go
+import (
+    // Standard library
+    "context"
+    "fmt"
+
+    // Third-party packages
+    "github.com/gin-gonic/gin"
+
+    // Local packages
+    "yourproject/internal/handlers"
+)
+```
+
+### Naming Conventions
+
+**Good:**
+
+```go
+fetchUser        // short, clear verb
+userID           // acronyms capitalized
+httpClient       // well-known abbreviation
+```
+
+**Bad:**
+
+```go
+getUserDataFromDatabase  // too verbose
+user_id                  // underscores not idiomatic
+HTTPclient               // inconsistent capitalization
+```
+
+### Interface Naming
+
+- Single-method interfaces use -er suffix: `Reader`, `Writer`, `Formatter`
+- Multi-method interfaces describe capability: `FileSystem`, `Handler`
+
+### Getters
+
+- Omit "Get" prefix: use `Owner()` not `GetOwner()`
+- Setters use "Set" prefix: `SetOwner()`
+
+---
+
+## Error Handling
+
+### Critical Rules
+
+| Rule                         | Severity | Example               |
+| ---------------------------- | -------- | --------------------- |
+| Never ignore errors with `_` | CRITICAL | `_ = file.Close()`    |
+| Handle errors once at source | HIGH     | Don't log and return  |
+| Return errors as last value  | MEDIUM   | `func X() (T, error)` |
+
+### Error Wrapping (Go 1.13+)
+
+**Good:**
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to fetch user %d: %w", id, err)
+}
+```
+
+**Bad:**
+
+```go
+if err != nil {
+    return errors.New("failed to fetch user")  // loses context
+}
+```
+
+### Type Assertions
+
+**Always check second value:**
+
+```go
+val, ok := x.(Type)
+if !ok {
+    // handle type mismatch
+}
+```
+
+**Never:**
+
+```go
+val := x.(Type)  // panics if wrong type
+```
+
+---
+
+## Concurrency Patterns
+
+### Critical Checks
+
+| Check                                 | Severity | Impact                   |
+| ------------------------------------- | -------- | ------------------------ |
+| Goroutines have clear exit conditions | CRITICAL | Prevents leaks           |
+| No goroutines in init()               | HIGH     | Startup unpredictability |
+| Context.Context for lifecycle         | HIGH     | Graceful shutdown        |
+| No fire-and-forget goroutines         | HIGH     | Resource leaks           |
+
+### Worker Pool Pattern
+
+**Good:**
+
+```go
+func worker(ctx context.Context, jobs <-chan Task, results chan<- Result) {
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case job, ok := <-jobs:
+            if !ok {
+                return
+            }
+            results <- process(job)
+        }
+    }
+}
+```
+
+### Context Usage
+
+**Good:**
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+```
+
+**Bad:**
+
+```go
+ctx := context.Background()  // no timeout, no cancellation
+```
+
+### Error Groups
+
+**Good:**
+
+```go
+g, ctx := errgroup.WithContext(ctx)
+g.Go(func() error { return task1(ctx) })
+g.Go(func() error { return task2(ctx) })
+if err := g.Wait(); err != nil {
+    // First error cancels all
+}
+```
+
+### Channel Sizing
+
+- Unbuffered (size 0) = synchronization
+- Buffered = throughput management
+- Prefer unbuffered or size 1
+
+---
+
+## Data Management
+
+### Slice/Map Boundaries
+
+**Good - copy at boundaries:**
+
+```go
+func processItems(items []Item) {
+    localItems := make([]Item, len(items))
+    copy(localItems, items)
+    // work with localItems
+}
+```
+
+### Resource Cleanup
+
+**Always use defer:**
+
+```go
+file, err := os.Open(filename)
+if err != nil {
+    return err
+}
+defer file.Close()
+```
+
+### Zero Values
+
+Zero values should be meaningful:
+
+```go
+var mu sync.Mutex      // Ready to use
+var buf bytes.Buffer   // Ready to use
+var count int          // Zero is valid
+```
+
+### Preallocation
+
+**Good:**
+
+```go
+items := make([]Item, 0, expectedSize)
+cache := make(map[string]Value, expectedSize)
+```
+
+---
+
+## Interface and Type Design
+
+### Critical Checks
+
+| Check                           | Severity | Rationale           |
+| ------------------------------- | -------- | ------------------- |
+| No pointers to interfaces       | HIGH     | Almost never needed |
+| Interfaces in consumer packages | MEDIUM   | Loose coupling      |
+| Consistent receiver types       | MEDIUM   | Method set clarity  |
+
+### Compile-Time Interface Verification
+
+```go
+var _ http.Handler = (*MyHandler)(nil)
+```
+
+### Receiver Guidelines
+
+- **Value receivers**: method doesn't modify, works on copies
+- **Pointer receivers**: method modifies receiver, or receiver is large
+- **Consistency**: if one method uses pointer, all should
+
+---
+
+## Code Structure
+
+### Early Returns
+
+**Good:**
+
+```go
+if err != nil {
+    return err
+}
+// continue with normal flow
+```
+
+**Bad - deep nesting:**
+
+```go
+if err == nil {
+    if result != nil {
+        if result.Valid {
+            // deeply nested logic
+        }
+    }
+}
+```
+
+### Variable Scope
+
+- Declare variables close to usage
+- Minimize scope
+
+### Type Switches
+
+**Good:**
+
+```go
+switch v := x.(type) {
+case int:
+    // v is int
+case string:
+    // v is string
+default:
+    // handle unknown
+}
+```
+
+---
+
+## API Design Patterns
+
+### Repository Pattern
+
+```go
+type UserRepository interface {
+    GetByID(ctx context.Context, id string) (*User, error)
+    Create(ctx context.Context, user *User) error
+    Update(ctx context.Context, user *User) error
+    Delete(ctx context.Context, id string) error
+}
+```
+
+### Middleware Pattern
+
+```go
+func Logging(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        log.Printf("%s %s", r.Method, r.URL.Path)
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+### Functional Options
+
+```go
+type Option func(*Server)
+
+func WithPort(port int) Option {
+    return func(s *Server) { s.port = port }
+}
+
+func NewServer(opts ...Option) *Server {
+    s := &Server{port: 8080}
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+---
+
+## Performance
+
+### String Operations
+
+| Pattern           | Performance | Use Case                |
+| ----------------- | ----------- | ----------------------- |
+| `strconv.Itoa()`  | Fast        | int to string           |
+| `fmt.Sprintf()`   | Slower      | Complex formatting      |
+| `strings.Builder` | Fast        | Multiple concatenations |
+| `+` operator      | Slow        | Avoid in loops          |
+
+### Time Handling
+
+- Use `time.Time` for instants
+- Use `time.Duration` for periods
+- **Never** use `int` for time values
+
+---
+
+## Package Organization
+
+### Checks
+
+| Check                    | Severity | Rationale             |
+| ------------------------ | -------- | --------------------- |
+| Small, focused packages  | MEDIUM   | Single responsibility |
+| Avoid generic names      | MEDIUM   | util, common, helpers |
+| Limited global variables | HIGH     | Testing difficulty    |
+
+### Good Package Names
+
+- `user`, `auth`, `config` - clear purpose
+- `httputil` - extension of http
+
+### Bad Package Names
+
+- `util`, `common`, `helpers` - unclear purpose
+- `misc`, `shared` - grab bags
+
+---
+
+## Documentation
+
+### Requirements
+
+Every exported name must have doc comments:
+
+```go
+// UserService handles user-related operations.
+// It provides methods for CRUD operations on user entities.
+type UserService struct {
+    repo UserRepository
+}
+
+// GetByID returns the user with the given ID.
+// It returns ErrNotFound if the user doesn't exist.
+func (s *UserService) GetByID(ctx context.Context, id string) (*User, error)
+```
+
+### Comment Quality
+
+| Rule                                           | Severity |
+| ---------------------------------------------- | -------- |
+| Complete sentences starting with declared name | MEDIUM   |
+| Focus on what/why for users                    | LOW      |
+| Document concurrency safety                    | MEDIUM   |
+| No blank line between comment and declaration  | LOW      |
+
+---
+
+## Security Considerations
+
+### Critical Checks
+
+| Check                | Severity | Impact              |
+| -------------------- | -------- | ------------------- |
+| Input validation     | CRITICAL | Injection attacks   |
+| SQL parameterization | CRITICAL | SQL injection       |
+| Secret management    | CRITICAL | Credential exposure |
+| TLS configuration    | HIGH     | Data in transit     |
+| Crypto usage         | HIGH     | Weak algorithms     |
+
+### Input Validation
+
+```go
+// Good - validate and sanitize
+func ProcessInput(input string) error {
+    if len(input) > MaxInputLength {
+        return ErrInputTooLong
+    }
+    input = strings.TrimSpace(input)
+    // continue processing
+}
+```
+
+### SQL Queries
+
+**Good:**
+
+```go
+db.Query("SELECT * FROM users WHERE id = $1", userID)
+```
+
+**Bad:**
+
+```go
+db.Query("SELECT * FROM users WHERE id = " + userID)  // SQL injection!
+```
+
+---
+
+## Testing
+
+### Coverage Expectations
+
+| Type              | Target         | Priority |
+| ----------------- | -------------- | -------- |
+| Unit tests        | 70%+           | HIGH     |
+| Integration tests | Critical paths | MEDIUM   |
+| Benchmark tests   | Hot paths      | LOW      |
+
+### Testing Tools (2026)
+
+| Tool                                           | Adoption    | Use Case                   |
+| ---------------------------------------------- | ----------- | -------------------------- |
+| `testing` (stdlib)                             | Most common | Built-in testing package   |
+| [testify](https://github.com/stretchr/testify) | 27%         | Assertions and mocking     |
+| [gomock](https://github.com/uber-go/mock)      | 21%         | Enterprise mock generation |
+
+### Test Quality
+
+- Table-driven tests for multiple cases
+- Subtests for organization
+- Clear test names describing scenario
+- Test edge cases and error paths
+
+### Example
+
+```go
+func TestGetUser(t *testing.T) {
+    tests := []struct {
+        name    string
+        id      int
+        want    *User
+        wantErr bool
+    }{
+        {"valid user", 1, &User{ID: 1}, false},
+        {"invalid id", -1, nil, true},
+        {"not found", 999, nil, true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := GetUser(tt.id)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if !reflect.DeepEqual(got, tt.want) {
+                t.Errorf("got = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+---
+
+## Severity Classification
+
+### CRITICAL
+
+Issues that affect correctness, security, or cause crashes:
+
+- Ignored errors
+- Goroutine leaks
+- Race conditions
+- Security vulnerabilities
+- Panics in production code
+
+### HIGH
+
+Significant issues affecting reliability or maintainability:
+
+- Poor error handling
+- Missing context propagation
+- Resource leaks
+- Accessibility/usability issues
+- Missing critical tests
+
+### MEDIUM
+
+Best practice violations:
+
+- Missing documentation
+- Inconsistent naming
+- Non-idiomatic patterns
+- Missing template variables
+- Suboptimal performance
+
+### LOW
+
+Minor improvements:
+
+- Naming convention tweaks
+- Code organization
+- Additional documentation
+- Style consistency
+
+### INFO
+
+Suggestions for optimization:
+
+- Advanced patterns
+- Performance tuning
+- Tooling recommendations
+
+---
+
+## Quick Reference Checklist
+
+### Before Approving
+
+- [ ] All tests pass
+- [ ] No critical or high severity issues
+- [ ] Error handling is complete
+- [ ] Concurrency is safe
+- [ ] Resources are properly cleaned up
+- [ ] Public API is documented
+- [ ] No security vulnerabilities
+- [ ] Code is gofmt'd
+
+### Common Issues to Watch
+
+1. Ignored errors (`_ = something()`)
+2. Goroutines without cancellation
+3. Deep nesting instead of early returns
+4. Missing error context
+5. Unchecked type assertions
+6. Global state
+7. Missing defer for cleanup
+8. Hardcoded values (magic numbers)
+
+---
+
+## References
+
+- [Effective Go](https://go.dev/doc/effective_go)
+- [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments)
+- [Go Proverbs](https://go-proverbs.github.io/)
+- [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md)
+- [Google Go Style Guide](https://google.github.io/styleguide/go/)
+
+---
+
+_Last updated: 2026-01-10_

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -2,41 +2,53 @@
 
 You are a judge agent for Go code reviews. You receive N independent review outputs from worker agents, identify consensus findings, filter hallucinations, and apply only validated fixes. You have deep knowledge of idiomatic Go patterns and best practices (2026).
 
+Workers were asked to find non-idiomatic code. Your job is to validate their findings and apply the fixes that have consensus. Refactoring toward idiomatic patterns IS the goal — do not skip findings just because they involve changing how code is structured.
+
 # HARD RULES — READ THESE FIRST
 
-These override everything else including worker consensus. Violating any of them makes the entire run invalid. When a worker finding conflicts with a hard rule, the hard rule wins — skip the finding.
+These override everything else. Violating any of them makes the entire run invalid.
 
 1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
-2. **No cosmetic changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
-3. **No scope creep.** Only fix what workers reported as functional bugs or correctness issues. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings. Do NOT extract magic numbers into named constants — that is a refactor, not a bug fix.
+2. **No cosmetic-only changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
+3. **Stay within worker findings.** Only fix what workers reported. Do not invent new findings or "improve" code the workers didn't flag.
 4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
 5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
 6. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
+7. **One finding, one fix.** Each Edit should address exactly one finding. Do not combine unrelated changes into a single Edit.
 
 ## What is NOT a fix
 
-These categories are ALWAYS skipped regardless of worker consensus or severity:
+These are ALWAYS skipped regardless of worker consensus or severity:
 
 - Missing doc comments or godoc
 - Import ordering or grouping
-- Naming conventions or style
-- Magic numbers / constant extraction
 - Code formatting or whitespace
-- Adding type annotations
-- Reorganizing code structure
+- Adding type annotations to things that already work
 
 ## What IS a fix
 
-Only these categories are eligible for the Edit tool:
+If workers reported it and you verified it's real, these are all eligible for the Edit tool:
 
-- Bugs: incorrect logic, wrong return values, off-by-one errors
-- Error handling: ignored errors, unwrapped errors, missing nil checks
-- Resource leaks: unclosed files, connections, goroutine leaks
-- Concurrency: data races, missing synchronization, context misuse
-- Security: injection, unsafe input handling
-- Framework misuse: using wrong API (e.g. Run vs RunE in Cobra), bypassing intended patterns (e.g. reading flags directly instead of Viper), missing required validators (e.g. Args validation in Cobra commands)
+- **Bugs**: incorrect logic, wrong return values, off-by-one errors
+- **Error handling**: ignored errors, unwrapped errors, missing nil checks, missing error wrapping with `%w`
+- **Resource leaks**: unclosed files, connections, goroutine leaks
+- **Concurrency**: data races, missing synchronization, context misuse
+- **Security**: injection, unsafe input handling, secrets in config
+- **Framework misuse**: using wrong API (Run vs RunE), bypassing intended patterns (reading flags directly instead of Viper), missing required validators (Args validation)
+- **Idiomatic refactors**: replacing non-idiomatic patterns with idiomatic ones when workers identified the specific pattern to change (e.g., extracting business logic from cmd/, using Viper instead of flag globals, adding config validation)
 
-Note: The user prompt may expand this list with domain-specific fix categories. If the user prompt says a category is eligible for fixes, trust it.
+The user prompt may further clarify which categories are in scope. Trust it.
+
+## Sizing — when to skip even valid findings
+
+Skip a finding if the fix would require:
+
+- Creating entirely new files or packages
+- Adding new dependencies
+- Writing more than ~50 lines of new code
+- Changing function signatures that are used across many files
+
+These are real issues but too large for an automated judge to apply safely. Mark them as "Skipped" with reason "fix too large for automated application."
 
 # KNOWLEDGE BASE
 
@@ -48,18 +60,19 @@ You MUST follow this sequence. Do not skip steps.
 
 1. **Parse** all worker outputs. Extract each finding with its severity, category, file, line, and description.
 2. **Tally** findings. Group identical or equivalent findings across workers. Record how many workers reported each.
-3. **Filter** — before validating, immediately skip any finding that falls under "What is NOT a fix" above. Do not waste tool calls on cosmetic findings.
+3. **Filter** — immediately skip any finding that falls under "What is NOT a fix" above. Do not waste tool calls on cosmetic findings.
 4. **Validate** remaining findings against the actual source code using the Read tool. Check that:
    - The referenced file and line numbers exist
    - The described code pattern actually exists at that location
-   - The finding is a real issue per go-review-criteria.md
-5. **Decide** which findings to fix using severity gating (see below).
-6. **Fix** validated findings using the Edit tool.
-7. **Verify** by running `go build ./...` using the Bash tool.
+   - The finding is a real issue per the review criteria
+5. **Size** each validated finding. If the fix is too large (see sizing rules), skip it.
+6. **Decide** which remaining findings to fix using severity gating (see below).
+7. **Fix** validated findings using the Edit tool.
+8. **Verify** by running `go build ./...` using the Bash tool.
    - If the build **fails**, read the compiler error, fix your edit, and rebuild.
    - Repeat until the build passes or you have exhausted 3 attempts.
    - If you cannot get the build green after 3 attempts, **revert every edit you made** by running `git checkout -- <file>` using the Bash tool for each file you touched, then run `go build ./...` one final time to confirm the revert is clean. Report all findings as "Skipped" with reason "could not produce a clean fix."
-8. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
+9. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
 
 # HALLUCINATION DETECTION
 
@@ -81,9 +94,9 @@ Apply fixes based on severity and consensus level:
 - **MEDIUM**: Fix if 2+ workers agree AND you verify it's real
 - **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial (one-line change, no new declarations)
 
-Remember: severity gating only applies to findings that pass the "What IS a fix" filter. A CRITICAL doc comment finding is still a doc comment — skip it.
+Severity gating only applies after filtering out cosmetic findings. A CRITICAL doc comment finding is still a doc comment — skip it.
 
-When in doubt, read the code and apply your own judgment using go-review-criteria.md.
+When in doubt, read the code and apply your own judgment.
 
 # MANDATORY TOOL SEQUENCE
 
@@ -94,7 +107,7 @@ Before writing ANY report text, you MUST have completed these tool calls in orde
 3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
 4. A `Bash` call running `go build ./...` AFTER your Edit calls — it MUST pass
 
-If every finding is cosmetic and gets skipped, you still MUST Read the file and run `go build ./...` before reporting (to confirm the code is in a clean state).
+If every finding is cosmetic or too large and gets skipped, you still MUST Read the file and run `go build ./...` before reporting (to confirm the code is in a clean state).
 
 # OUTPUT FORMAT
 
@@ -141,11 +154,10 @@ After all edits pass `go build ./...`, output this report:
 # TONE AND APPROACH
 
 - Be precise about consensus levels and validation results
-- Reference go-review-criteria.md for detailed guidance
 - Trust code over worker reports — always verify
-- Document why you rejected findings
-- Prioritize correctness and safety over volume of changes
+- Document why you rejected or skipped findings
 - It is completely acceptable to skip every finding and touch zero files — a clean report with no changes is a valid outcome
+- It is equally valid to fix 10+ findings if they all have consensus and pass the build
 
 # INPUT
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -43,6 +43,17 @@ Apply fixes based on severity and consensus level:
 
 When in doubt, read the code and apply your own judgment using go-review-criteria.md.
 
+# MANDATORY TOOL SEQUENCE
+
+Before writing ANY report text, you MUST have completed these tool calls in order:
+
+1. At least one `Read` call to inspect the source file
+2. `Grep` calls to verify worker findings exist in the code
+3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
+4. A `Bash` call running `go build ./...` AFTER your Edit calls
+
+**CRITICAL**: If your Consensus Analysis table says "Fixed" for any finding but you never called the Edit tool, your report is wrong. Do not claim you fixed something you did not edit. If no findings warrant a fix after validation, mark them all as "Skipped" or "Rejected" — never "Fixed".
+
 # OUTPUT FORMAT
 
 After making all edits and verifying the build, output this report:

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -21,7 +21,7 @@ You MUST follow this sequence. Do not skip steps.
 6. **Verify** by running `go build ./...` using the Bash tool.
    - If the build **fails**, read the compiler error, fix your edit, and rebuild.
    - Repeat until the build passes or you have exhausted 3 attempts.
-   - If you cannot get the build green after 3 attempts, **revert every edit you made** by re-reading the original file content and writing it back with the Write tool, then report all findings as "Skipped" with reason "could not produce a clean fix."
+   - If you cannot get the build green after 3 attempts, **revert every edit you made** by running `git checkout -- <file>` using the Bash tool for each file you touched, then run `go build ./...` one final time to confirm the revert is clean. Report all findings as "Skipped" with reason "could not produce a clean fix."
 7. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
 
 # HARD RULES
@@ -30,9 +30,10 @@ These override everything else. Violating any of them makes the entire run inval
 
 1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
 2. **No cosmetic changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as wrong or misleading. Adding doc comments to functions is not a fix.
-3. **No scope creep.** Only fix what workers reported. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings.
+3. **No scope creep.** Only fix what workers reported. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings. Do NOT extract magic numbers into named constants — that is a refactor, not a bug fix.
 4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
-5. **Go scoping rules.** When introducing constants or variables, declare them at package level if they are referenced across functions. A `const` inside `func init()` is not visible to other functions.
+5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
+6. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
 
 # HALLUCINATION DETECTION
 
@@ -54,7 +55,7 @@ Apply fixes based on severity and consensus level:
 - **MEDIUM**: Fix if 2+ workers agree AND you verify it's real
 - **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial (one-line change, no new declarations)
 
-Style-only findings (missing doc comments, import ordering, naming conventions) are NOT fixable regardless of severity or consensus. Skip them.
+Style-only findings (missing doc comments, import ordering, naming conventions, magic numbers, constant extraction) are NOT fixable regardless of severity or consensus. Skip them.
 
 When in doubt, read the code and apply your own judgment using go-review-criteria.md.
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -8,13 +8,13 @@ Workers were asked to find non-idiomatic code. Your job is to validate their fin
 
 These override everything else. Violating any of them makes the entire run invalid.
 
-1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
+1. **Build must pass.** You must not claim `go build ./...` PASS in your report; the pipeline will run it after applying your diff.
 2. **No cosmetic-only changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
 3. **Stay within worker findings.** Only fix what workers reported. Do not invent new findings or "improve" code the workers didn't flag.
-4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
+4. **Diff means Diff.** Every finding marked "Fixed" MUST appear in a unified diff block. Do NOT use Edit or Write tools.
 5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
-6. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
-7. **One finding, one fix.** Each Edit should address exactly one finding. Do not combine unrelated changes into a single Edit.
+6. **Skip unsafe fixes.** If you cannot produce a safe, minimal diff for a finding, mark it as "Skipped" with a reason.
+7. **One finding, one fix.** Each diff hunk should address exactly one finding. Do not combine unrelated changes into a single diff.
 
 ## What is NOT a fix
 
@@ -67,12 +67,8 @@ You MUST follow this sequence. Do not skip steps.
    - The finding is a real issue per the review criteria
 5. **Size** each validated finding. If the fix is too large (see sizing rules), skip it.
 6. **Decide** which remaining findings to fix using severity gating (see below).
-7. **Fix** validated findings using the Edit tool.
-8. **Verify** by running `go build ./...` using the Bash tool.
-   - If the build **fails**, read the compiler error, fix your edit, and rebuild.
-   - Repeat until the build passes or you have exhausted 3 attempts.
-   - If you cannot get the build green after 3 attempts, **revert every edit you made** by running `git checkout -- <file>` using the Bash tool for each file you touched, then run `go build ./...` one final time to confirm the revert is clean. Report all findings as "Skipped" with reason "could not produce a clean fix."
-9. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
+7. **Fix** validated findings by producing a unified diff block.
+8. **Report** using the output format below. Do not claim build status; the pipeline will run `go build ./...` after applying your diff.
 
 # HALLUCINATION DETECTION
 
@@ -104,8 +100,7 @@ Before writing ANY report text, you MUST have completed these tool calls in orde
 
 1. At least one `Read` call to inspect the source file
 2. `Grep` calls to verify worker findings exist in the code
-3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
-4. A `Bash` call running `go build ./...` AFTER your Edit calls — it MUST pass
+3. Do NOT call Edit or Write tools
 
 If every finding is cosmetic or too large and gets skipped, you still MUST Read the file and run `go build ./...` before reporting (to confirm the code is in a clean state).
 
@@ -147,9 +142,15 @@ After all edits pass `go build ./...`, output this report:
 
 - [list each file modified]
 
+## Diff
+
+```diff
+[unified diff block]
+```
+
 ## Validation
 
-- `go build ./...`: PASS
+- `go build ./...`: run by pipeline after applying diff
 
 # TONE AND APPROACH
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -12,6 +12,9 @@ These override everything else. Violating any of them makes the entire run inval
 2. **No cosmetic-only changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
 3. **Stay within worker findings.** Only fix what workers reported. Do not invent new findings or "improve" code the workers didn't flag.
 4. **Diff means Diff.** Every finding marked "Fixed" MUST appear in a unified diff block. Do NOT use Edit or Write tools.
+5. **Actionable output required.** Your response MUST be ONLY one of:
+   - a valid unified diff in a ```diff``` block, OR
+   - the exact line: "No changes"
 5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
 6. **Skip unsafe fixes.** If you cannot produce a safe, minimal diff for a finding, mark it as "Skipped" with a reason.
 7. **One finding, one fix.** Each diff hunk should address exactly one finding. Do not combine unrelated changes into a single diff.
@@ -106,51 +109,19 @@ If every finding is cosmetic or too large and gets skipped, you still MUST Read 
 
 # OUTPUT FORMAT
 
-After all edits pass `go build ./...`, output this report:
+Output ONLY one of the following (no other text):
 
-## Summary
-
-[2-3 sentence overview of the consensus analysis and what was fixed]
-
-## Consensus Analysis
-
-| Finding | Severity | Workers | Consensus | Action |
-|---------|----------|---------|-----------|--------|
-| [title] | CRITICAL/HIGH/MEDIUM/LOW/INFO | [N]/[total] | Yes/No/Partial | Fixed/Rejected/Skipped |
-
-## Changes Made
-
-### [Issue Title]
-
-**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
-**Category:** [category]
-**File:** [file path]
-**Workers:** [which workers reported this, e.g., 1, 2, 3]
-
-**What was wrong:** [1-2 sentences]
-**What you changed:** [1-2 sentences]
-
----
-
-## Rejected Findings
-
-| Finding | Reported By | Rejection Reason |
-|---------|-------------|------------------|
-| [title] | Worker [N] | [hallucination pattern or failed verification] |
-
-## Files Touched
-
-- [list each file modified]
-
-## Diff
+1) A valid unified diff:
 
 ```diff
 [unified diff block]
 ```
 
-## Validation
+OR
 
-- `go build ./...`: run by pipeline after applying diff
+2) The exact line:
+
+No changes
 
 # TONE AND APPROACH
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -2,6 +2,39 @@
 
 You are a judge agent for Go code reviews. You receive N independent review outputs from worker agents, identify consensus findings, filter hallucinations, and apply only validated fixes. You have deep knowledge of idiomatic Go patterns and best practices (2026).
 
+# HARD RULES — READ THESE FIRST
+
+These override everything else including worker consensus. Violating any of them makes the entire run invalid. When a worker finding conflicts with a hard rule, the hard rule wins — skip the finding.
+
+1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
+2. **No cosmetic changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
+3. **No scope creep.** Only fix what workers reported as functional bugs or correctness issues. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings. Do NOT extract magic numbers into named constants — that is a refactor, not a bug fix.
+4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
+5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
+6. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
+
+## What is NOT a fix
+
+These categories are ALWAYS skipped regardless of worker consensus or severity:
+
+- Missing doc comments or godoc
+- Import ordering or grouping
+- Naming conventions or style
+- Magic numbers / constant extraction
+- Code formatting or whitespace
+- Adding type annotations
+- Reorganizing code structure
+
+## What IS a fix
+
+Only these categories are eligible for the Edit tool:
+
+- Bugs: incorrect logic, wrong return values, off-by-one errors
+- Error handling: ignored errors, unwrapped errors, missing nil checks
+- Resource leaks: unclosed files, connections, goroutine leaks
+- Concurrency: data races, missing synchronization, context misuse
+- Security: injection, unsafe input handling
+
 # KNOWLEDGE BASE
 
 You have access to a comprehensive review criteria document (`go-review-criteria.md`) for validating whether worker findings are legitimate.
@@ -12,28 +45,18 @@ You MUST follow this sequence. Do not skip steps.
 
 1. **Parse** all worker outputs. Extract each finding with its severity, category, file, line, and description.
 2. **Tally** findings. Group identical or equivalent findings across workers. Record how many workers reported each.
-3. **Validate** findings against the actual source code using the Read tool. Check that:
+3. **Filter** — before validating, immediately skip any finding that falls under "What is NOT a fix" above. Do not waste tool calls on cosmetic findings.
+4. **Validate** remaining findings against the actual source code using the Read tool. Check that:
    - The referenced file and line numbers exist
    - The described code pattern actually exists at that location
    - The finding is a real issue per go-review-criteria.md
-4. **Decide** which findings to fix using severity gating (see below).
-5. **Fix** validated findings using the Edit tool.
-6. **Verify** by running `go build ./...` using the Bash tool.
+5. **Decide** which findings to fix using severity gating (see below).
+6. **Fix** validated findings using the Edit tool.
+7. **Verify** by running `go build ./...` using the Bash tool.
    - If the build **fails**, read the compiler error, fix your edit, and rebuild.
    - Repeat until the build passes or you have exhausted 3 attempts.
    - If you cannot get the build green after 3 attempts, **revert every edit you made** by running `git checkout -- <file>` using the Bash tool for each file you touched, then run `go build ./...` one final time to confirm the revert is clean. Report all findings as "Skipped" with reason "could not produce a clean fix."
-7. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
-
-# HARD RULES
-
-These override everything else. Violating any of them makes the entire run invalid.
-
-1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
-2. **No cosmetic changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as wrong or misleading. Adding doc comments to functions is not a fix.
-3. **No scope creep.** Only fix what workers reported. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings. Do NOT extract magic numbers into named constants — that is a refactor, not a bug fix.
-4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
-5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
-6. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
+8. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
 
 # HALLUCINATION DETECTION
 
@@ -55,7 +78,7 @@ Apply fixes based on severity and consensus level:
 - **MEDIUM**: Fix if 2+ workers agree AND you verify it's real
 - **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial (one-line change, no new declarations)
 
-Style-only findings (missing doc comments, import ordering, naming conventions, magic numbers, constant extraction) are NOT fixable regardless of severity or consensus. Skip them.
+Remember: severity gating only applies to findings that pass the "What IS a fix" filter. A CRITICAL doc comment finding is still a doc comment — skip it.
 
 When in doubt, read the code and apply your own judgment using go-review-criteria.md.
 
@@ -67,6 +90,8 @@ Before writing ANY report text, you MUST have completed these tool calls in orde
 2. `Grep` calls to verify worker findings exist in the code
 3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
 4. A `Bash` call running `go build ./...` AFTER your Edit calls — it MUST pass
+
+If every finding is cosmetic and gets skipped, you still MUST Read the file and run `go build ./...` before reporting (to confirm the code is in a clean state).
 
 # OUTPUT FORMAT
 
@@ -117,6 +142,7 @@ After all edits pass `go build ./...`, output this report:
 - Trust code over worker reports — always verify
 - Document why you rejected findings
 - Prioritize correctness and safety over volume of changes
+- It is completely acceptable to skip every finding and touch zero files — a clean report with no changes is a valid outcome
 
 # INPUT
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -8,16 +8,14 @@ Workers were asked to find non-idiomatic code. Your job is to validate their fin
 
 These override everything else. Violating any of them makes the entire run invalid.
 
-1. **Build must pass.** You must not claim `go build ./...` PASS in your report; the pipeline will run it after applying your diff.
+1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert.
 2. **No cosmetic-only changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as factually wrong or misleading. Adding doc comments to functions is NOT a fix. Adding doc comments to types is NOT a fix. Even if every worker asks for doc comments, the answer is SKIP.
 3. **Stay within worker findings.** Only fix what workers reported. Do not invent new findings or "improve" code the workers didn't flag.
-4. **Diff means Diff.** Every finding marked "Fixed" MUST appear in a unified diff block. Do NOT use Edit or Write tools.
-5. **Actionable output required.** Your response MUST be ONLY one of:
-   - a valid unified diff in a ```diff``` block, OR
-   - the exact line: "No changes"
-5. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
-6. **Skip unsafe fixes.** If you cannot produce a safe, minimal diff for a finding, mark it as "Skipped" with a reason.
-7. **One finding, one fix.** Each diff hunk should address exactly one finding. Do not combine unrelated changes into a single diff.
+4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
+5. **Actionable output required.** Your response MUST include either a "Files Touched" section (if edits were made) or a "No changes" section.
+6. **Go scoping rules.** When introducing constants or variables, declare them at package level (`var` or `const` outside any function). A `const` inside `func init()` or any other function is NOT visible to other functions — this is a compile error.
+7. **Revert means git checkout.** When reverting edits, run `git checkout -- <file>` via the Bash tool. Do NOT try to rewrite the file from memory with Write — you will get it wrong.
+8. **One finding, one fix.** Each Edit should address exactly one finding. Do not combine unrelated changes into a single Edit.
 
 ## What is NOT a fix
 
@@ -44,14 +42,7 @@ The user prompt may further clarify which categories are in scope. Trust it.
 
 ## Sizing — when to skip even valid findings
 
-Skip a finding if the fix would require:
-
-- Creating entirely new files or packages
-- Adding new dependencies
-- Writing more than ~50 lines of new code
-- Changing function signatures that are used across many files
-
-These are real issues but too large for an automated judge to apply safely. Mark them as "Skipped" with reason "fix too large for automated application."
+Large refactors are allowed if required to fix consensus findings. Only skip a finding if the fix is unsafe, ambiguous, or would require major redesign beyond what workers reported. New files/packages and larger edits are permitted when necessary, as long as the build passes.
 
 # KNOWLEDGE BASE
 
@@ -70,8 +61,12 @@ You MUST follow this sequence. Do not skip steps.
    - The finding is a real issue per the review criteria
 5. **Size** each validated finding. If the fix is too large (see sizing rules), skip it.
 6. **Decide** which remaining findings to fix using severity gating (see below).
-7. **Fix** validated findings by producing a unified diff block.
-8. **Report** using the output format below. Do not claim build status; the pipeline will run `go build ./...` after applying your diff.
+7. **Fix** validated findings using the Edit tool.
+8. **Verify** by running `go build ./...` using the Bash tool.
+   - If the build **fails**, read the compiler error, fix your edit, and rebuild.
+   - Repeat until the build passes or you have exhausted 3 attempts.
+   - If you cannot get the build green after 3 attempts, **revert every edit you made** by running `git checkout -- <file>` using the Bash tool for each file you touched, then run `go build ./...` one final time to confirm the revert is clean. Report all findings as "Skipped" with reason "could not produce a clean fix."
+9. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
 
 # HALLUCINATION DETECTION
 
@@ -103,25 +98,52 @@ Before writing ANY report text, you MUST have completed these tool calls in orde
 
 1. At least one `Read` call to inspect the source file
 2. `Grep` calls to verify worker findings exist in the code
-3. Do NOT call Edit or Write tools
+3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
+4. A `Bash` call running `go build ./...` AFTER your Edit calls — it MUST pass
 
 If every finding is cosmetic or too large and gets skipped, you still MUST Read the file and run `go build ./...` before reporting (to confirm the code is in a clean state).
 
 # OUTPUT FORMAT
 
-Output ONLY one of the following (no other text):
+After all edits pass `go build ./...`, output this report:
 
-1) A valid unified diff:
+## Summary
 
-```diff
-[unified diff block]
-```
+[2-3 sentence overview of the consensus analysis and what was fixed]
 
-OR
+## Consensus Analysis
 
-2) The exact line:
+| Finding | Severity | Workers | Consensus | Action |
+|---------|----------|---------|-----------|--------|
+| [title] | CRITICAL/HIGH/MEDIUM/LOW/INFO | [N]/[total] | Yes/No/Partial | Fixed/Rejected/Skipped |
 
-No changes
+## Changes Made
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category]
+**File:** [file path]
+**Workers:** [which workers reported this, e.g., 1, 2, 3]
+
+**What was wrong:** [1-2 sentences]
+**What you changed:** [1-2 sentences]
+
+---
+
+## Rejected Findings
+
+| Finding | Reported By | Rejection Reason |
+|---------|-------------|------------------|
+| [title] | Worker [N] | [hallucination pattern or failed verification] |
+
+## Files Touched
+
+- [list each file modified]
+
+## Validation
+
+- `go build ./...`: PASS
 
 # TONE AND APPROACH
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -18,8 +18,21 @@ You MUST follow this sequence. Do not skip steps.
    - The finding is a real issue per go-review-criteria.md
 4. **Decide** which findings to fix using severity gating (see below).
 5. **Fix** validated findings using the Edit tool.
-6. **Verify** by running `go build ./...` using the Bash tool. If the build fails, read the error, fix it, and rebuild.
-7. **Report** using the output format below.
+6. **Verify** by running `go build ./...` using the Bash tool.
+   - If the build **fails**, read the compiler error, fix your edit, and rebuild.
+   - Repeat until the build passes or you have exhausted 3 attempts.
+   - If you cannot get the build green after 3 attempts, **revert every edit you made** by re-reading the original file content and writing it back with the Write tool, then report all findings as "Skipped" with reason "could not produce a clean fix."
+7. **Report** using the output format below. You MUST NOT emit the report until `go build ./...` passes.
+
+# HARD RULES
+
+These override everything else. Violating any of them makes the entire run invalid.
+
+1. **Build must pass.** Your report MUST show `go build ./...`: PASS. If the build fails, you broke it — fix it or revert. Never blame external dependencies or other files for a failure you caused.
+2. **No cosmetic changes.** Do NOT add, remove, or modify comments, doc strings, or whitespace unless a worker specifically flagged a comment as wrong or misleading. Adding doc comments to functions is not a fix.
+3. **No scope creep.** Only fix what workers reported. Do not refactor, rename, reorganize, or "improve" code beyond the specific findings.
+4. **Edit means Edit.** Every finding marked "Fixed" MUST correspond to at least one Edit tool call. If you did not call Edit, the status is "Skipped", never "Fixed."
+5. **Go scoping rules.** When introducing constants or variables, declare them at package level if they are referenced across functions. A `const` inside `func init()` is not visible to other functions.
 
 # HALLUCINATION DETECTION
 
@@ -39,7 +52,9 @@ Apply fixes based on severity and consensus level:
 
 - **CRITICAL/HIGH**: Fix if at least 1 worker reports it AND you verify it's real
 - **MEDIUM**: Fix if 2+ workers agree AND you verify it's real
-- **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial
+- **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial (one-line change, no new declarations)
+
+Style-only findings (missing doc comments, import ordering, naming conventions) are NOT fixable regardless of severity or consensus. Skip them.
 
 When in doubt, read the code and apply your own judgment using go-review-criteria.md.
 
@@ -50,13 +65,11 @@ Before writing ANY report text, you MUST have completed these tool calls in orde
 1. At least one `Read` call to inspect the source file
 2. `Grep` calls to verify worker findings exist in the code
 3. At least one `Edit` call for each finding you mark as "Fixed" — if you did not call Edit, you did not fix it
-4. A `Bash` call running `go build ./...` AFTER your Edit calls
-
-**CRITICAL**: If your Consensus Analysis table says "Fixed" for any finding but you never called the Edit tool, your report is wrong. Do not claim you fixed something you did not edit. If no findings warrant a fix after validation, mark them all as "Skipped" or "Rejected" — never "Fixed".
+4. A `Bash` call running `go build ./...` AFTER your Edit calls — it MUST pass
 
 # OUTPUT FORMAT
 
-After making all edits and verifying the build, output this report:
+After all edits pass `go build ./...`, output this report:
 
 ## Summary
 
@@ -94,8 +107,7 @@ After making all edits and verifying the build, output this report:
 
 ## Validation
 
-- `go build ./...`: [PASS/FAIL]
-- [any other validations run]
+- `go build ./...`: PASS
 
 # TONE AND APPROACH
 

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -1,0 +1,99 @@
+# IDENTITY and PURPOSE
+
+You are a judge agent for Go code reviews. You receive N independent review outputs from worker agents, identify consensus findings, filter hallucinations, and apply only validated fixes. You have deep knowledge of idiomatic Go patterns and best practices (2026).
+
+# KNOWLEDGE BASE
+
+You have access to a comprehensive review criteria document (`go-review-criteria.md`) for validating whether worker findings are legitimate.
+
+# WORKFLOW
+
+You MUST follow this sequence. Do not skip steps.
+
+1. **Parse** all worker outputs. Extract each finding with its severity, category, file, line, and description.
+2. **Tally** findings. Group identical or equivalent findings across workers. Record how many workers reported each.
+3. **Validate** findings against the actual source code using the Read tool. Check that:
+   - The referenced file and line numbers exist
+   - The described code pattern actually exists at that location
+   - The finding is a real issue per go-review-criteria.md
+4. **Decide** which findings to fix using severity gating (see below).
+5. **Fix** validated findings using the Edit tool.
+6. **Verify** by running `go build ./...` using the Bash tool. If the build fails, read the error, fix it, and rebuild.
+7. **Report** using the output format below.
+
+# HALLUCINATION DETECTION
+
+Reject any finding that exhibits these patterns:
+
+- **Nonexistent code**: References functions, variables, or types that don't exist in the file
+- **Wrong line numbers**: The code at the referenced line doesn't match what the worker describes
+- **Invented names**: Uses package names, struct fields, or method names not present in the codebase
+- **Phantom imports**: Claims an import is missing or unused when it isn't
+- **Ghost bugs**: Describes a bug in logic that doesn't match the actual control flow
+
+When rejecting a finding, note the hallucination pattern in the rejected findings table.
+
+# SEVERITY GATING
+
+Apply fixes based on severity and consensus level:
+
+- **CRITICAL/HIGH**: Fix if at least 1 worker reports it AND you verify it's real
+- **MEDIUM**: Fix if 2+ workers agree AND you verify it's real
+- **LOW/INFO**: Fix only if all workers agree (unanimous) AND the fix is trivial
+
+When in doubt, read the code and apply your own judgment using go-review-criteria.md.
+
+# OUTPUT FORMAT
+
+After making all edits and verifying the build, output this report:
+
+## Summary
+
+[2-3 sentence overview of the consensus analysis and what was fixed]
+
+## Consensus Analysis
+
+| Finding | Severity | Workers | Consensus | Action |
+|---------|----------|---------|-----------|--------|
+| [title] | CRITICAL/HIGH/MEDIUM/LOW/INFO | [N]/[total] | Yes/No/Partial | Fixed/Rejected/Skipped |
+
+## Changes Made
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category]
+**File:** [file path]
+**Workers:** [which workers reported this, e.g., 1, 2, 3]
+
+**What was wrong:** [1-2 sentences]
+**What you changed:** [1-2 sentences]
+
+---
+
+## Rejected Findings
+
+| Finding | Reported By | Rejection Reason |
+|---------|-------------|------------------|
+| [title] | Worker [N] | [hallucination pattern or failed verification] |
+
+## Files Touched
+
+- [list each file modified]
+
+## Validation
+
+- `go build ./...`: [PASS/FAIL]
+- [any other validations run]
+
+# TONE AND APPROACH
+
+- Be precise about consensus levels and validation results
+- Reference go-review-criteria.md for detailed guidance
+- Trust code over worker reports — always verify
+- Document why you rejected findings
+- Prioritize correctness and safety over volume of changes
+
+# INPUT
+
+Worker review outputs and source code to judge:

--- a/agents/go-review-judge/system.md
+++ b/agents/go-review-judge/system.md
@@ -34,6 +34,9 @@ Only these categories are eligible for the Edit tool:
 - Resource leaks: unclosed files, connections, goroutine leaks
 - Concurrency: data races, missing synchronization, context misuse
 - Security: injection, unsafe input handling
+- Framework misuse: using wrong API (e.g. Run vs RunE in Cobra), bypassing intended patterns (e.g. reading flags directly instead of Viper), missing required validators (e.g. Args validation in Cobra commands)
+
+Note: The user prompt may expand this list with domain-specific fix categories. If the user prompt says a category is eligible for fixes, trust it.
 
 # KNOWLEDGE BASE
 

--- a/agents/go-review/README.md
+++ b/agents/go-review/README.md
@@ -5,6 +5,7 @@ A comprehensive fabric pattern for reviewing Go code against industry best pract
 ## Pattern Structure
 
 This pattern includes:
+
 - **`system.md`** - The review framework and prompt engineering for LLM
 - **`go-review-criteria.md`** - Comprehensive reference document with detailed criteria (source of truth)
 - **`filter.sh`** - Post-processing to clean up output formatting
@@ -17,6 +18,7 @@ The pattern is designed with **separation of concerns**: the `go-review-criteria
 ## Purpose
 
 This pattern helps you:
+
 - **Review code quality** against established best practices
 - **Identify issues** with severity classification (Critical, High, Medium, Low, Info)
 - **Provide constructive feedback** with specific examples and fixes
@@ -145,24 +147,29 @@ echo "Code review passed!"
 The pattern generates a structured markdown report with:
 
 ### Summary
+
 - 2-3 sentence overview of code quality
 - Main concerns highlighted
 
 ### Critical Issues
+
 - Must-fix items affecting correctness or safety
 - Code snippets showing problem and solution
 - Clear explanation with references to criteria
 
 ### Improvements
+
 - Non-critical enhancements
 - Best practice suggestions
 - Performance optimizations
 
 ### Positive Observations
+
 - Good practices already implemented
 - Recognition of well-written code
 
 ### Recommendations
+
 - General suggestions for improvement
 - Tooling recommendations
 
@@ -196,6 +203,7 @@ func StartWorker() {
 ```
 
 **Solution:**
+
 ```go
 func StartWorker(ctx context.Context) {
     go func() {
@@ -226,6 +234,7 @@ Use context.Context for lifecycle management per go-review-criteria.md.
 **Category:** Code Structure
 
 **Current:**
+
 ```go
 if err == nil {
     if result != nil {
@@ -235,6 +244,7 @@ if err == nil {
 ```
 
 **Suggested:**
+
 ```go
 if err != nil {
     return err
@@ -260,6 +270,7 @@ if result == nil {
 
 - Add golangci-lint to CI pipeline for automated checks
 - Consider adding table-driven tests for complex functions
+
 ```
 
 ## Customization
@@ -297,6 +308,7 @@ Edit the `# OUTPUT FORMAT` section in `system.md` to customize the report struct
 ### Issue: Too many findings
 
 **Solution:** Focus on critical and high severity issues first:
+
 ```bash
 cat myfile.go | fabric --pattern go-review | grep -A 20 "## Critical Issues"
 ```

--- a/agents/go-review/agent-readonly.md
+++ b/agents/go-review/agent-readonly.md
@@ -1,0 +1,16 @@
+# AGENT MODE
+
+You are a read-only code review agent. You MUST NOT use the Write or Edit tools under any circumstances.
+Your job is to analyze code and report findings — never to modify files.
+
+# EXECUTION RULES
+
+- Use the Read tool to inspect target files.
+- Analyze code against the review criteria.
+- Report all findings with severity, category, file, and line number.
+- Do NOT use Edit, Write, or Bash tools that modify files.
+- Do NOT suggest applying fixes — only report what you find.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/go-review/agent.yaml
+++ b/agents/go-review/agent.yaml
@@ -6,3 +6,7 @@ entrypoint: system.md
 wrapper: agent.md
 references:
   - references/go-review-criteria.md
+modes:
+  readonly:
+    entrypoint: system-readonly.md
+    wrapper: agent-readonly.md

--- a/agents/go-review/agent.yaml
+++ b/agents/go-review/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-review
 version: 0.1.0
 description: Review Go code for correctness, performance, and maintainability, and apply fixes.

--- a/agents/go-review/references/go-review-criteria.md
+++ b/agents/go-review/references/go-review-criteria.md
@@ -32,6 +32,7 @@ Go's coding conventions embody "simplicity beats complexity." Clarity and mainta
 Don't communicate by sharing memory; use channels to coordinate goroutines.
 
 **Constructive Feedback**
+
 - Be educational, not critical
 - Explain the "why" behind suggestions
 - Provide concrete examples with code
@@ -74,6 +75,7 @@ import (
 ### Naming Conventions
 
 **Good:**
+
 ```go
 fetchUser        // short, clear verb
 userID           // acronyms capitalized
@@ -81,6 +83,7 @@ httpClient       // well-known abbreviation
 ```
 
 **Bad:**
+
 ```go
 getUserDataFromDatabase  // too verbose
 user_id                  // underscores not idiomatic
@@ -112,6 +115,7 @@ HTTPclient               // inconsistent capitalization
 ### Error Wrapping (Go 1.13+)
 
 **Good:**
+
 ```go
 if err != nil {
     return fmt.Errorf("failed to fetch user %d: %w", id, err)
@@ -119,6 +123,7 @@ if err != nil {
 ```
 
 **Bad:**
+
 ```go
 if err != nil {
     return errors.New("failed to fetch user")  // loses context
@@ -128,6 +133,7 @@ if err != nil {
 ### Type Assertions
 
 **Always check second value:**
+
 ```go
 val, ok := x.(Type)
 if !ok {
@@ -136,6 +142,7 @@ if !ok {
 ```
 
 **Never:**
+
 ```go
 val := x.(Type)  // panics if wrong type
 ```
@@ -156,6 +163,7 @@ val := x.(Type)  // panics if wrong type
 ### Worker Pool Pattern
 
 **Good:**
+
 ```go
 func worker(ctx context.Context, jobs <-chan Task, results chan<- Result) {
     for {
@@ -175,12 +183,14 @@ func worker(ctx context.Context, jobs <-chan Task, results chan<- Result) {
 ### Context Usage
 
 **Good:**
+
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 defer cancel()
 ```
 
 **Bad:**
+
 ```go
 ctx := context.Background()  // no timeout, no cancellation
 ```
@@ -188,6 +198,7 @@ ctx := context.Background()  // no timeout, no cancellation
 ### Error Groups
 
 **Good:**
+
 ```go
 g, ctx := errgroup.WithContext(ctx)
 g.Go(func() error { return task1(ctx) })
@@ -210,6 +221,7 @@ if err := g.Wait(); err != nil {
 ### Slice/Map Boundaries
 
 **Good - copy at boundaries:**
+
 ```go
 func processItems(items []Item) {
     localItems := make([]Item, len(items))
@@ -221,6 +233,7 @@ func processItems(items []Item) {
 ### Resource Cleanup
 
 **Always use defer:**
+
 ```go
 file, err := os.Open(filename)
 if err != nil {
@@ -232,6 +245,7 @@ defer file.Close()
 ### Zero Values
 
 Zero values should be meaningful:
+
 ```go
 var mu sync.Mutex      // Ready to use
 var buf bytes.Buffer   // Ready to use
@@ -241,6 +255,7 @@ var count int          // Zero is valid
 ### Preallocation
 
 **Good:**
+
 ```go
 items := make([]Item, 0, expectedSize)
 cache := make(map[string]Value, expectedSize)
@@ -277,6 +292,7 @@ var _ http.Handler = (*MyHandler)(nil)
 ### Early Returns
 
 **Good:**
+
 ```go
 if err != nil {
     return err
@@ -285,6 +301,7 @@ if err != nil {
 ```
 
 **Bad - deep nesting:**
+
 ```go
 if err == nil {
     if result != nil {
@@ -303,6 +320,7 @@ if err == nil {
 ### Type Switches
 
 **Good:**
+
 ```go
 switch v := x.(type) {
 case int:
@@ -458,11 +476,13 @@ func ProcessInput(input string) error {
 ### SQL Queries
 
 **Good:**
+
 ```go
 db.Query("SELECT * FROM users WHERE id = $1", userID)
 ```
 
 **Bad:**
+
 ```go
 db.Query("SELECT * FROM users WHERE id = " + userID)  // SQL injection!
 ```
@@ -530,6 +550,7 @@ func TestGetUser(t *testing.T) {
 ### CRITICAL
 
 Issues that affect correctness, security, or cause crashes:
+
 - Ignored errors
 - Goroutine leaks
 - Race conditions
@@ -539,6 +560,7 @@ Issues that affect correctness, security, or cause crashes:
 ### HIGH
 
 Significant issues affecting reliability or maintainability:
+
 - Poor error handling
 - Missing context propagation
 - Resource leaks
@@ -548,6 +570,7 @@ Significant issues affecting reliability or maintainability:
 ### MEDIUM
 
 Best practice violations:
+
 - Missing documentation
 - Inconsistent naming
 - Non-idiomatic patterns
@@ -557,6 +580,7 @@ Best practice violations:
 ### LOW
 
 Minor improvements:
+
 - Naming convention tweaks
 - Code organization
 - Additional documentation
@@ -565,6 +589,7 @@ Minor improvements:
 ### INFO
 
 Suggestions for optimization:
+
 - Advanced patterns
 - Performance tuning
 - Tooling recommendations

--- a/agents/go-review/references/go-review-criteria.md
+++ b/agents/go-review/references/go-review-criteria.md
@@ -46,13 +46,13 @@ Don't communicate by sharing memory; use channels to coordinate goroutines.
 
 ### Mandatory Checks
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| Code formatted with gofmt | HIGH | Non-negotiable Go standard |
-| Imports organized with goimports | MEDIUM | Standard library → third-party → local |
-| MixedCaps naming (never underscores) | MEDIUM | Go naming convention |
-| Short, meaningful names | LOW | Readability |
-| Package names lowercase, concise | MEDIUM | Avoid util, common, helpers |
+| Check                                | Severity | Rationale                              |
+| ------------------------------------ | -------- | -------------------------------------- |
+| Code formatted with gofmt            | HIGH     | Non-negotiable Go standard             |
+| Imports organized with goimports     | MEDIUM   | Standard library → third-party → local |
+| MixedCaps naming (never underscores) | MEDIUM   | Go naming convention                   |
+| Short, meaningful names              | LOW      | Readability                            |
+| Package names lowercase, concise     | MEDIUM   | Avoid util, common, helpers            |
 
 ### Import Organization
 
@@ -106,11 +106,11 @@ HTTPclient               // inconsistent capitalization
 
 ### Critical Rules
 
-| Rule | Severity | Example |
-|------|----------|---------|
-| Never ignore errors with `_` | CRITICAL | `_ = file.Close()` |
-| Handle errors once at source | HIGH | Don't log and return |
-| Return errors as last value | MEDIUM | `func X() (T, error)` |
+| Rule                         | Severity | Example               |
+| ---------------------------- | -------- | --------------------- |
+| Never ignore errors with `_` | CRITICAL | `_ = file.Close()`    |
+| Handle errors once at source | HIGH     | Don't log and return  |
+| Return errors as last value  | MEDIUM   | `func X() (T, error)` |
 
 ### Error Wrapping (Go 1.13+)
 
@@ -153,12 +153,12 @@ val := x.(Type)  // panics if wrong type
 
 ### Critical Checks
 
-| Check | Severity | Impact |
-|-------|----------|--------|
-| Goroutines have clear exit conditions | CRITICAL | Prevents leaks |
-| No goroutines in init() | HIGH | Startup unpredictability |
-| Context.Context for lifecycle | HIGH | Graceful shutdown |
-| No fire-and-forget goroutines | HIGH | Resource leaks |
+| Check                                 | Severity | Impact                   |
+| ------------------------------------- | -------- | ------------------------ |
+| Goroutines have clear exit conditions | CRITICAL | Prevents leaks           |
+| No goroutines in init()               | HIGH     | Startup unpredictability |
+| Context.Context for lifecycle         | HIGH     | Graceful shutdown        |
+| No fire-and-forget goroutines         | HIGH     | Resource leaks           |
 
 ### Worker Pool Pattern
 
@@ -267,11 +267,11 @@ cache := make(map[string]Value, expectedSize)
 
 ### Critical Checks
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| No pointers to interfaces | HIGH | Almost never needed |
-| Interfaces in consumer packages | MEDIUM | Loose coupling |
-| Consistent receiver types | MEDIUM | Method set clarity |
+| Check                           | Severity | Rationale           |
+| ------------------------------- | -------- | ------------------- |
+| No pointers to interfaces       | HIGH     | Almost never needed |
+| Interfaces in consumer packages | MEDIUM   | Loose coupling      |
+| Consistent receiver types       | MEDIUM   | Method set clarity  |
 
 ### Compile-Time Interface Verification
 
@@ -382,12 +382,12 @@ func NewServer(opts ...Option) *Server {
 
 ### String Operations
 
-| Pattern | Performance | Use Case |
-|---------|-------------|----------|
-| `strconv.Itoa()` | Fast | int to string |
-| `fmt.Sprintf()` | Slower | Complex formatting |
-| `strings.Builder` | Fast | Multiple concatenations |
-| `+` operator | Slow | Avoid in loops |
+| Pattern           | Performance | Use Case                |
+| ----------------- | ----------- | ----------------------- |
+| `strconv.Itoa()`  | Fast        | int to string           |
+| `fmt.Sprintf()`   | Slower      | Complex formatting      |
+| `strings.Builder` | Fast        | Multiple concatenations |
+| `+` operator      | Slow        | Avoid in loops          |
 
 ### Time Handling
 
@@ -401,11 +401,11 @@ func NewServer(opts ...Option) *Server {
 
 ### Checks
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| Small, focused packages | MEDIUM | Single responsibility |
-| Avoid generic names | MEDIUM | util, common, helpers |
-| Limited global variables | HIGH | Testing difficulty |
+| Check                    | Severity | Rationale             |
+| ------------------------ | -------- | --------------------- |
+| Small, focused packages  | MEDIUM   | Single responsibility |
+| Avoid generic names      | MEDIUM   | util, common, helpers |
+| Limited global variables | HIGH     | Testing difficulty    |
 
 ### Good Package Names
 
@@ -439,12 +439,12 @@ func (s *UserService) GetByID(ctx context.Context, id string) (*User, error)
 
 ### Comment Quality
 
-| Rule | Severity |
-|------|----------|
-| Complete sentences starting with declared name | MEDIUM |
-| Focus on what/why for users | LOW |
-| Document concurrency safety | MEDIUM |
-| No blank line between comment and declaration | LOW |
+| Rule                                           | Severity |
+| ---------------------------------------------- | -------- |
+| Complete sentences starting with declared name | MEDIUM   |
+| Focus on what/why for users                    | LOW      |
+| Document concurrency safety                    | MEDIUM   |
+| No blank line between comment and declaration  | LOW      |
 
 ---
 
@@ -452,13 +452,13 @@ func (s *UserService) GetByID(ctx context.Context, id string) (*User, error)
 
 ### Critical Checks
 
-| Check | Severity | Impact |
-|-------|----------|--------|
-| Input validation | CRITICAL | Injection attacks |
-| SQL parameterization | CRITICAL | SQL injection |
-| Secret management | CRITICAL | Credential exposure |
-| TLS configuration | HIGH | Data in transit |
-| Crypto usage | HIGH | Weak algorithms |
+| Check                | Severity | Impact              |
+| -------------------- | -------- | ------------------- |
+| Input validation     | CRITICAL | Injection attacks   |
+| SQL parameterization | CRITICAL | SQL injection       |
+| Secret management    | CRITICAL | Credential exposure |
+| TLS configuration    | HIGH     | Data in transit     |
+| Crypto usage         | HIGH     | Weak algorithms     |
 
 ### Input Validation
 
@@ -493,19 +493,19 @@ db.Query("SELECT * FROM users WHERE id = " + userID)  // SQL injection!
 
 ### Coverage Expectations
 
-| Type | Target | Priority |
-|------|--------|----------|
-| Unit tests | 70%+ | HIGH |
-| Integration tests | Critical paths | MEDIUM |
-| Benchmark tests | Hot paths | LOW |
+| Type              | Target         | Priority |
+| ----------------- | -------------- | -------- |
+| Unit tests        | 70%+           | HIGH     |
+| Integration tests | Critical paths | MEDIUM   |
+| Benchmark tests   | Hot paths      | LOW      |
 
-### Testing Tools (2025)
+### Testing Tools (2026)
 
-| Tool | Adoption | Use Case |
-|------|----------|----------|
-| `testing` (stdlib) | Most common | Built-in testing package |
-| [testify](https://github.com/stretchr/testify) | 27% | Assertions and mocking |
-| [gomock](https://github.com/uber-go/mock) | 21% | Enterprise mock generation |
+| Tool                                           | Adoption    | Use Case                   |
+| ---------------------------------------------- | ----------- | -------------------------- |
+| `testing` (stdlib)                             | Most common | Built-in testing package   |
+| [testify](https://github.com/stretchr/testify) | 27%         | Assertions and mocking     |
+| [gomock](https://github.com/uber-go/mock)      | 21%         | Enterprise mock generation |
 
 ### Test Quality
 
@@ -632,4 +632,4 @@ Suggestions for optimization:
 
 ---
 
-*Last updated: 2026-01-10*
+_Last updated: 2026-01-10_

--- a/agents/go-review/system-readonly.md
+++ b/agents/go-review/system-readonly.md
@@ -1,0 +1,105 @@
+# IDENTITY and PURPOSE
+
+You are an expert Go code reviewer with deep knowledge of idiomatic Go patterns, best practices, and modern ecosystem standards (2026). Your role is to analyze Go code and report findings. You MUST NOT edit or modify any files.
+
+# KNOWLEDGE BASE
+
+You have access to a comprehensive review criteria document in the same directory as this pattern (`go-review-criteria.md`). This document contains:
+
+- Review philosophy and core principles
+- Code formatting and style requirements
+- Error handling patterns and anti-patterns
+- Concurrency patterns and safety checks
+- Data management (slices, maps, resources)
+- Interface and type design guidelines
+- Code structure patterns (early returns, variable scope)
+- API design patterns (repository, middleware, functional options)
+- Performance considerations
+- Package organization standards
+- Documentation requirements
+- Security considerations
+- Testing expectations
+- Severity classification (Critical, High, Medium, Low, Info)
+
+**CRITICAL**: Apply ALL criteria from the go-review-criteria.md document when conducting your review. Do not limit yourself to the brief summaries below - use the full depth of knowledge in that reference document.
+
+# WORKFLOW
+
+You MUST follow this sequence. Do not skip steps.
+
+1. **Read** the target file(s) using the Read tool.
+2. **Analyze** the code against the review categories below. Identify issues by severity.
+3. **Report** a structured list of all findings.
+
+Do NOT use the Edit or Write tools. Do NOT attempt to fix issues. Only read and report.
+
+# REVIEW CATEGORIES
+
+Reference the go-review-criteria.md document for detailed criteria. Brief category overview:
+
+1. **Code Formatting & Style** - gofmt, imports, naming conventions
+2. **Error Handling** - wrapping, handling once, type assertions
+3. **Concurrency Patterns** - context, goroutine lifecycle, channels
+4. **Data Management** - slice boundaries, resource cleanup, zero values
+5. **Interface & Type Design** - consumer interfaces, receivers
+6. **Code Structure** - early returns, variable scope, type switches
+7. **API Design** - repository, middleware, functional options
+8. **Performance** - string operations, time handling, allocations
+9. **Package Organization** - naming, scope, globals
+10. **Documentation** - exported names, comment quality
+11. **Security** - input validation, SQL, secrets, crypto
+12. **Testing** - coverage, quality, table-driven tests
+
+# SEVERITY LEVELS
+
+- **CRITICAL**: Affects correctness, security, or causes crashes
+- **HIGH**: Significant reliability or maintainability issues
+- **MEDIUM**: Best practice violations
+- **LOW**: Minor improvements
+- **INFO**: Suggestions for optimization
+
+# OUTPUT FORMAT
+
+Output this report:
+
+## Summary
+
+[2-3 sentence overview of what you found]
+
+## Findings
+
+### [Finding Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number or range]
+
+**Description:** [What is wrong and why it matters]
+**Suggested Fix:** [Brief description of how to fix it, but do NOT apply it]
+
+---
+
+[Repeat for each finding]
+
+## Statistics
+
+- Total findings: [N]
+- CRITICAL: [N]
+- HIGH: [N]
+- MEDIUM: [N]
+- LOW: [N]
+- INFO: [N]
+
+# TONE AND APPROACH
+
+- Be precise about what you found and where
+- Reference go-review-criteria.md for detailed guidance
+- Focus on idiomatic Go patterns, not personal preferences
+- Prioritize correctness and safety over style
+- Report real issues — do not invent problems in code you haven't read
+- Include line numbers for every finding
+
+# INPUT
+
+Go code to review (read-only):

--- a/agents/go-review/system.md
+++ b/agents/go-review/system.md
@@ -84,12 +84,14 @@ Structure your review with clear sections:
 **Impact:** [Why it matters]
 
 **Problem:**
+
 ```go
 // Current code
 [problematic code snippet]
 ```
 
 **Solution:**
+
 ```go
 // Suggested fix
 [improved code snippet]
@@ -107,11 +109,13 @@ Structure your review with clear sections:
 **Category:** [category]
 
 **Current:**
+
 ```go
 [current approach]
 ```
 
 **Suggested:**
+
 ```go
 [better approach]
 ```

--- a/agents/go-review/system.md
+++ b/agents/go-review/system.md
@@ -1,6 +1,6 @@
 # IDENTITY and PURPOSE
 
-You are an expert Go code reviewer with deep knowledge of idiomatic Go patterns, best practices, and modern ecosystem standards (2025). Your role is to analyze Go code and provide constructive feedback focused on improving code quality, maintainability, and adherence to Go community conventions.
+You are an expert Go code reviewer and fixer with deep knowledge of idiomatic Go patterns, best practices, and modern ecosystem standards (2026). Your role is to analyze Go code, identify issues, fix them using tools, and verify the fixes compile.
 
 # KNOWLEDGE BASE
 
@@ -23,16 +23,17 @@ You have access to a comprehensive review criteria document in the same director
 
 **CRITICAL**: Apply ALL criteria from the go-review-criteria.md document when conducting your review. Do not limit yourself to the brief summaries below - use the full depth of knowledge in that reference document.
 
-# STEPS
+# WORKFLOW
 
-1. Analyze the provided Go code for adherence to idiomatic patterns
-2. Identify areas that deviate from Go best practices
-3. Check for common anti-patterns and code smells
-4. Evaluate error handling, concurrency patterns, and resource management
-5. Review documentation quality and completeness
-6. Assess security considerations
-7. Provide specific, actionable feedback with examples
-8. Prioritize simplicity and clarity over cleverness
+You MUST follow this sequence. Do not skip steps.
+
+1. **Read** the target file(s) using the Read tool.
+2. **Analyze** the code against the review categories below. Identify issues by severity.
+3. **Fix** each CRITICAL and HIGH issue using the Edit tool. Fix MEDIUM issues when the fix is straightforward.
+4. **Verify** by running `go build ./...` using the Bash tool after all edits. If the build fails, read the error, fix it, and rebuild.
+5. **Report** a summary of what you found and what you changed.
+
+Do NOT just describe fixes in markdown — apply them with the Edit tool. If you choose not to fix an issue, state why.
 
 # REVIEW CATEGORIES
 
@@ -59,94 +60,48 @@ Reference the go-review-criteria.md document for detailed criteria. Brief catego
 - **LOW**: Minor improvements
 - **INFO**: Suggestions for optimization
 
-# OUTPUT INSTRUCTIONS
-
-Structure your review with clear sections:
-
-1. **Summary** - High-level assessment (2-3 sentences)
-2. **Critical Issues** - Must-fix items affecting correctness or safety
-3. **Improvements** - Non-critical enhancements for better idiomatic code
-4. **Positive Observations** - What the code does well (1-2 items)
-5. **Recommendations** - General suggestions for codebase improvement
-
 # OUTPUT FORMAT
+
+After making all edits and verifying the build, output this report:
 
 ## Summary
 
-[2-3 sentence overview of code quality and main concerns]
+[2-3 sentence overview of what you found and fixed]
 
-## Critical Issues
+## Changes Made
 
 ### [Issue Title]
 
-**Severity:** CRITICAL/HIGH
+**Severity:** CRITICAL/HIGH/MEDIUM
 **Category:** [category from review categories]
-**Impact:** [Why it matters]
+**File:** [file path]
 
-**Problem:**
-
-```go
-// Current code
-[problematic code snippet]
-```
-
-**Solution:**
-
-```go
-// Suggested fix
-[improved code snippet]
-```
-
-**Explanation:** [Why this change is needed - reference criteria]
+**What was wrong:** [1-2 sentences]
+**What you changed:** [1-2 sentences]
 
 ---
 
-## Improvements
+## Issues Not Fixed
 
-### [Improvement Title]
+[List any issues you found but chose not to fix, with reasoning. Omit this section if you fixed everything.]
 
-**Severity:** MEDIUM/LOW
-**Category:** [category]
+## Files Touched
 
-**Current:**
+- [list each file modified]
 
-```go
-[current approach]
-```
+## Validation
 
-**Suggested:**
-
-```go
-[better approach]
-```
-
-**Why:** [Explanation referencing go-review-criteria.md]
-
----
-
-## Positive Observations
-
-- [Good practice observed with specific example]
-- [Another good practice]
-
----
-
-## Recommendations
-
-- [General suggestion 1]
-- [General suggestion 2]
+- `go build ./...`: [PASS/FAIL]
+- [any other validations run]
 
 # TONE AND APPROACH
 
-- Be constructive and educational, not critical
-- Explain the "why" behind suggestions
-- Provide concrete examples with code
-- Acknowledge good practices
-- Prioritize actionable feedback
-- Focus on idiomatic Go patterns, not personal preferences
-- Reference official Go documentation when relevant
+- Be precise about what you changed and why
 - Reference go-review-criteria.md for detailed guidance
+- Focus on idiomatic Go patterns, not personal preferences
+- Prioritize correctness and safety over style
+- Only fix real issues — do not refactor working code for aesthetic reasons
 
 # INPUT
 
-Go code to review:
+Go code to review and fix:

--- a/agents/go-security-audit/README.md
+++ b/agents/go-security-audit/README.md
@@ -157,17 +157,20 @@ rows, err := db.Query(query)
 ```
 
 **Security Impact:**
+
 - Attackers can bypass authentication
 - Unauthorized data access or modification
 - Potential database compromise
 
 **Secure Implementation:**
+
 ```go
 query := "SELECT * FROM users WHERE username=$1"
 rows, err := db.Query(query, username)
 ```
 
 **Remediation Steps:**
+
 1. Replace string formatting with parameterized queries
 2. Use database/sql package's parameterized query methods
 3. Validate and sanitize all user input
@@ -176,9 +179,11 @@ rows, err := db.Query(query, username)
 **Detection Tool:** `gosec -include=G201,G202 ./...`
 
 **References:**
+
 - [Official: Avoiding SQL injection risk](https://go.dev/doc/database/sql-injection)
 - golang-security-guide.md: SQL Injection section
 ...
+
 ```
 
 ## When to Use
@@ -215,6 +220,7 @@ cat main.go vulns.txt | fabric -p go-security-audit
 ```
 
 ### gosec (Static Security Analysis)
+
 ```bash
 # Combine gosec findings with code audit
 gosec -fmt=text ./... > gosec.txt
@@ -222,6 +228,7 @@ cat $(find . -name "*.go") gosec.txt | fabric -p go-security-audit
 ```
 
 ### go vet (Built-in Analysis)
+
 ```bash
 # Include go vet output
 go vet ./... 2>&1 | tee vet.txt
@@ -231,6 +238,7 @@ cat main.go vet.txt | fabric -p go-security-audit
 ## Best Practices
 
 1. **Run Regularly**: Integrate into your development workflow
+
    ```bash
    # Git pre-commit hook
    git diff HEAD --name-only --diff-filter=ACM | grep '\.go$' | xargs cat | fabric -p go-security-audit
@@ -247,6 +255,7 @@ cat main.go vet.txt | fabric -p go-security-audit
 6. **Customize Checks**: Modify system.md to add organization-specific security requirements
 
 7. **Track Remediation**: Save reports to track progress over time
+
    ```bash
    cat main.go | fabric -p go-security-audit > audits/$(date +%Y-%m-%d)-audit.md
    ```
@@ -309,6 +318,7 @@ jobs:
 ## Troubleshooting
 
 ### Pattern Not Found
+
 ```bash
 # Verify pattern installation
 ls ~/.config/fabric/patterns/go-security-audit
@@ -318,6 +328,7 @@ fabric --update
 ```
 
 ### Large Codebase Timeout
+
 ```bash
 # Audit packages individually
 for pkg in $(go list ./...); do
@@ -327,7 +338,9 @@ done
 ```
 
 ### False Positives
+
 The pattern is designed to be thorough. Review each finding in context - some may not apply to your specific use case. Consider:
+
 - Input validation already performed elsewhere
 - Code running in trusted contexts only
 - False positives from security tools included in input
@@ -378,6 +391,7 @@ This pattern is part of the Fabric Patterns Hub and follows the same license ter
 ## Support
 
 For issues, questions, or contributions:
+
 - Open an issue in the fabric-patterns-hub repository
 - Refer to the comprehensive `golang-security-guide.md` for detailed security information
 - Check official Go security resources for the latest updates

--- a/agents/go-security-audit/agent.yaml
+++ b/agents/go-security-audit/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-security-audit
 version: 0.1.0
 description: Audit Go code for security issues and apply fixes.

--- a/agents/go-security-audit/references/golang-security-guide.md
+++ b/agents/go-security-audit/references/golang-security-guide.md
@@ -323,7 +323,7 @@ template.CSS       // Unescaped CSS
 **Resources:**
 
 - [Understanding XSS Protection in Go's html/template](https://leapcell.io/blog/understanding-xss-protection-in-go-s-html-template)
-- [Preventing Cross-Site Scripting (XSS) Attacks in Go](https://medium.com/@mgm06bm/preventing-cross-site-scripting-xss-attacks-in-go-a-step-by-step-guide-6b8e3cf01d9f)
+- [Understanding XSS Protection in Go's html/template](https://leapcell.io/blog/understanding-xss-protection-in-go-s-html-template)
 
 ### 3. Path Traversal
 
@@ -443,7 +443,7 @@ if len(slice) >= 4 {
 
 **Resources:**
 
-- [Go: Memory Safety with Bounds Check](https://medium.com/a-journey-with-go/go-memory-safety-with-bounds-check-1397bef748b5)
+- [BCE (Bound Check Elimination) in Go](https://go101.org/optimizations/5-bce.html)
 - [Bounds Check Elimination In Go](https://www.ardanlabs.com/blog/2018/04/bounds-check-elimination-in-go.html)
 - [CISA: Eliminating Buffer Overflow Vulnerabilities](https://www.cisa.gov/resources-tools/resources/secure-design-alert-eliminating-buffer-overflow-vulnerabilities)
 
@@ -974,7 +974,7 @@ grpcServer := grpc.NewServer(
 
 - [Enhancing gRPC Security Best Practices](https://www.bytesizego.com/blog/grpc-security)
 - [Protecting gRPC Against OWASP's Top Ten API Risks](https://nordicapis.com/protecting-grpc-against-owasps-top-ten-api-risks/)
-- [gRPC Security Series: Part 3](https://medium.com/@ibm_ptc_security/grpc-security-series-part-3-c92f3b687dd9)
+- [Securing gRPC Services with JWT Authentication in Go](https://www.bytesizego.com/blog/securing-grpc-golang)
 
 ---
 
@@ -1394,7 +1394,7 @@ jobs:
 
 - [How Go Mitigates Supply Chain Attacks](https://go.dev/blog/supply-chain)
 - [GitLab catches MongoDB Go module supply chain attack](https://about.gitlab.com/blog/gitlab-catches-mongodb-go-module-supply-chain-attack/)
-- [Go Supply Chain Attack: Malicious Package Exploits Go Module](https://socket.dev/blog/malicious-package-exploits-go-module-proxy-caching-for-persistence)
+- [Supply Chain Attacks in the Golang Open-Source Ecosystem](https://www.crocoder.dev/blog/supply-chain-attacks-in-the-golang-open-source-ecosystem)
 
 ---
 
@@ -1503,7 +1503,7 @@ jobs:
 
 - [OWASP Go Secure Coding Practices Guide](https://owasp.org/www-project-go-secure-coding-practices-guide/)
 - [OWASP Go-SCP GitHub](https://github.com/OWASP/Go-SCP)
-- [OWASP Top Ten Guide for Go Developers](https://medium.com/@erwindev/the-owasp-top-ten-guide-for-go-developers-e80786dc4400)
+- [How to Secure Go APIs Against OWASP Top 10](https://oneuptime.com/blog/post/2026-01-07-go-secure-apis-owasp-top-10/view)
 - [OWASP gRPC Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/gRPC_Security_Cheat_Sheet.html)
 
 ### Security Tools

--- a/agents/go-security-audit/references/golang-security-guide.md
+++ b/agents/go-security-audit/references/golang-security-guide.md
@@ -16,7 +16,7 @@
 
 ## Introduction
 
-Go is designed with security in mind, featuring built-in memory safety, garbage collection, and strong typing. However, vulnerabilities can still occur through improper use of language features, dependencies, or external integrations. In 2025, there have been 9 vulnerabilities in Go with an average score of 6.5 out of ten.
+Go is designed with security in mind, featuring built-in memory safety, garbage collection, and strong typing. However, vulnerabilities can still occur through improper use of language features, dependencies, or external integrations. In 2026, there have been 9 vulnerabilities in Go with an average score of 6.5 out of ten.
 
 ### Key Security Principles
 
@@ -885,7 +885,6 @@ grpcServer := grpc.NewServer(
 **Resources:**
 
 - [Protovalidate for gRPC and Go](https://protovalidate.com/quickstart/grpc-go/)
-- [Know your inputs or gRPC request validation](https://medium.com/swlh/know-your-inputs-or-grpc-request-validation-8eb29a0ebc31)
 - [Learning Protocol Buffers: Validations](https://mariocarrion.com/2023/11/13/learning-grpc-protobuf-validation.html)
 
 ### 4. Rate Limiting
@@ -1382,7 +1381,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: "1.21"
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -1519,7 +1518,6 @@ jobs:
 
 - [Awesome Golang Security](https://github.com/guardrailsio/awesome-golang-security)
 - [Go Security Cheatsheet - Snyk](https://snyk.io/blog/go-security-cheatsheet-for-go-developers/)
-- [Secure Coding in Go: OWASP Top 10](https://www.hitechtrends.com/2025/05/25/secure-coding-in-go-owasp-top-10-exploits-and-fixes/)
 
 ---
 

--- a/agents/go-security-audit/references/golang-security-guide.md
+++ b/agents/go-security-audit/references/golang-security-guide.md
@@ -972,7 +972,6 @@ grpcServer := grpc.NewServer(
 
 **Resources:**
 
-- [Enhancing gRPC Security Best Practices](https://www.bytesizego.com/blog/grpc-security)
 - [Protecting gRPC Against OWASP's Top Ten API Risks](https://nordicapis.com/protecting-grpc-against-owasps-top-ten-api-risks/)
 - [Securing gRPC Services with JWT Authentication in Go](https://www.bytesizego.com/blog/securing-grpc-golang)
 

--- a/agents/go-security-audit/references/golang-security-guide.md
+++ b/agents/go-security-audit/references/golang-security-guide.md
@@ -1,6 +1,7 @@
 # Go Security: Comprehensive Guide to Identifying and Patching Vulnerabilities
 
 ## Table of Contents
+
 1. [Introduction](#introduction)
 2. [Security Tools and Analysis](#security-tools-and-analysis)
 3. [Common Vulnerabilities](#common-vulnerabilities)
@@ -18,6 +19,7 @@
 Go is designed with security in mind, featuring built-in memory safety, garbage collection, and strong typing. However, vulnerabilities can still occur through improper use of language features, dependencies, or external integrations. In 2025, there have been 9 vulnerabilities in Go with an average score of 6.5 out of ten.
 
 ### Key Security Principles
+
 - Keep Go updated (security fixes issued to the two most recent major releases)
 - Use official security tools (govulncheck, gosec, go vet)
 - Validate and sanitize all user input
@@ -34,11 +36,13 @@ Go is designed with security in mind, featuring built-in memory safety, garbage 
 **govulncheck** is backed by the Go vulnerability database and analyzes your codebase to surface only vulnerabilities that actually affect you, based on which functions in your code are transitively calling vulnerable functions.
 
 **Installation:**
+
 ```bash
 go install golang.org/x/vuln/cmd/govulncheck@latest
 ```
 
 **Usage:**
+
 ```bash
 # Scan your code
 govulncheck ./...
@@ -48,11 +52,13 @@ govulncheck ./pkg/...
 ```
 
 **CI/CD Integration:**
+
 - GitHub Action available on GitHub Marketplace
 - Can be integrated into any CI/CD pipeline
 - VS Code Go extension checks dependencies and surfaces vulnerabilities
 
 **Resources:**
+
 - [Go Vulnerability Management](https://go.dev/doc/security/vuln/)
 - [Govulncheck Tutorial](https://go.dev/doc/tutorial/govulncheck)
 - [Vulnerability Scanning in Go With Govulncheck](https://semaphore.io/blog/govulncheck)
@@ -62,11 +68,13 @@ govulncheck ./pkg/...
 **gosec** scans Go code for security problems by inspecting the AST (Abstract Syntax Tree) and matching against security rules.
 
 **Installation:**
+
 ```bash
 go install github.com/securego/gosec/v2/cmd/gosec@latest
 ```
 
 **Usage:**
+
 ```bash
 # Scan entire project
 gosec ./...
@@ -79,12 +87,14 @@ gosec -include=G401,G501 ./...
 ```
 
 **Key Features:**
+
 - Maps issues to CWE (Common Weakness Enumeration)
 - Multiple output formats (text, JSON, SARIF)
 - Configurable rules and severity filtering
 - Supports exclusion of directories/packages
 
 **Common Security Checks:**
+
 - Hard-coded credentials (G101, G102)
 - SQL injection vulnerabilities (G201, G202)
 - Weak cryptographic algorithms (G401, G501, G502)
@@ -93,10 +103,12 @@ gosec -include=G401,G501 ./...
 - Use of unsafe package (G103)
 
 **Limitations:**
+
 - Only static analysis (cannot detect runtime vulnerabilities)
 - Should be complemented with dynamic analysis and manual reviews
 
 **Resources:**
+
 - [gosec GitHub Repository](https://github.com/securego/gosec)
 - [Secure Your Go Code: A Deep Dive into Gosec](https://www.security.land/secure-your-go-code-a-deep-dive-into-gosec-for-static-analysis/)
 - [Find security issues in Go code using gosec](https://opensource.com/article/20/9/gosec)
@@ -106,6 +118,7 @@ gosec -include=G401,G501 ./...
 **go vet** examines Go source code and reports suspicious constructs that might lead to runtime problems.
 
 **Usage:**
+
 ```bash
 # Check current package
 go vet
@@ -118,6 +131,7 @@ go vet -race ./...
 ```
 
 **What it catches:**
+
 - Unreachable code
 - Unused variables
 - Common mistakes with goroutines
@@ -127,17 +141,20 @@ go vet -race ./...
 ### 4. Additional Security Tools
 
 **staticcheck:**
+
 ```bash
 go install honnef.co/go/tools/cmd/staticcheck@latest
 staticcheck ./...
 ```
 
 **golangci-lint** (aggregates multiple linters):
+
 ```bash
 golangci-lint run
 ```
 
 **osv-scanner** (Google's vulnerability scanner):
+
 ```bash
 go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 osv-scanner --lockfile=go.mod
@@ -155,6 +172,7 @@ osv-scanner --lockfile=go.mod
 Occurs when untrusted data is sent to an interpreter as part of a command or query.
 
 **Vulnerable Code:**
+
 ```go
 // NEVER DO THIS
 query := fmt.Sprintf("SELECT * FROM users WHERE username='%s'", username)
@@ -162,6 +180,7 @@ rows, err := db.Query(query)
 ```
 
 **Secure Code:**
+
 ```go
 // Use parameterized queries
 query := "SELECT * FROM users WHERE username=$1"
@@ -177,15 +196,16 @@ rows, err := stmt.Query(username)
 ```
 
 **Key Points:**
+
 - SQL parameter values as function arguments prevent injection
 - Use `database/sql` package's parameterized query methods
 - Placeholder format varies by driver (?, $1, etc.)
 - Parameterized queries guarantee proper escaping
 
 **Resources:**
+
 - [Official: Avoiding SQL injection risk](https://go.dev/doc/database/sql-injection)
 - [Golang SQL Injection Guide](https://www.stackhawk.com/blog/golang-sql-injection-guide-examples-and-prevention/)
-- [SQL injection in Go](https://docs.fluidattacks.com/criteria/fixes/go/146/)
 
 #### Command Injection
 
@@ -193,6 +213,7 @@ rows, err := stmt.Query(username)
 Untrusted input passed directly to system shell allows arbitrary command execution.
 
 **Vulnerable Code:**
+
 ```go
 // NEVER DO THIS
 cmd := exec.Command("/bin/sh", "-c", "ls "+userInput)
@@ -202,6 +223,7 @@ cmd := exec.Command("bash", "-c", "myCommand "+userInput)
 ```
 
 **Secure Code:**
+
 ```go
 // Use parameterization - separate arguments
 cmd := exec.Command("/path/to/myCommand", "myArg1", inputValue)
@@ -221,12 +243,14 @@ cmd := exec.Command("/bin/ls", "-la", filepath.Clean(userPath))
 ```
 
 **Prevention Strategies:**
+
 1. Use parameterization instead of string concatenation
 2. Avoid shell invocation when possible (Go lacks proper shell-escaping)
 3. Use allowlists for permitted commands
 4. Validate and sanitize all user inputs
 
 **Resources:**
+
 - [Command Injection in Go](https://semgrep.dev/docs/cheat-sheets/go-command-injection)
 - [Golang Command Injection: Examples and Prevention](https://www.stackhawk.com/blog/golang-command-injection-examples-and-prevention/)
 - [Understanding command injection vulnerabilities in Go](https://snyk.io/blog/understanding-go-command-injection-vulnerabilities/)
@@ -237,6 +261,7 @@ cmd := exec.Command("/bin/ls", "-la", filepath.Clean(userPath))
 User-generated content executed as JavaScript or HTML in browsers.
 
 **Vulnerable Code:**
+
 ```go
 // NEVER DO THIS - using text/template
 import "text/template"
@@ -251,6 +276,7 @@ io.WriteString(w, "<div>"+userContent+"</div>")
 ```
 
 **Secure Code:**
+
 ```go
 // Use html/template for automatic escaping
 import "html/template"
@@ -262,6 +288,7 @@ tmpl.Execute(w, data) // Automatically escaped!
 ```
 
 **Contextual Auto-Escaping:**
+
 ```go
 // html/template understands context
 template := `
@@ -276,6 +303,7 @@ template := `
 ```
 
 **Dangerous Types to AVOID:**
+
 ```go
 // These bypass escaping - BAN THEM
 template.HTML      // Unescaped HTML
@@ -286,13 +314,14 @@ template.CSS       // Unescaped CSS
 ```
 
 **Best Practices:**
+
 1. **Always use `html/template`, NEVER `text/template`** for HTML output
 2. Ban dangerous bypass types in code reviews
 3. Set appropriate Content-Type headers
 4. Never write user content directly to response without template engine
 
 **Resources:**
-- [Cross-site scripting: Explanation and prevention with Go](https://developers.redhat.com/articles/2022/06/28/cross-site-scripting-explanation-and-prevention-go)
+
 - [Understanding XSS Protection in Go's html/template](https://leapcell.io/blog/understanding-xss-protection-in-go-s-html-template)
 - [Preventing Cross-Site Scripting (XSS) Attacks in Go](https://medium.com/@mgm06bm/preventing-cross-site-scripting-xss-attacks-in-go-a-step-by-step-guide-6b8e3cf01d9f)
 
@@ -302,6 +331,7 @@ template.CSS       // Unescaped CSS
 Attackers control file system access through manipulated file paths.
 
 **Vulnerable Code:**
+
 ```go
 // NEVER DO THIS
 filepath := "/var/www/files/" + userInput
@@ -310,6 +340,7 @@ content, err := ioutil.ReadFile(filepath)
 ```
 
 **Secure Code (Go 1.20+):**
+
 ```go
 import "path/filepath"
 
@@ -334,6 +365,7 @@ content, err := os.ReadFile(fullPath)
 ```
 
 **Secure Code (Go 1.24+):**
+
 ```go
 // Method 3: Use os.Root (Go 1.24+) - Recommended
 root := os.Root("/var/www/files")
@@ -345,6 +377,7 @@ content, err := root.ReadFile(userInput)
 On Windows, `filepath.Clean` could transform invalid paths like "a/../c:/b" into valid path "c:\b", enabling directory traversal. Fixed in Go 1.19.6 and 1.20.1.
 
 **Best Practices:**
+
 1. Always validate and clean user-supplied file paths
 2. Use `filepath.Join` and `filepath.Clean` together
 3. Verify final path stays within expected directory
@@ -352,6 +385,7 @@ On Windows, `filepath.Clean` could transform invalid paths like "a/../c:/b" into
 5. Never trust user input for file operations
 
 **Resources:**
+
 - [Golang Path Traversal Guide](https://www.stackhawk.com/blog/golang-path-traversal-guide-examples-and-prevention/)
 - [CVE-2022-41722](https://github.com/golang/go/issues/57274)
 - [Traversal-resistant file APIs](https://go.dev/blog/osroot)
@@ -366,16 +400,19 @@ On Windows, `filepath.Clean` could transform invalid paths like "a/../c:/b" into
 Go is generally memory-safe with built-in bounds checking, preventing traditional buffer overflow vulnerabilities common in C/C++. However, vulnerabilities can still occur.
 
 **Go's Protection Mechanisms:**
+
 - Bounds-checked arrays and slices
 - No dangling pointers
 - Garbage collection
 - Automatic memory management
 
 **Known CVEs:**
+
 - **CVE-2022-24675**: Buffer overflow via large arguments in WASM function invocation (Go < 1.16.9, 1.17.2)
 - **CVE-2021-38297**: Decode stack overflow via large PEM data in encoding/pem (Go < 1.17.9, 1.18.1)
 
 **Bounds Checking in Go:**
+
 ```go
 // Go automatically checks bounds
 arr := []int{1, 2, 3, 4, 5}
@@ -405,6 +442,7 @@ if len(slice) >= 4 {
 ```
 
 **Resources:**
+
 - [Go: Memory Safety with Bounds Check](https://medium.com/a-journey-with-go/go-memory-safety-with-bounds-check-1397bef748b5)
 - [Bounds Check Elimination In Go](https://www.ardanlabs.com/blog/2018/04/bounds-check-elimination-in-go.html)
 - [CISA: Eliminating Buffer Overflow Vulnerabilities](https://www.cisa.gov/resources-tools/resources/secure-design-alert-eliminating-buffer-overflow-vulnerabilities)
@@ -415,11 +453,13 @@ if len(slice) >= 4 {
 Go doesn't check for integer overflow, similar to C, C++, and Java. Operations wrap around silently.
 
 **Behavior:**
+
 - Unsigned integers: operations computed modulo 2^n upon overflow
 - Signed integers: computed using two's complement arithmetic, truncated to bit width
 - No exception raised on overflow
 
 **Vulnerable Code:**
+
 ```go
 // Silent overflow
 var x uint8 = 255
@@ -435,12 +475,14 @@ ptr := unsafe.Pointer(offset) // Dangerous!
 ```
 
 **Security Implications:**
+
 1. Programs making system calls may pass corrupted data structures to kernel
 2. Marshaled data sent over network may be silently corrupted
 3. Programs using `unsafe` are vulnerable to same bugs as C
 4. Bounds-checking on slices mitigates some but not all harmful effects
 
 **Secure Code:**
+
 ```go
 // Check before arithmetic operations
 func SafeAdd(a, b uint32) (uint32, error) {
@@ -469,9 +511,8 @@ result := new(big.Int).Add(bigA, bigB) // No overflow
 Integer overflow in crypto/elliptic allows DoS via specially crafted scalar input > 32 bytes to P256().ScalarMult or P256().ScalarBaseMult.
 
 **Resources:**
+
 - [Integer Overflows in Golang](https://blog.rene.sh/blog/2020/06/22/int-overflow/)
-- [Understanding Integer Overflow](https://www.infosecinstitute.com/resources/secure-coding/what-is-is-integer-overflow-and-underflow/)
-- [Go Integer Overflow Vulnerability](https://www.cybersecurity-help.cz/vulnerabilities/64269/)
 
 ### 3. The `unsafe` Package
 
@@ -480,12 +521,14 @@ Integer overflow in crypto/elliptic allows DoS via specially crafted scalar inpu
 The `unsafe` package allows programs to defeat the type system and bypass Go's memory safety guarantees.
 
 **Dangers:**
+
 - Defeats memory safety
 - Can read/write arbitrary memory
 - No compiler enforcement of safety
 - Combined with user data, can enable attackers to break memory safety
 
 **Common Use Cases (and risks):**
+
 ```go
 import "unsafe"
 
@@ -512,6 +555,7 @@ When combining `unsafe` with CGO:
 4. **Manual Memory Management**: C.CString() allocates C memory that must be manually freed
 
 **Safer CGO Alternative:**
+
 ```go
 import "runtime/cgo"
 
@@ -525,6 +569,7 @@ defer h.Delete()
 Data races can break Go's memory safety guarantees even without `unsafe`.
 
 **Best Practices:**
+
 1. Avoid `unsafe` unless absolutely necessary
 2. Thoroughly audit all `unsafe` usage
 3. Never use `unsafe` with user-controlled data
@@ -533,6 +578,7 @@ Data races can break Go's memory safety guarantees even without `unsafe`.
 6. Document and justify every use of `unsafe`
 
 **Resources:**
+
 - [unsafe package documentation](https://pkg.go.dev/unsafe)
 - [Golang data races to break memory safety](https://blog.stalkr.net/2015/04/golang-data-races-to-break-memory-safety.html)
 - [Exploitation Exercise with unsafe.Pointer](https://dev.to/jlauinger/exploitation-exercise-with-unsafe-pointer-in-go-information-leak-part-1-1kga)
@@ -550,6 +596,7 @@ Data races can break Go's memory safety guarantees even without `unsafe`.
 gRPC servers by default allow plaintext communication, exposing data to eavesdropping and tampering.
 
 **Vulnerable Code:**
+
 ```go
 // CLIENT - INSECURE
 conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure())
@@ -561,6 +608,7 @@ grpcServer.Serve(lis)
 ```
 
 **Secure Code:**
+
 ```go
 // CLIENT - TLS
 creds, err := credentials.NewClientTLSFromFile("server.crt", "")
@@ -579,6 +627,7 @@ grpcServer := grpc.NewServer(grpc.Creds(creds))
 ```
 
 **Resources:**
+
 - [How to secure gRPC connection with SSL/TLS in Go](https://dev.to/techschoolguru/how-to-secure-grpc-connection-with-ssl-tls-in-go-4ph)
 - [gRPC API Security Best Practices](https://www.stackhawk.com/blog/best-practices-for-grpc-security/)
 
@@ -588,12 +637,14 @@ grpcServer := grpc.NewServer(grpc.Creds(creds))
 Attackers send and cancel HTTP/2 requests rapidly, causing excessive concurrent method handlers and resource exhaustion.
 
 **Vulnerable Code:**
+
 ```go
 // No limits on concurrent streams
 grpcServer := grpc.NewServer()
 ```
 
 **Secure Code:**
+
 ```go
 // Limit concurrent streams
 grpcServer := grpc.NewServer(
@@ -602,6 +653,7 @@ grpcServer := grpc.NewServer(
 ```
 
 **Resources:**
+
 - [gRPC-Go HTTP/2 Rapid Reset vulnerability](https://github.com/grpc/grpc-go/security/advisories/GHSA-m425-mq94-257g)
 - [CVE-2023-44487](https://www.resolvedsecurity.com/vulnerability-catalog/CVE-2023-44487)
 
@@ -611,6 +663,7 @@ grpcServer := grpc.NewServer(
 Arbitrarily large messages can exhaust server memory.
 
 **Secure Code:**
+
 ```go
 // CLIENT - Set limits
 conn, err := grpc.Dial("localhost:50051",
@@ -741,6 +794,7 @@ conn, err := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(creds))
 ```
 
 **Resources:**
+
 - [gRPC Authentication](https://grpc.io/docs/guides/auth/)
 - [gRPC-Go Authentication Support](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-auth-support.md)
 - [gRPC Client Authentication](https://jbrandhorst.com/post/grpc-auth/)
@@ -750,6 +804,7 @@ conn, err := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(creds))
 **Modern Approach (Recommended):**
 
 **Proto Definition:**
+
 ```protobuf
 syntax = "proto3";
 
@@ -776,6 +831,7 @@ message User {
 ```
 
 **Server Implementation:**
+
 ```go
 import (
     "context"
@@ -808,6 +864,7 @@ grpcServer := grpc.NewServer(
 ```
 
 **Legacy Approach:**
+
 ```go
 // Using grpc_validator from go-grpc-middleware
 import (
@@ -826,6 +883,7 @@ grpcServer := grpc.NewServer(
 ```
 
 **Resources:**
+
 - [Protovalidate for gRPC and Go](https://protovalidate.com/quickstart/grpc-go/)
 - [Know your inputs or gRPC request validation](https://medium.com/swlh/know-your-inputs-or-grpc-request-validation-8eb29a0ebc31)
 - [Learning Protocol Buffers: Validations](https://mariocarrion.com/2023/11/13/learning-grpc-protobuf-validation.html)
@@ -894,6 +952,7 @@ grpcServer := grpc.NewServer(
 ```
 
 **Resources:**
+
 - [OWASP gRPC Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/gRPC_Security_Cheat_Sheet.html)
 - [envoyproxy/ratelimit](https://github.com/envoyproxy/ratelimit)
 - [rate-limiter-grpc-go](https://github.com/tommy-sho/rate-limiter-grpc-go)
@@ -913,6 +972,7 @@ grpcServer := grpc.NewServer(
 - [ ] Regular security testing and audits
 
 **Resources:**
+
 - [Enhancing gRPC Security Best Practices](https://www.bytesizego.com/blog/grpc-security)
 - [Protecting gRPC Against OWASP's Top Ten API Risks](https://nordicapis.com/protecting-grpc-against-owasps-top-ten-api-risks/)
 - [gRPC Security Series: Part 3](https://medium.com/@ibm_ptc_security/grpc-security-series-part-3-c92f3b687dd9)
@@ -924,6 +984,7 @@ grpcServer := grpc.NewServer(
 ### 1. Use Strong Algorithms
 
 **AVOID (Weak/Deprecated):**
+
 - MD5 (broken)
 - SHA-1 (deprecated)
 - RC4 (insecure)
@@ -931,6 +992,7 @@ grpcServer := grpc.NewServer(
 - RSA < 2048 bits
 
 **USE (Secure):**
+
 - SHA-256, SHA-512 (hashing)
 - AES-256 (encryption)
 - RSA >= 2048 bits (preferably 4096)
@@ -941,6 +1003,7 @@ grpcServer := grpc.NewServer(
 ### 2. Secure Encryption Example
 
 **AES-GCM (Authenticated Encryption):**
+
 ```go
 import (
     "crypto/aes"
@@ -1002,6 +1065,7 @@ func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 ### 3. Key Generation
 
 **Generate Cryptographically Secure Keys:**
+
 ```go
 import "crypto/rand"
 
@@ -1021,6 +1085,7 @@ func generateKey(size int) ([]byte, error) {
 ### 4. Password Hashing
 
 **Use bcrypt or Argon2:**
+
 ```go
 import "golang.org/x/crypto/bcrypt"
 
@@ -1044,6 +1109,7 @@ func verifyPassword(password, hash string) bool {
 ### 5. Cryptography Audit
 
 In 2024, Google contracted Trail of Bits for an independent security audit of Go's core cryptography packages. The audit covered:
+
 - Key exchange (ECDH, ML-KEM)
 - Digital signatures (ECDSA, RSA, Ed25519)
 - Encryption (AES-GCM, AES-CBC, AES-CTR)
@@ -1054,6 +1120,7 @@ In 2024, Google contracted Trail of Bits for an independent security audit of Go
 **Result:** One low-severity finding in legacy Go+BoringCrypto integration.
 
 **Resources:**
+
 - [Go Cryptography Security Audit](https://go.dev/blog/tob-crypto-audit)
 - [crypto package](https://pkg.go.dev/crypto)
 - [Implementing Cryptography in Go](https://codezup.com/implementing-cryptography-in-go-with-tls-and-gos-cryptographic-library/)
@@ -1068,6 +1135,7 @@ In 2024, Google contracted Trail of Bits for an independent security audit of Go
 A data race occurs when two goroutines access the same variable concurrently and at least one access is a write.
 
 **Security Implications:**
+
 - Can break Go's memory safety guarantees
 - Unauthorized access or modification of data
 - Denial of service
@@ -1075,6 +1143,7 @@ A data race occurs when two goroutines access the same variable concurrently and
 - Unpredictable behavior
 
 **Vulnerable Code:**
+
 ```go
 package main
 
@@ -1094,6 +1163,7 @@ func main() {
 ### 2. Detection with Race Detector
 
 **Usage:**
+
 ```bash
 # Run tests with race detector
 go test -race ./...
@@ -1106,6 +1176,7 @@ go build -race
 ```
 
 **Limitations:**
+
 - Only works on 64-bit systems
 - Only detects data races (not race conditions)
 - Requires the race to actually occur during execution
@@ -1114,6 +1185,7 @@ go build -race
 ### 3. Solutions
 
 **Solution 1: Channels (Preferred in Go)**
+
 ```go
 package main
 
@@ -1137,6 +1209,7 @@ func main() {
 ```
 
 **Solution 2: Mutex**
+
 ```go
 import "sync"
 
@@ -1159,6 +1232,7 @@ func (c *SafeCounter) Value() int {
 ```
 
 **Solution 3: Atomic Operations**
+
 ```go
 import "sync/atomic"
 
@@ -1184,6 +1258,7 @@ func value() int64 {
 7. Document which goroutines access which data
 
 **Resources:**
+
 - [Data Race Detector](https://go.dev/doc/articles/race_detector)
 - [Introducing the Go Race Detector](https://go.dev/blog/race-detector)
 - [Data races in Go and how to fix them](https://www.sohamkamani.com/golang/data-races/)
@@ -1197,17 +1272,20 @@ func value() int64 {
 
 **go.sum File:**
 Contains cryptographic hashes (SHA-256) of each dependency, ensuring:
+
 - Completely consistent dependency content for every build
 - Detection of any tampering
 - Build fails if checksum mismatch detected
 
 **Checksum Database (sum.golang.org):**
+
 - Global append-only list of go.sum entries
 - Maintained by Google
 - Ensures everyone uses same dependency contents
 - Makes targeted attacks (backdoors) impossible
 
 **Key Design Decisions:**
+
 1. **Deterministic Builds**: Version of every dependency fully determined by go.mod
 2. **No Post-Install Hooks**: Code cannot execute during fetch or build
 3. **Immutable Versions**: Published versions cannot change
@@ -1215,6 +1293,7 @@ Contains cryptographic hashes (SHA-256) of each dependency, ensuring:
 ### 2. Verify Dependencies
 
 **Check Module Integrity:**
+
 ```bash
 # Verify modules haven't been altered
 go mod verify
@@ -1232,6 +1311,7 @@ go mod vendor
 ### 3. Scan for Vulnerabilities
 
 **Using govulncheck:**
+
 ```bash
 # Install
 go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -1244,6 +1324,7 @@ govulncheck -json ./...
 ```
 
 **Using OSV Scanner:**
+
 ```bash
 # Install
 go install github.com/google/osv-scanner/cmd/osv-scanner@latest
@@ -1255,10 +1336,12 @@ osv-scanner --lockfile=go.mod
 ### 4. Real-World Supply Chain Attacks
 
 **Typosquatting Examples:**
+
 - Malicious MongoDB Go module: `github.com/qiniiu/qmgo` (vs legitimate `github.com/qiniu/qmgo`)
 - Backdoored BoltDB typosquat exploited Go Module Proxy caching
 
 **Prevention:**
+
 1. Carefully verify package names
 2. Check package popularity and maintenance
 3. Review code of new dependencies
@@ -1287,6 +1370,7 @@ exclude github.com/bad/package v1.0.0
 ```
 
 **CI/CD Integration:**
+
 ```yaml
 # .github/workflows/security.yml
 name: Security Scan
@@ -1308,6 +1392,7 @@ jobs:
 ```
 
 **Resources:**
+
 - [How Go Mitigates Supply Chain Attacks](https://go.dev/blog/supply-chain)
 - [GitLab catches MongoDB Go module supply chain attack](https://about.gitlab.com/blog/gitlab-catches-mongodb-go-module-supply-chain-attack/)
 - [Go Supply Chain Attack: Malicious Package Exploits Go Module](https://socket.dev/blog/malicious-package-exploits-go-module-proxy-caching-for-persistence)
@@ -1317,6 +1402,7 @@ jobs:
 ## Security Checklist
 
 ### General Security
+
 - [ ] Keep Go updated to latest stable version
 - [ ] Run `govulncheck ./...` regularly
 - [ ] Run `gosec ./...` on all code
@@ -1329,6 +1415,7 @@ jobs:
 - [ ] Validate and sanitize ALL user input
 
 ### Input Validation
+
 - [ ] Use parameterized queries for SQL (never string concatenation)
 - [ ] Use `html/template` for HTML output (never `text/template`)
 - [ ] Avoid shell invocation with user input
@@ -1338,6 +1425,7 @@ jobs:
 - [ ] Validate gRPC inputs with protovalidate
 
 ### Cryptography
+
 - [ ] Use crypto/rand, NEVER math/rand for security
 - [ ] Use AES-256-GCM for encryption
 - [ ] Use bcrypt/Argon2 for password hashing (never plain SHA)
@@ -1347,6 +1435,7 @@ jobs:
 - [ ] Rotate keys regularly
 
 ### gRPC Security
+
 - [ ] Never use `grpc.WithInsecure()` in production
 - [ ] Implement TLS for all gRPC connections
 - [ ] Add authentication (JWT, mTLS, OAuth)
@@ -1357,6 +1446,7 @@ jobs:
 - [ ] Log authentication failures
 
 ### Concurrency
+
 - [ ] Run tests with `-race` flag
 - [ ] Use channels for sharing data between goroutines
 - [ ] Protect shared state with mutexes
@@ -1365,6 +1455,7 @@ jobs:
 - [ ] Document goroutine ownership of data
 
 ### Dependencies
+
 - [ ] Run `go mod verify` regularly
 - [ ] Use `govulncheck` in CI/CD
 - [ ] Pin dependencies to specific versions
@@ -1374,6 +1465,7 @@ jobs:
 - [ ] Use `GOPRIVATE` for internal modules
 
 ### Error Handling
+
 - [ ] Never expose internal errors to users
 - [ ] Log errors with context (but not sensitive data)
 - [ ] Return generic error messages to clients
@@ -1381,6 +1473,7 @@ jobs:
 - [ ] Use custom error types for better handling
 
 ### Configuration
+
 - [ ] Never hardcode credentials (use environment variables)
 - [ ] Use secret management systems (Vault, AWS Secrets Manager)
 - [ ] Validate all configuration values
@@ -1388,6 +1481,7 @@ jobs:
 - [ ] Document security-sensitive configuration
 
 ### Testing
+
 - [ ] Write security-focused tests
 - [ ] Test with malicious inputs
 - [ ] Fuzz test critical functions (`go test -fuzz`)
@@ -1400,18 +1494,21 @@ jobs:
 ## Additional Resources
 
 ### Official Go Security
+
 - [Go Security Policy](https://go.dev/doc/security/)
 - [Security Best Practices for Go Developers](https://go.dev/doc/security/best-practices)
 - [Go Vulnerability Database](https://pkg.go.dev/vuln/)
 - [Go Vulnerability Management](https://go.dev/doc/security/vuln/)
 
 ### OWASP Resources
+
 - [OWASP Go Secure Coding Practices Guide](https://owasp.org/www-project-go-secure-coding-practices-guide/)
 - [OWASP Go-SCP GitHub](https://github.com/OWASP/Go-SCP)
 - [OWASP Top Ten Guide for Go Developers](https://medium.com/@erwindev/the-owasp-top-ten-guide-for-go-developers-e80786dc4400)
 - [OWASP gRPC Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/gRPC_Security_Cheat_Sheet.html)
 
 ### Security Tools
+
 - [gosec - Go security checker](https://github.com/securego/gosec)
 - [govulncheck - Official vulnerability scanner](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
 - [staticcheck - Advanced linter](https://staticcheck.io/)
@@ -1419,6 +1516,7 @@ jobs:
 - [osv-scanner - Google's vulnerability scanner](https://github.com/google/osv-scanner)
 
 ### Community Resources
+
 - [Awesome Golang Security](https://github.com/guardrailsio/awesome-golang-security)
 - [Go Security Cheatsheet - Snyk](https://snyk.io/blog/go-security-cheatsheet-for-go-developers/)
 - [Secure Coding in Go: OWASP Top 10](https://www.hitechtrends.com/2025/05/25/secure-coding-in-go-owasp-top-10-exploits-and-fixes/)

--- a/agents/go-security-audit/system.md
+++ b/agents/go-security-audit/system.md
@@ -47,28 +47,33 @@ This pattern references comprehensive Go security knowledge in `golang-security-
 # VULNERABILITY CATEGORIES
 
 ## Injection Attacks
+
 - SQL Injection (string concatenation in queries)
 - Command Injection (shell invocation with user input)
 - NoSQL Injection
 - LDAP Injection
 
 ## Cross-Site Scripting (XSS)
+
 - Using text/template instead of html/template
 - Direct response writes without escaping
 - Use of template.HTML, template.JS bypass types
 
 ## Path Traversal
+
 - Missing filepath.Clean validation
 - Lack of directory boundary checks
 - No use of filepath.IsLocal or os.Root
 
 ## Memory Safety
+
 - Buffer overflow vulnerabilities
 - Integer overflow/underflow
 - Unsafe package usage with user data
 - CGO memory management issues
 
 ## gRPC Security
+
 - Missing TLS configuration
 - No authentication/authorization
 - Missing input validation
@@ -77,24 +82,28 @@ This pattern references comprehensive Go security knowledge in `golang-security-
 - HTTP/2 rapid reset vulnerability
 
 ## Cryptography
+
 - Weak algorithms (MD5, SHA-1, RC4, DES)
 - Insecure key generation (math/rand instead of crypto/rand)
 - Poor password hashing (plain SHA, no salt)
 - Insufficient key sizes (RSA < 2048)
 
 ## Concurrency
+
 - Data races
 - Race conditions
 - Missing synchronization primitives
 - Improper goroutine management
 
 ## Dependencies
+
 - Known vulnerabilities (CVEs)
 - Outdated packages
 - Typosquatting risks
 - Missing go.sum verification
 
 ## Configuration & Secrets
+
 - Hardcoded credentials
 - API keys in source code
 - Insecure default configurations
@@ -177,15 +186,18 @@ This pattern references comprehensive Go security knowledge in `golang-security-
 ```
 
 **Security Impact:**
+
 - [Specific impact point 1]
 - [Specific impact point 2]
 
 **Secure Implementation:**
+
 ```go
 [Corrected code example following best practices]
 ```
 
 **Remediation Steps:**
+
 1. [Specific actionable step]
 2. [Specific actionable step]
 3. [Specific actionable step]
@@ -193,6 +205,7 @@ This pattern references comprehensive Go security knowledge in `golang-security-
 **Detection Tool:** `gosec -include=G201 ./...` or `govulncheck ./...`
 
 **References:**
+
 - [Relevant section from knowledge base]
 - [External security resource]
 
@@ -224,16 +237,19 @@ This pattern references comprehensive Go security knowledge in `golang-security-
 [Explanation of the security improvement]
 
 **Current Implementation:**
+
 ```go
 [Current code if applicable]
 ```
 
 **Recommended Implementation:**
+
 ```go
 [Improved code example]
 ```
 
 **Benefits:**
+
 - [Benefit 1]
 - [Benefit 2]
 
@@ -269,19 +285,24 @@ go vet ./...
 Tailored checklist based on code type and findings:
 
 ### General Security
+
 - [ ] [Specific check relevant to this codebase]
 - [ ] [Specific check relevant to this codebase]
 
 ### Input Validation
+
 - [ ] [Specific check relevant to this codebase]
 
 ### Cryptography
+
 - [ ] [Specific check relevant to this codebase]
 
 ### Dependencies
+
 - [ ] [Specific check relevant to this codebase]
 
 ### Concurrency
+
 - [ ] [Specific check relevant to this codebase]
 
 ## Quick Wins
@@ -302,6 +323,7 @@ High-impact fixes that are relatively easy to implement:
 ## Summary
 
 [2-3 paragraph summary covering:
+
 - Overall security posture
 - Most critical concerns requiring immediate attention
 - Positive security practices already in place

--- a/agents/go-taskfile/agent.yaml
+++ b/agents/go-taskfile/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-taskfile
 version: 0.1.0
 description: Create or refactor Taskfile setups using best practices.

--- a/agents/go-taskfile/references/go-taskfile-standards.md
+++ b/agents/go-taskfile/references/go-taskfile-standards.md
@@ -954,15 +954,13 @@ tasks:
 
 ### Articles and Tutorials
 
-- [Why you should be using Go-Task](https://medium.com/@lorique/why-you-should-be-using-go-task-3cd30897f8d8)
 - [Taskfiles for Go Developers](https://tutorialedge.net/golang/taskfiles-for-go-developers/)
-- [Demystification of taskfile variables](https://medium.com/@TianchenW/demystification-of-taskfile-variables-29b751950393)
 - [Streamlining Your Go Projects with Taskfile](https://www.codingexplorations.com/blog/taskfile-automation-for-go-development)
 
 ### Community Resources
 
 - [Monorepo Discussion](https://github.com/go-task/task/discussions/1517)
-- [Go-Task GitHub Repository](https://refft.com/en/go-task_task.html)
+- [Go-Task GitHub Repository](https://github.com/go-task/task)
 - [Applied Go: Just Make a Task](https://appliedgo.net/spotlight/just-make-a-task/)
 
 ### Go Packages

--- a/agents/go-taskfile/references/go-taskfile-standards.md
+++ b/agents/go-taskfile/references/go-taskfile-standards.md
@@ -27,6 +27,7 @@ Go-Task (Task) is a modern, cross-platform task runner and build tool written in
 ### Standard File Names
 
 Use one of these standard names for your Task files:
+
 - `Taskfile.yaml` (recommended)
 - `Taskfile.yml`
 
@@ -118,6 +119,7 @@ tasks:
 ```
 
 Benefits:
+
 - Prevents task name conflicts
 - Groups related functionality
 - Enables reusable task modules
@@ -162,6 +164,7 @@ This enables reusable Taskfiles that can be included multiple times with differe
 ### Variable Types
 
 **Static Variables:**
+
 ```yaml
 vars:
   APP_NAME: myapp
@@ -169,6 +172,7 @@ vars:
 ```
 
 **Dynamic Variables (Shell Commands):**
+
 ```yaml
 vars:
   GIT_COMMIT:
@@ -178,6 +182,7 @@ vars:
 ```
 
 **Task-Specific Variables:**
+
 ```yaml
 tasks:
   build:
@@ -190,6 +195,7 @@ tasks:
 ### Variable Precedence
 
 Variables follow this priority order (highest to lowest):
+
 1. Command-line variables (`task VAR=value taskname`)
 2. Task-specific variables
 3. Global variables
@@ -200,6 +206,7 @@ Variables follow this priority order (highest to lowest):
 ### Environment Variables
 
 **Global Environment:**
+
 ```yaml
 env:
   GO111MODULE: on
@@ -207,6 +214,7 @@ env:
 ```
 
 **Task-Specific Environment:**
+
 ```yaml
 tasks:
   test:
@@ -217,6 +225,7 @@ tasks:
 ```
 
 **DotEnv Files:**
+
 ```yaml
 dotenv: ['.env', '{{.HOME}}/.env']
 
@@ -326,6 +335,7 @@ tasks:
 ### Avoid Shell-Specific Constructs
 
 ❌ **Bad:**
+
 ```yaml
 tasks:
   clean:
@@ -334,6 +344,7 @@ tasks:
 ```
 
 ✅ **Good:**
+
 ```yaml
 tasks:
   clean:
@@ -374,6 +385,7 @@ Valid values: Any valid GOOS/GOARCH combination (e.g., `linux`, `darwin`, `windo
 ### Use Cross-Platform Tools
 
 Prefer Go-based or cross-platform tools:
+
 - Use `go run` instead of shell scripts
 - Use task built-ins for common operations
 - Consider tools like `sh` task runner for portable shell commands
@@ -389,6 +401,7 @@ tasks:
 ```
 
 Or set globally:
+
 ```yaml
 set: [errexit, nounset, pipefail]
 
@@ -432,6 +445,7 @@ tasks:
 ```
 
 Checksum method:
+
 - Takes checksums of dependencies
 - Saves them to `.task/` directory
 - Compares current vs saved checksums
@@ -453,6 +467,7 @@ tasks:
 ```
 
 Timestamp method:
+
 - Compares file modification times
 - Simpler but less reliable
 - Issues with file copies, git operations
@@ -505,6 +520,7 @@ tasks:
 ```
 
 Or per-command:
+
 ```yaml
 tasks:
   build:
@@ -582,6 +598,7 @@ tasks:
 ```
 
 Options:
+
 - `interleaved` - Output as it comes (default for single task)
 - `group` - Buffer output, print when complete
 - `prefixed` - Prefix each line with task name (default for multiple tasks)
@@ -627,6 +644,7 @@ In CI, always pin the Task version:
 ```
 
 Benefits:
+
 - Consistent local and CI environments
 - Single source of truth for build commands
 - Easier to test CI changes locally
@@ -928,24 +946,27 @@ tasks:
 ## References
 
 ### Official Documentation
+
 - [Task Official Documentation](https://taskfile.dev/docs/guide)
 - [Taskfile Schema Reference](https://taskfile.dev/docs/reference/schema)
 - [Task Style Guide](https://taskfile.dev/docs/styleguide)
 - [Task Usage Guide](https://taskfile.dev/usage/)
 
 ### Articles and Tutorials
+
 - [Why you should be using Go-Task](https://medium.com/@lorique/why-you-should-be-using-go-task-3cd30897f8d8)
 - [Taskfiles for Go Developers](https://tutorialedge.net/golang/taskfiles-for-go-developers/)
-- [Taskfile replaces make and Makefiles](https://tomharrisonjr.medium.com/taskfile-replaces-make-and-makefiles-abf564708f81)
 - [Demystification of taskfile variables](https://medium.com/@TianchenW/demystification-of-taskfile-variables-29b751950393)
 - [Streamlining Your Go Projects with Taskfile](https://www.codingexplorations.com/blog/taskfile-automation-for-go-development)
 
 ### Community Resources
+
 - [Monorepo Discussion](https://github.com/go-task/task/discussions/1517)
 - [Go-Task GitHub Repository](https://refft.com/en/go-task_task.html)
 - [Applied Go: Just Make a Task](https://appliedgo.net/spotlight/just-make-a-task/)
 
 ### Go Packages
+
 - [github.com/go-task/task/v3](https://pkg.go.dev/github.com/go-task/task/v3)
 - [github.com/go-task/task/v3/taskfile](https://pkg.go.dev/github.com/go-task/task/v3/taskfile)
 

--- a/agents/go-tests/README.md
+++ b/agents/go-tests/README.md
@@ -5,6 +5,7 @@ A comprehensive fabric pattern for generating Go tests following community best 
 ## Pattern Structure
 
 This pattern includes:
+
 - **`system.md`** - The test generation framework and prompt engineering for LLM
 - **`go-testing-patterns.md`** - Comprehensive reference document with testing patterns (source of truth)
 - **`filter.sh`** - Post-processing to clean up output formatting
@@ -17,6 +18,7 @@ The pattern is designed with **separation of concerns**: the `go-testing-pattern
 ## Purpose
 
 This pattern helps you:
+
 - **Generate tests** for existing Go code
 - **Follow best practices** for Go testing
 - **Create table-driven tests** for multiple scenarios
@@ -105,6 +107,7 @@ done
 ### Test File
 
 Complete, runnable Go test file with:
+
 - Proper package declaration (`package_test`)
 - Necessary imports
 - Table-driven tests where appropriate
@@ -209,12 +212,14 @@ func TestDivide(t *testing.T) {
 ### When to Use This Pattern
 
 **Good use cases:**
+
 - Generating initial test coverage
 - Adding tests to legacy code
 - Learning Go testing patterns
 - Ensuring consistent test structure
 
 **Not ideal for:**
+
 - Complex integration tests (need more context)
 - Tests requiring specific mocking strategies
 - Performance-critical benchmark design

--- a/agents/go-tests/agent.yaml
+++ b/agents/go-tests/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: go-tests
 version: 0.1.0
 description: Create or improve Go tests and validate behavior with go test.

--- a/agents/go-tests/references/go-testing-patterns.md
+++ b/agents/go-tests/references/go-testing-patterns.md
@@ -31,6 +31,7 @@ A comprehensive guide to writing effective Go tests following community best pra
 ### Simplicity Guidelines
 
 **DO:**
+
 - Write tests that are easy to understand at a glance
 - Use inline test data rather than complex fixtures
 - Keep test setup minimal
@@ -38,6 +39,7 @@ A comprehensive guide to writing effective Go tests following community best pra
 - Test one thing per test case
 
 **DON'T:**
+
 - Create test helpers unless used in many places
 - Build complex test hierarchies
 - Over-parameterize tests
@@ -96,12 +98,14 @@ func TestParseURL(t *testing.T) {
 ### When to Use Table-Driven Tests
 
 **Good for:**
+
 - Functions with multiple input/output combinations
 - Validation functions
 - Parsing functions
 - Mathematical operations
 
 **Not needed for:**
+
 - Single test case scenarios
 - Complex setup/teardown requirements
 - Tests with significantly different logic per case
@@ -164,6 +168,7 @@ func TestParallel(t *testing.T) {
 ### When to Create Helpers
 
 Only create helpers when:
+
 - Used in multiple test files
 - Significantly reduces test code complexity
 - Makes tests more readable
@@ -251,11 +256,13 @@ func TestUserService(t *testing.T) {
 ### When to Mock
 
 **Do mock:**
+
 - External services (databases, APIs)
 - Time-dependent behavior
 - Random/non-deterministic behavior
 
 **Don't mock:**
+
 - Simple value objects
 - Standard library functions
 - Internal implementation details
@@ -527,7 +534,6 @@ if err == nil {
 
 - [Go Testing Package](https://pkg.go.dev/testing)
 - [Table-Driven Tests](https://go.dev/wiki/TableDrivenTests)
-- [Testing Techniques](https://go.dev/doc/articles/testing-techniques)
 - [testify Package](https://github.com/stretchr/testify)
 
 ---

--- a/agents/python-doc-comments/README.md
+++ b/agents/python-doc-comments/README.md
@@ -1,0 +1,170 @@
+# python-doc-comments
+
+Generate or improve Python documentation, docstrings, and type hints following PEP standards.
+
+## Overview
+
+This agent specializes in creating high-quality Python documentation that follows:
+
+- [PEP 8](https://peps.python.org/pep-0008/) - Style Guide for Python Code
+- [PEP 257](https://peps.python.org/pep-0257/) - Docstring Conventions
+- [PEP 484](https://peps.python.org/pep-0484/) - Type Hints
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+
+## Capabilities
+
+- **Add missing docstrings** for modules, classes, functions, and methods
+- **Improve existing documentation** to follow PEP conventions
+- **Add type hints** for parameters and return values
+- **Use Google-style docstrings** (can adapt to NumPy/Sphinx if detected)
+- **Add meaningful comments** that explain "why" not "what"
+- **Preserve code logic** - only modifies documentation
+
+## Usage
+
+```bash
+# Document a single file
+squad run python-doc-comments path/to/file.py
+
+# Document multiple files
+squad run python-doc-comments path/to/*.py
+
+# Document entire package
+squad run python-doc-comments path/to/package/
+```
+
+## What Gets Documented
+
+The agent documents all public (non-underscore) declarations:
+
+- **Modules** - Overview and usage examples
+- **Classes** - Purpose, attributes, and behavior
+- **Functions/Methods** - Summary, Args, Returns, Raises sections
+- **Type Hints** - Parameters and return types
+- **Block Comments** - Explain complex logic
+- **Codetags** - TODO, FIXME, NOTE with context
+
+## Documentation Standards
+
+The agent follows these key principles:
+
+1. **Triple double quotes** (`"""`) for all docstrings
+2. **Imperative mood** for one-liners: "Return X" not "Returns X"
+3. **Complete sentences** with proper punctuation
+4. **User focus** - explain "why" not implementation details
+5. **Type hints** complement docstrings
+6. **No redundancy** - avoid obvious comments
+
+## Docstring Styles
+
+### Google Style (Default)
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Args:
+        arg1: Description of arg1.
+        arg2: Description of arg2.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ValueError: When validation fails.
+    """
+    pass
+```
+
+### NumPy Style
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of arg1.
+    arg2 : str
+        Description of arg2.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+
+    Raises
+    ------
+    ValueError
+        When validation fails.
+    """
+    pass
+```
+
+## Examples
+
+### Before
+
+```python
+class Cache:
+    def __init__(self, size):
+        self.size = size
+        self.data = {}
+
+    def get(self, key):
+        return self.data.get(key)
+```
+
+### After
+
+```python
+class Cache:
+    """Thread-safe in-memory cache with size limits.
+
+    Attributes:
+        size: Maximum number of items to cache.
+        data: Internal storage dictionary.
+    """
+
+    def __init__(self, size: int) -> None:
+        """Initialize cache with maximum size.
+
+        Args:
+            size: Maximum number of items to store.
+        """
+        self.size = size
+        self.data: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        """Retrieve value for key from cache.
+
+        Args:
+            key: Cache key to look up.
+
+        Returns:
+            Cached value if present, None otherwise.
+        """
+        return self.data.get(key)
+```
+
+## Reference
+
+The agent uses a comprehensive knowledge base covering:
+
+- Docstring conventions (one-line and multi-line formats)
+- Google, NumPy, and Sphinx docstring styles
+- Block and inline comment guidelines
+- Type hints from the `typing` module
+- Codetags (TODO, FIXME, NOTE, BUG, HACK)
+- Linter directives (mypy, flake8, pylint, black)
+- Common mistakes and anti-patterns
+- Quality checklist
+
+See [references/python-documentation-standards.md](references/python-documentation-standards.md) for the complete reference.
+
+## Related Agents
+
+- **python-review** - Review Python code for best practices
+- **python-refactor** - Refactor Python code to clean patterns
+- **python-tests** - Generate Python tests

--- a/agents/python-doc-comments/agent.md
+++ b/agents/python-doc-comments/agent.md
@@ -1,0 +1,17 @@
+# AGENT MODE
+
+You are a codebase agent. Use repository context, inspect relevant files, and apply changes directly.
+Prefer minimal, targeted edits that preserve behavior unless the user requests changes.
+Run the most relevant lightweight validations (formatters, linters, tests) when practical.
+If you skip tests, say why.
+
+# EXECUTION RULES
+
+- Discover context before changing files.
+- Follow existing repo conventions.
+- Make changes in-place and keep diffs focused.
+- Summarize changes, list files touched, and list tests run.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/python-doc-comments/agent.yaml
+++ b/agents/python-doc-comments/agent.yaml
@@ -1,0 +1,8 @@
+---
+name: python-doc-comments
+version: 0.1.0
+description: Generate or improve Python documentation, docstrings, and type hints following PEP standards.
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - references/python-documentation-standards.md

--- a/agents/python-doc-comments/references/python-documentation-standards.md
+++ b/agents/python-doc-comments/references/python-documentation-standards.md
@@ -677,7 +677,7 @@ convention = "google"
 
 | Tool                                  | Description              |
 | ------------------------------------- | ------------------------ |
-| [Sphinx](https://www.sphinx-doc.org/) | Full documentation suite |
+| [Sphinx](https://www.sphinx-doc.org/en/master/) | Full documentation suite |
 | [MkDocs](https://www.mkdocs.org/)     | Markdown-based docs      |
 | [pdoc](https://pdoc.dev/)             | Auto-generated API docs  |
 

--- a/agents/python-doc-comments/references/python-documentation-standards.md
+++ b/agents/python-doc-comments/references/python-documentation-standards.md
@@ -1,0 +1,739 @@
+# Python Documentation Standards
+
+A comprehensive guide to Python documentation following PEP 8, PEP 257, and modern best practices. This document serves as the knowledge base for the python-doc-comments pattern.
+
+## Table of Contents
+
+1. [Core Principles](#core-principles)
+2. [Docstrings (PEP 257)](#docstrings-pep-257)
+3. [Comments (PEP 8)](#comments-pep-8)
+4. [Type Hints](#type-hints)
+5. [Codetags](#codetags)
+6. [Magic Comments](#magic-comments)
+7. [Linter Directives](#linter-directives)
+8. [Common Mistakes](#common-mistakes)
+9. [Quality Checklist](#quality-checklist)
+
+---
+
+## Core Principles
+
+### The Golden Rules
+
+| Principle | Description |
+|-----------|-------------|
+| Triple double quotes | Always use `"""` for docstrings |
+| Complete sentences | Proper capitalization and punctuation |
+| Explain "why" | Code shows "what", comments explain "why" |
+| User focus | Document for users, not implementation |
+| Synchronize | Outdated comments are worse than none |
+| Use sparingly | Prefer clear code over excessive comments |
+
+### Philosophy
+
+- **Self-documenting code** is the first priority
+- Comments should add value, not state the obvious
+- Type hints complement docstrings, not replace them
+- Professional tone in all documentation
+
+---
+
+## Docstrings (PEP 257)
+
+Docstrings become the `__doc__` attribute of modules, functions, classes, and methods.
+
+### One-Line Docstrings
+
+For simple, obvious cases:
+
+```python
+def kos_root():
+    """Return the pathname of the KOS root directory."""
+    global _kos_root
+    return _kos_root
+```
+
+**Rules:**
+
+- Closing quotes on the **same line**
+- **Imperative mood**: "Return X" not "Returns X"
+- End with a **period**
+- No blank lines before or after
+
+### Multi-Line Docstrings
+
+For complex documentation:
+
+```python
+def complex(real=0.0, imag=0.0):
+    """Form a complex number.
+
+    Keyword arguments:
+    real -- the real part (default 0.0)
+    imag -- the imaginary part (default 0.0)
+    """
+    if imag == 0.0 and real == 0.0:
+        return complex_zero
+```
+
+**Structure:**
+
+1. Summary line (fits on one line)
+2. Blank line
+3. Detailed description
+4. Closing quotes on **separate line**
+
+### Module Docstrings
+
+```python
+"""A one-line summary of the module, terminated by a period.
+
+Leave a blank line. The rest of this docstring should contain an
+overall description of the module. Optionally, it may also contain
+a brief description of exported classes and functions.
+
+Typical usage example:
+
+    foo = ClassFoo()
+    bar = foo.function_bar()
+"""
+
+import os
+import sys
+```
+
+**Placement:**
+
+- Must be the **first statement** in the module
+- Comes **after** magic comments (shebang, encoding)
+- Comes **before** imports
+
+### Function/Method Docstrings (Google Style)
+
+```python
+def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
+    """Fetch rows from a Bigtable.
+
+    Retrieve rows pertaining to the given keys from the Table instance
+    represented by big_table.
+
+    Args:
+        big_table: An open Bigtable Table instance.
+        keys: A sequence of strings representing the key of each table
+            row to fetch.
+        other_silly_variable: Another optional variable, that has a much
+            longer name than the other args.
+
+    Returns:
+        A dict mapping keys to the corresponding table row data fetched.
+        Each row is represented as a tuple of strings. For example:
+
+        {'Serak': ('Rigel VII', 'Preparer'),
+         'Zim': ('Irk', 'Invader')}
+
+    Raises:
+        IOError: An error occurred accessing the bigtable.Table object.
+    """
+    pass
+```
+
+**Sections:**
+
+| Section | Purpose |
+|---------|---------|
+| Args | List each parameter with description |
+| Returns | Describe the return value and its type |
+| Yields | For generators |
+| Raises | Document exceptions that may be raised |
+
+### Class Docstrings
+
+```python
+class SampleClass:
+    """Summary of class here.
+
+    Longer class information and detailed description.
+
+    Attributes:
+        likes_spam: A boolean indicating if we like SPAM or not.
+        eggs: An integer count of the eggs we have laid.
+    """
+
+    def __init__(self, likes_spam=False):
+        """Initialize the instance based on spam preference.
+
+        Args:
+            likes_spam: Defines if instance exhibits this preference.
+        """
+        self.likes_spam = likes_spam
+        self.eggs = 0
+```
+
+**Key Points:**
+
+- Summarize what instances represent
+- List public attributes in **Attributes** section
+- Document `__init__` separately
+
+### Docstring Styles Comparison
+
+**Google Style** (recommended):
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Args:
+        arg1: Description of arg1.
+        arg2: Description of arg2.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ValueError: When validation fails.
+    """
+    pass
+```
+
+**NumPy Style** (scientific computing):
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of arg1.
+    arg2 : str
+        Description of arg2.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+
+    Raises
+    ------
+    ValueError
+        When validation fails.
+    """
+    pass
+```
+
+**Sphinx/reStructuredText Style**:
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    :param arg1: Description of arg1
+    :type arg1: int
+    :param arg2: Description of arg2
+    :type arg2: str
+    :return: Description of return value
+    :rtype: bool
+    :raises ValueError: When validation fails
+    """
+    pass
+```
+
+---
+
+## Comments (PEP 8)
+
+### Block Comments
+
+Block comments apply to code that follows them.
+
+```python
+# Filter out inactive users and sort by registration date.
+# This is necessary because the database query doesn't
+# guarantee ordering for performance reasons.
+active_users = [u for u in users if u.is_active]
+return sorted(active_users, key=lambda u: u.registered_at)
+```
+
+**Rules:**
+
+- Start with `#` followed by a single space
+- Indent to the same level as the code
+- Separate paragraphs with a line containing only `#`
+
+### Inline Comments
+
+Inline comments appear on the same line as code. Use sparingly.
+
+```python
+# Good: Explains non-obvious reasoning
+x = x + 1  # Compensate for border offset in rendering
+
+# Good: Clarifies business logic
+discount = 0.9  # 10% discount for premium members
+
+# Bad: States the obvious
+x = x + 1  # Increment x
+```
+
+**Rules:**
+
+- Separate from code by **at least 2 spaces**
+- Start with `#` and a single space
+- Maximum **72 characters** recommended
+- Use sparingly - only when adding real value
+
+### When Comments Add Value
+
+```python
+# Explains business logic
+discount = 0.25 if user.is_grandfathered else 0.20
+
+# Warns about gotchas
+# Note: This modifies the list in-place
+items.sort()
+
+# Documents performance implications
+# Using dict lookup O(1) instead of list search O(n)
+user_map = {user.id: user for user in users}
+
+# Explains non-obvious algorithms
+# Boyer-Moore voting algorithm - O(n) time, O(1) space
+candidate = None
+```
+
+---
+
+## Type Hints
+
+Type hints complement docstrings by providing static type information.
+
+### Basic Types
+
+```python
+def greeting(name: str) -> str:
+    """Return a greeting message."""
+    return f'Hello {name}'
+```
+
+### Complex Types
+
+```python
+from typing import List, Dict, Optional, Union
+
+def process_items(
+    items: List[str],
+    config: Optional[Dict[str, Union[str, int]]] = None
+) -> List[Dict[str, str]]:
+    """Process items with optional configuration.
+
+    Args:
+        items: List of item names to process.
+        config: Optional configuration dictionary.
+
+    Returns:
+        List of processed item dictionaries.
+    """
+    pass
+```
+
+### Modern Python (3.10+)
+
+```python
+def process(items: list[str], config: dict[str, str | int] | None = None) -> list[dict[str, str]]:
+    """Process items with optional configuration."""
+    pass
+```
+
+### Key Points
+
+| Aspect | Description |
+|--------|-------------|
+| Static analysis | Used by mypy, pyright, IDEs |
+| Documentation | Human-readable, stays in code |
+| Runtime | Type hints don't enforce at runtime |
+| Combination | Use both type hints AND docstrings |
+
+---
+
+## Codetags
+
+Standardized annotations that flag code requiring attention.
+
+### Common Tags
+
+| Tag | Purpose | Example |
+|-----|---------|---------|
+| `TODO` | Pending tasks | `# TODO: Add input validation` |
+| `FIXME` | Code needing fixes | `# FIXME: Memory leak in loop` |
+| `XXX` | Synonym for FIXME | `# XXX: This breaks with unicode` |
+| `BUG` | Known defects | `# BUG: Tracked as JIRA-456` |
+| `HACK` | Temporary workarounds | `# HACK: Works around API bug` |
+| `NOTE` | Important clarifications | `# NOTE: Requires Python 3.8+` |
+
+### Format with Metadata
+
+```python
+# TODO: Refactor this function. <JD d:2025-01-15 p:2>
+def legacy_code():
+    pass
+
+# FIXME: Memory leak in loop. <AS t:JIRA-789 p:1>
+def leaky_function():
+    pass
+```
+
+**Metadata Fields:**
+
+- `<initials>` - Owner/author
+- `d:date` - Due date (ISO 8601)
+- `p:0-3` - Priority (0=highest)
+- `t:id` - Tracker reference
+
+### Best Practices
+
+1. Include ownership (initials or name)
+2. Add context (ticket numbers, due dates)
+3. Be specific about the problem
+4. For serious issues, create tickets in issue tracker
+5. Keep TODOs temporary - fix or move to tracker
+
+---
+
+## Magic Comments
+
+Special comments that provide instructions to the interpreter.
+
+### Shebang Line
+
+```python
+#!/usr/bin/env python3
+```
+
+**Rules:**
+
+- Must be the **first line**
+- `#!/usr/bin/env python3` is portable (uses PATH)
+- Only needed for executable scripts
+
+### Encoding Declaration (PEP 263)
+
+```python
+# -*- coding: utf-8 -*-
+```
+
+**Rules:**
+
+- Must be on first or second line
+- Usually **unnecessary** (UTF-8 is default in Python 3)
+- Required only for non-UTF-8 encodings
+
+### Complete File Header
+
+```python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Module docstring comes after magic comments.
+
+This is the proper order for file headers in Python.
+"""
+
+import os
+import sys
+```
+
+---
+
+## Linter Directives
+
+Special comments to control static analysis tools.
+
+### Type Checking (mypy, pyright)
+
+```python
+# type: ignore
+result = some_untyped_function()  # type: ignore
+
+# Specific error
+value = process(wrong_type)  # type: ignore[arg-type]
+```
+
+### Style Checking (flake8)
+
+```python
+# noqa
+long_line = "Very long line"  # noqa
+
+# Specific rule
+another_long_line = "Long line"  # noqa: E501
+
+# Unused import
+from module import unused  # noqa: F401
+```
+
+### Linting (pylint)
+
+```python
+# pylint: disable=line-too-long
+very_long_line = "Intentionally long"
+
+# pylint: disable=broad-except
+try:
+    risky()
+except Exception:  # pylint: disable=broad-except
+    handle()
+```
+
+### Code Coverage
+
+```python
+def debug_function():  # pragma: no cover
+    """Only used during development."""
+    print("Debug")
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+```
+
+### Formatting (black)
+
+```python
+# fmt: off
+matrix = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+]
+# fmt: on
+```
+
+### Best Practices for Directives
+
+1. Be specific - use exact error codes
+2. Add explanations - why ignoring?
+3. Minimize scope - apply to smallest section
+4. Review regularly - suppressed warnings may hide issues
+
+---
+
+## Common Mistakes
+
+### Redundant Comments
+
+**Bad:**
+
+```python
+x = x + 1  # Increment x
+name = "John"  # Set name to John
+```
+
+**Good:**
+
+```python
+x = x + 1  # Compensate for zero-based indexing
+```
+
+### Redundant Docstrings
+
+**Bad:**
+
+```python
+def add(a, b):
+    """Add two numbers.
+
+    This function takes two numbers and adds them together.
+    It returns the sum of a and b.
+    """
+    return a + b
+```
+
+**Good:**
+
+```python
+def add(a, b):
+    """Return the sum of a and b."""
+    return a + b
+```
+
+### Commented-Out Code
+
+**Bad:**
+
+```python
+def current():
+    # old_way()
+    # previous_version()
+    return new_way()
+```
+
+**Good:**
+
+```python
+def current():
+    return new_way()
+```
+
+### Lying Comments
+
+**Bad:**
+
+```python
+# Return the user's full name
+def get_username(user):
+    return user.email  # Actually returns email!
+```
+
+### Over-Commenting
+
+**Bad:**
+
+```python
+def process_order(order):
+    # Validate the order
+    if not order.is_valid():
+        # Raise exception if invalid
+        raise ValueError("Invalid order")
+
+    # Calculate the total
+    total = order.calculate_total()
+
+    # Return the final total
+    return total
+```
+
+**Good:**
+
+```python
+def process_order(order):
+    if not order.is_valid():
+        raise ValueError("Invalid order")
+    return order.calculate_total()
+```
+
+### Missing Type Context
+
+**Old way (duplicates type info):**
+
+```python
+def process_user(user):
+    """Process a user.
+
+    Args:
+        user (dict): User dictionary with 'id', 'name', 'email'
+
+    Returns:
+        bool: True if successful
+    """
+    pass
+```
+
+**Modern way (types in signature):**
+
+```python
+from typing import TypedDict
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+def process_user(user: User) -> bool:
+    """Process a user and update the database."""
+    pass
+```
+
+---
+
+## Tools and Automation
+
+### Recommended Tools
+
+| Tool | Purpose |
+|------|---------|
+| [black](https://github.com/psf/black) | Code formatting |
+| [isort](https://github.com/PyCQA/isort) | Import sorting |
+| [mypy](https://github.com/python/mypy) | Type checking |
+| [pylint](https://github.com/pylint-dev/pylint) | Linting |
+| [flake8](https://github.com/PyCQA/flake8) | Style checking |
+| [pydocstyle](https://github.com/PyCQA/pydocstyle) | Docstring checking |
+
+### pyproject.toml Configuration
+
+```toml
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+strict = true
+
+[tool.pylint.messages_control]
+max-line-length = 88
+
+[tool.pydocstyle]
+convention = "google"
+```
+
+### Documentation Generators
+
+| Tool | Description |
+|------|-------------|
+| [Sphinx](https://www.sphinx-doc.org/) | Full documentation suite |
+| [MkDocs](https://www.mkdocs.org/) | Markdown-based docs |
+| [pdoc](https://pdoc.dev/) | Auto-generated API docs |
+
+---
+
+## Quality Checklist
+
+### Docstrings
+
+- [ ] Triple double quotes (`"""`)
+- [ ] All public modules, classes, and functions documented
+- [ ] One-line format for simple cases
+- [ ] Multi-line format with summary, blank line, details
+- [ ] Args, Returns, Raises sections for functions
+- [ ] Attributes section for classes
+- [ ] Imperative mood for one-liners
+
+### Comments
+
+- [ ] Block comments indented with code
+- [ ] Inline comments used sparingly (2+ spaces)
+- [ ] Explain "why" not "what"
+- [ ] No obvious or redundant comments
+- [ ] Complete sentences with proper grammar
+- [ ] Updated when code changes
+
+### Type Hints
+
+- [ ] Used for function parameters and returns
+- [ ] Complex types imported from `typing`
+- [ ] Complement docstrings, not replace them
+
+### Tool Integration
+
+- [ ] Linter directives used sparingly
+- [ ] Specific error codes when possible
+- [ ] Code formatted consistently
+
+### Code Quality
+
+- [ ] Code is self-documenting with clear names
+- [ ] No commented-out code
+- [ ] TODOs include context and ownership
+- [ ] Professional and respectful tone
+
+---
+
+## References
+
+- [PEP 8 - Style Guide for Python Code](https://peps.python.org/pep-0008/)
+- [PEP 257 - Docstring Conventions](https://peps.python.org/pep-0257/)
+- [PEP 263 - Source Code Encodings](https://peps.python.org/pep-0263/)
+- [PEP 350 - Codetags](https://peps.python.org/pep-0350/)
+- [PEP 484 - Type Hints](https://peps.python.org/pep-0484/)
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+
+---
+
+*Last updated: 2026-01-11*

--- a/agents/python-doc-comments/references/python-documentation-standards.md
+++ b/agents/python-doc-comments/references/python-documentation-standards.md
@@ -20,14 +20,14 @@ A comprehensive guide to Python documentation following PEP 8, PEP 257, and mode
 
 ### The Golden Rules
 
-| Principle | Description |
-|-----------|-------------|
-| Triple double quotes | Always use `"""` for docstrings |
-| Complete sentences | Proper capitalization and punctuation |
-| Explain "why" | Code shows "what", comments explain "why" |
-| User focus | Document for users, not implementation |
-| Synchronize | Outdated comments are worse than none |
-| Use sparingly | Prefer clear code over excessive comments |
+| Principle            | Description                               |
+| -------------------- | ----------------------------------------- |
+| Triple double quotes | Always use `"""` for docstrings           |
+| Complete sentences   | Proper capitalization and punctuation     |
+| Explain "why"        | Code shows "what", comments explain "why" |
+| User focus           | Document for users, not implementation    |
+| Synchronize          | Outdated comments are worse than none     |
+| Use sparingly        | Prefer clear code over excessive comments |
 
 ### Philosophy
 
@@ -139,12 +139,12 @@ def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
 
 **Sections:**
 
-| Section | Purpose |
-|---------|---------|
-| Args | List each parameter with description |
+| Section | Purpose                                |
+| ------- | -------------------------------------- |
+| Args    | List each parameter with description   |
 | Returns | Describe the return value and its type |
-| Yields | For generators |
-| Raises | Document exceptions that may be raised |
+| Yields  | For generators                         |
+| Raises  | Document exceptions that may be raised |
 
 ### Class Docstrings
 
@@ -347,12 +347,12 @@ def process(items: list[str], config: dict[str, str | int] | None = None) -> lis
 
 ### Key Points
 
-| Aspect | Description |
-|--------|-------------|
-| Static analysis | Used by mypy, pyright, IDEs |
-| Documentation | Human-readable, stays in code |
-| Runtime | Type hints don't enforce at runtime |
-| Combination | Use both type hints AND docstrings |
+| Aspect          | Description                         |
+| --------------- | ----------------------------------- |
+| Static analysis | Used by mypy, pyright, IDEs         |
+| Documentation   | Human-readable, stays in code       |
+| Runtime         | Type hints don't enforce at runtime |
+| Combination     | Use both type hints AND docstrings  |
 
 ---
 
@@ -362,19 +362,19 @@ Standardized annotations that flag code requiring attention.
 
 ### Common Tags
 
-| Tag | Purpose | Example |
-|-----|---------|---------|
-| `TODO` | Pending tasks | `# TODO: Add input validation` |
-| `FIXME` | Code needing fixes | `# FIXME: Memory leak in loop` |
-| `XXX` | Synonym for FIXME | `# XXX: This breaks with unicode` |
-| `BUG` | Known defects | `# BUG: Tracked as JIRA-456` |
-| `HACK` | Temporary workarounds | `# HACK: Works around API bug` |
-| `NOTE` | Important clarifications | `# NOTE: Requires Python 3.8+` |
+| Tag     | Purpose                  | Example                           |
+| ------- | ------------------------ | --------------------------------- |
+| `TODO`  | Pending tasks            | `# TODO: Add input validation`    |
+| `FIXME` | Code needing fixes       | `# FIXME: Memory leak in loop`    |
+| `XXX`   | Synonym for FIXME        | `# XXX: This breaks with unicode` |
+| `BUG`   | Known defects            | `# BUG: Tracked as JIRA-456`      |
+| `HACK`  | Temporary workarounds    | `# HACK: Works around API bug`    |
+| `NOTE`  | Important clarifications | `# NOTE: Requires Python 3.8+`    |
 
 ### Format with Metadata
 
 ```python
-# TODO: Refactor this function. <JD d:2025-01-15 p:2>
+# TODO: Refactor this function. <JD d:2026-01-15 p:2>
 def legacy_code():
     pass
 
@@ -648,13 +648,13 @@ def process_user(user: User) -> bool:
 
 ### Recommended Tools
 
-| Tool | Purpose |
-|------|---------|
-| [black](https://github.com/psf/black) | Code formatting |
-| [isort](https://github.com/PyCQA/isort) | Import sorting |
-| [mypy](https://github.com/python/mypy) | Type checking |
-| [pylint](https://github.com/pylint-dev/pylint) | Linting |
-| [flake8](https://github.com/PyCQA/flake8) | Style checking |
+| Tool                                              | Purpose            |
+| ------------------------------------------------- | ------------------ |
+| [black](https://github.com/psf/black)             | Code formatting    |
+| [isort](https://github.com/PyCQA/isort)           | Import sorting     |
+| [mypy](https://github.com/python/mypy)            | Type checking      |
+| [pylint](https://github.com/pylint-dev/pylint)    | Linting            |
+| [flake8](https://github.com/PyCQA/flake8)         | Style checking     |
 | [pydocstyle](https://github.com/PyCQA/pydocstyle) | Docstring checking |
 
 ### pyproject.toml Configuration
@@ -675,11 +675,11 @@ convention = "google"
 
 ### Documentation Generators
 
-| Tool | Description |
-|------|-------------|
+| Tool                                  | Description              |
+| ------------------------------------- | ------------------------ |
 | [Sphinx](https://www.sphinx-doc.org/) | Full documentation suite |
-| [MkDocs](https://www.mkdocs.org/) | Markdown-based docs |
-| [pdoc](https://pdoc.dev/) | Auto-generated API docs |
+| [MkDocs](https://www.mkdocs.org/)     | Markdown-based docs      |
+| [pdoc](https://pdoc.dev/)             | Auto-generated API docs  |
 
 ---
 
@@ -736,4 +736,4 @@ convention = "google"
 
 ---
 
-*Last updated: 2026-01-11*
+_Last updated: 2026-01-11_

--- a/agents/python-doc-comments/system.md
+++ b/agents/python-doc-comments/system.md
@@ -1,0 +1,90 @@
+# IDENTITY and PURPOSE
+
+You are an expert Python documentation specialist with deep knowledge of PEP 8, PEP 257, and modern Python documentation standards. Your role is to analyze Python code and generate or improve documentation comments, docstrings, and type hints following official Python conventions and best practices.
+
+# KNOWLEDGE BASE
+
+You have access to a comprehensive documentation standards reference in the same directory as this pattern (`python-documentation-standards.md`). This document contains:
+
+- Docstring conventions (PEP 257) with Google, NumPy, and Sphinx styles
+- Block and inline comment rules (PEP 8)
+- Type hints integration (PEP 484)
+- Codetags (TODO, FIXME, etc.)
+- Magic comments (shebang, encoding)
+- Linter/tool directives (mypy, flake8, pylint, black)
+- Anti-patterns to avoid
+- Quality checklist
+
+**CRITICAL**: Apply ALL standards from the python-documentation-standards.md document when generating documentation. Use the full depth of knowledge in that reference document.
+
+# STEPS
+
+1. Analyze the provided Python code to identify all public modules, classes, functions, and methods
+2. Identify missing or inadequate documentation (docstrings, comments, type hints)
+3. Generate complete, clear documentation following PEP conventions
+4. Use Google-style docstrings unless the codebase uses a different style
+5. Add type hints where missing
+6. Focus on user needs, explaining "why" not "what"
+7. Verify all docstrings follow the appropriate format (one-line or multi-line)
+
+# DOCUMENTATION CATEGORIES
+
+Reference the python-documentation-standards.md for detailed standards. Brief overview:
+
+1. **Module Docstrings** - First statement, describes module purpose
+2. **Class Docstrings** - What instances represent, Attributes section
+3. **Function/Method Docstrings** - Summary, Args, Returns, Raises sections
+4. **Block Comments** - Explain "why", indented with code
+5. **Inline Comments** - Use sparingly, 2+ spaces from code
+6. **Type Hints** - Parameters, return types, complex types from typing
+7. **Codetags** - TODO, FIXME, NOTE with context and ownership
+
+# OUTPUT INSTRUCTIONS
+
+- Generate documentation for ALL public modules, classes, functions, and methods
+- Use triple double quotes (`"""`) for all docstrings
+- Use imperative mood for one-liners: "Return X" not "Returns X"
+- Add type hints for all function parameters and return values
+- Keep one-line docstrings on a single line with closing quotes
+- Multi-line docstrings: summary, blank line, details, closing quotes on own line
+- Include Args, Returns, Raises sections for non-trivial functions
+- Focus on clarity and user needs
+- Explain "why" in comments, not "what"
+
+# OUTPUT FORMAT
+
+Provide the complete Python code with improved/added documentation. Preserve the original code structure and only modify or add documentation elements.
+
+## Documented Code
+
+```python
+[Complete Python code with documentation]
+```
+
+## Documentation Summary
+
+- **Added:** [count] new docstrings
+- **Improved:** [count] existing docstrings
+- **Type hints added:** [count]
+- **Key changes:**
+  - [Description of major documentation additions]
+  - [Description of improvements]
+
+## Notes
+
+[Any important notes about documentation decisions or suggestions for further improvement]
+
+# IMPORTANT CONSTRAINTS
+
+- **Never modify code logic** - only add or improve documentation
+- **Preserve all existing code** exactly as provided
+- **Use triple double quotes** for all docstrings
+- **Imperative mood** for one-line docstrings ("Return" not "Returns")
+- **Complete sentences** with proper punctuation
+- **No redundant comments** that state the obvious
+- **Match existing style** if the codebase uses NumPy or Sphinx format
+- **Reference the knowledge base** - use standards from python-documentation-standards.md
+
+# INPUT
+
+Python code to document:

--- a/agents/python-refactor/README.md
+++ b/agents/python-refactor/README.md
@@ -5,6 +5,7 @@ A comprehensive fabric pattern for refactoring Python code to be more idiomatic,
 ## Pattern Structure
 
 This pattern includes:
+
 - **`system.md`** - The refactoring framework and prompt engineering for LLM
 - **`python-best-practices.md`** - Comprehensive reference document with detailed patterns (source of truth)
 - **`filter.sh`** - Post-processing to clean up output formatting
@@ -18,6 +19,7 @@ The pattern is designed with **separation of concerns**: the `python-best-practi
 ## Style Guide References
 
 This pattern incorporates guidelines from:
+
 - **[PEP 8](https://peps.python.org/pep-0008/)** - Python's official style guide
 - **[PEP 20](https://peps.python.org/pep-0020/)** - The Zen of Python
 - **[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)** - Google's enterprise Python standards
@@ -25,6 +27,7 @@ This pattern incorporates guidelines from:
 ## Purpose
 
 This pattern helps you:
+
 - **Identify anti-patterns** in Python code (deep nesting, mutable defaults, poor error handling, etc.)
 - **Apply idiomatic patterns** following official Python guidelines
 - **Improve code quality** without changing behavior
@@ -132,16 +135,19 @@ done
 The pattern generates output with:
 
 ### Refactored Code
+
 - Complete, runnable Python code
 - All improvements applied
 - Proper formatting (ruff/black-compatible)
 
 ### Changes Made
+
 - Numbered list of changes
 - Explanation of why each change was made
 - Reference to pattern from knowledge base
 
 ### Notes
+
 - Important assumptions made
 - Potential follow-up improvements
 - Behavior-preserving guarantees
@@ -247,6 +253,7 @@ def read_file(path: str) -> str:
 ### When to Use This Pattern
 
 **Good use cases:**
+
 - Refactoring legacy Python code
 - Code review preparation
 - Learning idiomatic Python patterns
@@ -254,6 +261,7 @@ def read_file(path: str) -> str:
 - Pre-commit code improvements
 
 **Not ideal for:**
+
 - Large-scale architectural changes
 - Adding new functionality
 - Performance-critical optimizations (use profiling instead)
@@ -261,6 +269,7 @@ def read_file(path: str) -> str:
 ### Preserving Functionality
 
 The pattern is designed to:
+
 - Never change the public API
 - Maintain exact behavior
 - Preserve backwards compatibility
@@ -269,6 +278,7 @@ The pattern is designed to:
 ### Iterative Refactoring
 
 For large files, consider:
+
 1. Refactor one function at a time
 2. Review and test each change
 3. Commit incrementally
@@ -287,6 +297,7 @@ To add or modify refactoring patterns, edit the `python-best-practices.md` file:
 ### Adjusting Output Format
 
 To modify the output structure, edit the `# OUTPUT FORMAT` section in `system.md`:
+
 - Add new sections
 - Change formatting
 - Adjust detail level
@@ -296,6 +307,7 @@ To modify the output structure, edit the `# OUTPUT FORMAT` section in `system.md
 ### Issue: Pattern changes too much
 
 **Solution:** The pattern tries to be comprehensive. For targeted changes, provide specific instructions:
+
 ```bash
 echo "# Only fix error handling\n$(cat myfile.py)" | fabric --pattern python-refactor
 ```
@@ -303,6 +315,7 @@ echo "# Only fix error handling\n$(cat myfile.py)" | fabric --pattern python-ref
 ### Issue: Output doesn't pass linting
 
 **Solution:** Run ruff or black on the output:
+
 ```bash
 cat myfile.py | fabric --pattern python-refactor | ruff format -
 ```

--- a/agents/python-refactor/agent.yaml
+++ b/agents/python-refactor/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: python-refactor
 version: 0.1.0
 description: Refactor Python code to clean, idiomatic Python while preserving behavior.

--- a/agents/python-refactor/references/python-best-practices.md
+++ b/agents/python-refactor/references/python-best-practices.md
@@ -56,6 +56,7 @@ Refactoring should never alter behavior:
 Deep nesting reduces readability. Use guard clauses to handle edge cases first.
 
 **Anti-pattern:**
+
 ```python
 def get_user(user_id: int) -> User | None:
     if user_id is not None:
@@ -75,6 +76,7 @@ def get_user(user_id: int) -> User | None:
 ```
 
 **Idiomatic:**
+
 ```python
 def get_user(user_id: int) -> User | None:
     if user_id is None or user_id <= 0:
@@ -97,6 +99,7 @@ def get_user(user_id: int) -> User | None:
 Declare variables close to where they're used.
 
 **Anti-pattern:**
+
 ```python
 def process_data() -> str:
     data = None
@@ -115,6 +118,7 @@ def process_data() -> str:
 ```
 
 **Idiomatic:**
+
 ```python
 def process_data() -> str:
     data = load_data()
@@ -135,6 +139,7 @@ def process_data() -> str:
 Named constants make code self-documenting.
 
 **Anti-pattern:**
+
 ```python
 def validate_password(password: str) -> bool:
     if len(password) < 8:
@@ -145,6 +150,7 @@ def validate_password(password: str) -> bool:
 ```
 
 **Idiomatic:**
+
 ```python
 MIN_PASSWORD_LENGTH = 8
 MAX_PASSWORD_LENGTH = 128
@@ -164,6 +170,7 @@ def validate_password(password: str) -> bool:
 Python's truthiness rules make code more readable.
 
 **Anti-pattern:**
+
 ```python
 if len(items) > 0:
     process(items)
@@ -176,6 +183,7 @@ if enabled == True:
 ```
 
 **Idiomatic:**
+
 ```python
 if items:
     process(items)
@@ -194,6 +202,7 @@ if enabled:
 Prefer built-in string methods over slicing.
 
 **Anti-pattern:**
+
 ```python
 if filename[-3:] == ".py":
     pass
@@ -203,6 +212,7 @@ if text[:5] == "http:":
 ```
 
 **Idiomatic:**
+
 ```python
 if filename.endswith(".py"):
     pass
@@ -222,6 +232,7 @@ if text.startswith("http:"):
 Never use bare `except:` or catch `Exception` without re-raising.
 
 **Anti-pattern:**
+
 ```python
 try:
     data = fetch_data()
@@ -232,6 +243,7 @@ except:
 ```
 
 **Idiomatic:**
+
 ```python
 try:
     data = fetch_data()
@@ -250,6 +262,7 @@ except ValueError as e:
 Context managers ensure proper cleanup.
 
 **Anti-pattern:**
+
 ```python
 def read_file(path: str) -> str:
     f = open(path)
@@ -259,6 +272,7 @@ def read_file(path: str) -> str:
 ```
 
 **Idiomatic:**
+
 ```python
 def read_file(path: str) -> str:
     with open(path) as f:
@@ -272,6 +286,7 @@ def read_file(path: str) -> str:
 Preserve the error chain when re-raising.
 
 **Anti-pattern:**
+
 ```python
 try:
     config = load_config(path)
@@ -280,6 +295,7 @@ except FileNotFoundError:
 ```
 
 **Idiomatic:**
+
 ```python
 try:
     config = load_config(path)
@@ -294,6 +310,7 @@ except FileNotFoundError as e:
 Only wrap the code that can raise the expected exception.
 
 **Anti-pattern:**
+
 ```python
 try:
     data = fetch_data()
@@ -305,6 +322,7 @@ except ConnectionError:
 ```
 
 **Idiomatic:**
+
 ```python
 try:
     data = fetch_data()
@@ -328,6 +346,7 @@ notify_users(result)
 List comprehensions are more readable and faster than loops for simple transformations.
 
 **Anti-pattern:**
+
 ```python
 squares = []
 for x in numbers:
@@ -335,6 +354,7 @@ for x in numbers:
 ```
 
 **Idiomatic:**
+
 ```python
 squares = [x ** 2 for x in numbers]
 ```
@@ -346,6 +366,7 @@ squares = [x ** 2 for x in numbers]
 If a comprehension has multiple `for` clauses or complex filters, use explicit loops.
 
 **Anti-pattern:**
+
 ```python
 result = [
     transform(x, y)
@@ -358,6 +379,7 @@ result = [
 ```
 
 **Idiomatic:**
+
 ```python
 result = []
 for outer in data:
@@ -376,6 +398,7 @@ for outer in data:
 Generators save memory by yielding items one at a time.
 
 **Anti-pattern:**
+
 ```python
 def read_large_file(path: str) -> list[str]:
     with open(path) as f:
@@ -383,6 +406,7 @@ def read_large_file(path: str) -> list[str]:
 ```
 
 **Idiomatic:**
+
 ```python
 def read_large_file(path: str) -> Iterator[str]:
     with open(path) as f:
@@ -397,6 +421,7 @@ def read_large_file(path: str) -> Iterator[str]:
 Mutable defaults are shared across calls.
 
 **Anti-pattern:**
+
 ```python
 def append_to(item, target=[]):  # Bug!
     target.append(item)
@@ -404,6 +429,7 @@ def append_to(item, target=[]):  # Bug!
 ```
 
 **Idiomatic:**
+
 ```python
 def append_to(item, target=None):
     if target is None:
@@ -419,6 +445,7 @@ def append_to(item, target=None):
 Leverage dict methods for cleaner code.
 
 **Anti-pattern:**
+
 ```python
 if key in d:
     value = d[key]
@@ -431,6 +458,7 @@ d[key].append(item)
 ```
 
 **Idiomatic:**
+
 ```python
 value = d.get(key, default)
 
@@ -444,6 +472,7 @@ d.setdefault(key, []).append(item)
 Don't manually track indices.
 
 **Anti-pattern:**
+
 ```python
 for i in range(len(items)):
     item = items[i]
@@ -451,6 +480,7 @@ for i in range(len(items)):
 ```
 
 **Idiomatic:**
+
 ```python
 for i, item in enumerate(items):
     process(i, item)
@@ -463,12 +493,14 @@ for i, item in enumerate(items):
 Iterate over multiple sequences together.
 
 **Anti-pattern:**
+
 ```python
 for i in range(len(names)):
     print(f"{names[i]}: {scores[i]}")
 ```
 
 **Idiomatic:**
+
 ```python
 for name, score in zip(names, scores):
     print(f"{name}: {score}")
@@ -485,6 +517,7 @@ for name, score in zip(names, scores):
 Type hints improve code clarity and enable static analysis.
 
 **Anti-pattern:**
+
 ```python
 def get_user(user_id):
     """Get a user by ID."""
@@ -492,6 +525,7 @@ def get_user(user_id):
 ```
 
 **Idiomatic:**
+
 ```python
 def get_user(user_id: int) -> User | None:
     """Get a user by ID."""
@@ -505,6 +539,7 @@ def get_user(user_id: int) -> User | None:
 Functions should do one thing well.
 
 **Anti-pattern:**
+
 ```python
 def process_user(user_id: int) -> None:
     user = fetch_user(user_id)
@@ -515,6 +550,7 @@ def process_user(user_id: int) -> None:
 ```
 
 **Idiomatic:**
+
 ```python
 def process_user(user_id: int) -> None:
     user = fetch_user(user_id)
@@ -534,6 +570,7 @@ def notify_user_update(user: User) -> None:
 Prevent positional argument confusion with keyword-only arguments.
 
 **Anti-pattern:**
+
 ```python
 def connect(host, port, timeout, use_ssl):
     pass
@@ -542,6 +579,7 @@ connect("localhost", 8080, 30, True)  # What is True?
 ```
 
 **Idiomatic:**
+
 ```python
 def connect(host: str, port: int, *, timeout: int = 30, use_ssl: bool = False):
     pass
@@ -556,6 +594,7 @@ connect("localhost", 8080, use_ssl=True)
 Avoid storing results in variables just to return them.
 
 **Anti-pattern:**
+
 ```python
 def get_status(user: User) -> str:
     if user.is_admin:
@@ -568,6 +607,7 @@ def get_status(user: User) -> str:
 ```
 
 **Idiomatic:**
+
 ```python
 def get_status(user: User) -> str:
     if user.is_admin:
@@ -588,6 +628,7 @@ def get_status(user: User) -> str:
 Dataclasses reduce boilerplate for simple classes.
 
 **Anti-pattern:**
+
 ```python
 class User:
     def __init__(self, id: int, name: str, email: str):
@@ -605,6 +646,7 @@ class User:
 ```
 
 **Idiomatic:**
+
 ```python
 from dataclasses import dataclass
 
@@ -622,6 +664,7 @@ class User:
 Properties provide a clean interface for computed values.
 
 **Anti-pattern:**
+
 ```python
 class Circle:
     def __init__(self, radius: float):
@@ -632,6 +675,7 @@ class Circle:
 ```
 
 **Idiomatic:**
+
 ```python
 class Circle:
     def __init__(self, radius: float):
@@ -659,6 +703,7 @@ class Circle:
 Protocols define interfaces without inheritance.
 
 **Anti-pattern:**
+
 ```python
 from abc import ABC, abstractmethod
 
@@ -673,6 +718,7 @@ class MyFile(Readable):  # Must inherit
 ```
 
 **Idiomatic:**
+
 ```python
 from typing import Protocol
 
@@ -694,6 +740,7 @@ def process(source: Readable) -> None:  # MyFile is compatible
 `__slots__` reduces memory usage for many instances.
 
 **Anti-pattern:**
+
 ```python
 class Point:
     def __init__(self, x: float, y: float):
@@ -702,6 +749,7 @@ class Point:
 ```
 
 **Idiomatic (for memory-critical cases):**
+
 ```python
 class Point:
     __slots__ = ('x', 'y')
@@ -722,12 +770,14 @@ class Point:
 f-strings are the fastest and most readable option.
 
 **Anti-pattern:**
+
 ```python
 message = "User %s logged in at %s" % (user.name, timestamp)
 message = "User {} logged in at {}".format(user.name, timestamp)
 ```
 
 **Idiomatic:**
+
 ```python
 message = f"User {user.name} logged in at {timestamp}"
 ```
@@ -739,6 +789,7 @@ message = f"User {user.name} logged in at {timestamp}"
 String concatenation in loops creates many intermediate strings.
 
 **Anti-pattern:**
+
 ```python
 def build_report(items: list[str]) -> str:
     report = ""
@@ -748,6 +799,7 @@ def build_report(items: list[str]) -> str:
 ```
 
 **Idiomatic:**
+
 ```python
 def build_report(items: list[str]) -> str:
     return "\n".join(f"- {item}" for item in items)
@@ -760,6 +812,7 @@ def build_report(items: list[str]) -> str:
 Built-in functions are clearer and often faster.
 
 **Anti-pattern:**
+
 ```python
 def has_valid_item(items: list[Item]) -> bool:
     for item in items:
@@ -769,6 +822,7 @@ def has_valid_item(items: list[Item]) -> bool:
 ```
 
 **Idiomatic:**
+
 ```python
 def has_valid_item(items: list[Item]) -> bool:
     return any(item.is_valid for item in items)
@@ -781,6 +835,7 @@ def has_valid_item(items: list[Item]) -> bool:
 defaultdict eliminates key existence checks.
 
 **Anti-pattern:**
+
 ```python
 groups = {}
 for item in items:
@@ -790,6 +845,7 @@ for item in items:
 ```
 
 **Idiomatic:**
+
 ```python
 from collections import defaultdict
 
@@ -805,6 +861,7 @@ for item in items:
 Counter simplifies counting.
 
 **Anti-pattern:**
+
 ```python
 counts = {}
 for item in items:
@@ -815,6 +872,7 @@ for item in items:
 ```
 
 **Idiomatic:**
+
 ```python
 from collections import Counter
 
@@ -832,6 +890,7 @@ counts = Counter(items)
 Decorators separate cross-cutting logic from business logic.
 
 **Anti-pattern:**
+
 ```python
 def get_user(user_id: int) -> User:
     start = time.perf_counter()
@@ -843,6 +902,7 @@ def get_user(user_id: int) -> User:
 ```
 
 **Idiomatic:**
+
 ```python
 import functools
 
@@ -869,6 +929,7 @@ def get_user(user_id: int) -> User:
 contextlib simplifies context manager creation.
 
 **Anti-pattern:**
+
 ```python
 class Timer:
     def __init__(self, name: str):
@@ -884,6 +945,7 @@ class Timer:
 ```
 
 **Idiomatic:**
+
 ```python
 from contextlib import contextmanager
 
@@ -904,6 +966,7 @@ def timer(name: str):
 Cache expensive function results.
 
 **Anti-pattern:**
+
 ```python
 _cache = {}
 
@@ -916,6 +979,7 @@ def expensive_computation(n: int) -> int:
 ```
 
 **Idiomatic:**
+
 ```python
 from functools import lru_cache
 
@@ -935,6 +999,7 @@ def expensive_computation(n: int) -> int:
 Python 3.10+ supports `|` for unions.
 
 **Anti-pattern:**
+
 ```python
 from typing import Optional, Union
 
@@ -946,6 +1011,7 @@ def process(value: Union[str, int]) -> None:
 ```
 
 **Idiomatic:**
+
 ```python
 def get_user(user_id: int) -> User | None:
     pass
@@ -961,12 +1027,14 @@ def process(value: str | int) -> None:
 TypeVar enables generic functions.
 
 **Anti-pattern:**
+
 ```python
 def first(items: list) -> Any:
     return items[0] if items else None
 ```
 
 **Idiomatic:**
+
 ```python
 from typing import TypeVar
 from collections.abc import Sequence
@@ -984,6 +1052,7 @@ def first(items: Sequence[T]) -> T | None:
 Type aliases improve readability for complex types.
 
 **Anti-pattern:**
+
 ```python
 def process(
     handlers: dict[str, Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]]
@@ -992,6 +1061,7 @@ def process(
 ```
 
 **Idiomatic:**
+
 ```python
 from typing import TypeAlias
 
@@ -1013,6 +1083,7 @@ def process(handlers: dict[str, Handler]) -> None:
 Google-style docstrings are clean and widely supported.
 
 **Anti-pattern:**
+
 ```python
 def get_user(user_id, include_inactive=False):
     """Get user by id. Returns None if not found."""
@@ -1020,6 +1091,7 @@ def get_user(user_id, include_inactive=False):
 ```
 
 **Idiomatic:**
+
 ```python
 def get_user(
     user_id: int,
@@ -1057,6 +1129,7 @@ def get_user(
 Comments should explain reasoning, not restate code.
 
 **Anti-pattern:**
+
 ```python
 # Increment counter by 1
 counter += 1
@@ -1067,6 +1140,7 @@ if user.is_active:
 ```
 
 **Idiomatic:**
+
 ```python
 # Rate limit: max 100 requests per minute per user
 counter += 1

--- a/agents/python-refactor/references/python-best-practices.md
+++ b/agents/python-refactor/references/python-best-practices.md
@@ -1185,7 +1185,7 @@ These patterns have tradeoffs:
 
 ---
 
-## Modern Python Ecosystem (2025)
+## Modern Python Ecosystem (2026)
 
 ### Import Organization
 
@@ -1207,22 +1207,22 @@ from myproject.utils import helper
 
 ### Development Tools
 
-| Tool | Purpose |
-|------|---------|
-| `ruff` | Fast linter and formatter (replaces flake8, isort, black) |
-| `mypy` | Static type checking |
-| `pytest` | Testing framework |
-| `uv` | Fast package management |
+| Tool     | Purpose                                                   |
+| -------- | --------------------------------------------------------- |
+| `ruff`   | Fast linter and formatter (replaces flake8, isort, black) |
+| `mypy`   | Static type checking                                      |
+| `pytest` | Testing framework                                         |
+| `uv`     | Fast package management                                   |
 
 ### Common Libraries
 
-| Category | Library | Notes |
-|----------|---------|-------|
-| HTTP | `httpx` | Modern async-capable HTTP client |
-| CLI | `typer` | Type-hint based CLI framework |
-| Data | `pydantic` | Data validation using type hints |
-| Async | `asyncio` | Standard async framework |
-| Web | `FastAPI` | Modern async web framework |
+| Category | Library    | Notes                            |
+| -------- | ---------- | -------------------------------- |
+| HTTP     | `httpx`    | Modern async-capable HTTP client |
+| CLI      | `typer`    | Type-hint based CLI framework    |
+| Data     | `pydantic` | Data validation using type hints |
+| Async    | `asyncio`  | Standard async framework         |
+| Web      | `FastAPI`  | Modern async web framework       |
 
 ---
 
@@ -1256,4 +1256,4 @@ When refactoring Python code, check for:
 
 ---
 
-*Last updated: 2026-01-19*
+_Last updated: 2026-01-19_

--- a/agents/python-refactor/system.md
+++ b/agents/python-refactor/system.md
@@ -1,6 +1,6 @@
 # IDENTITY and PURPOSE
 
-You are an expert Python developer specializing in refactoring code to be more idiomatic, maintainable, and aligned with Python best practices (2025). Your role is to transform provided Python code into cleaner, more Pythonic versions while preserving functionality and improving readability.
+You are an expert Python developer specializing in refactoring code to be more idiomatic, maintainable, and aligned with Python best practices (2026). Your role is to transform provided Python code into cleaner, more Pythonic versions while preserving functionality and improving readability.
 
 # KNOWLEDGE BASE
 

--- a/agents/python-review/README.md
+++ b/agents/python-review/README.md
@@ -5,6 +5,7 @@ A comprehensive fabric pattern for reviewing Python code against industry best p
 ## Pattern Structure
 
 This pattern includes:
+
 - **`system.md`** - The review framework and prompt engineering for LLM
 - **`python-review-criteria.md`** - Comprehensive reference document with detailed criteria (source of truth)
 - **`filter.sh`** - Post-processing to clean up output formatting
@@ -17,12 +18,14 @@ The pattern is designed with **separation of concerns**: the `python-review-crit
 ## Style Guide References
 
 This pattern incorporates guidelines from:
+
 - **[PEP 8](https://peps.python.org/pep-0008/)** - Python's official style guide
 - **[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)** - Google's enterprise Python standards
 
 ## Purpose
 
 This pattern helps you:
+
 - **Review code quality** against established best practices
 - **Identify issues** with severity classification (Critical, High, Medium, Low, Info)
 - **Provide constructive feedback** with specific examples and fixes
@@ -151,24 +154,29 @@ echo "Code review passed!"
 The pattern generates a structured markdown report with:
 
 ### Summary
+
 - 2-3 sentence overview of code quality
 - Main concerns highlighted
 
 ### Critical Issues
+
 - Must-fix items affecting correctness or safety
 - Code snippets showing problem and solution
 - Clear explanation with references to PEP 8/Google Style Guide
 
 ### Improvements
+
 - Non-critical enhancements
 - Best practice suggestions
 - Performance optimizations
 
 ### Positive Observations
+
 - Good practices already implemented
 - Recognition of well-written code
 
 ### Recommendations
+
 - General suggestions for improvement
 - Tooling recommendations
 
@@ -197,6 +205,7 @@ def get_user(user_id: str) -> User:
 ```
 
 **Solution:**
+
 ```python
 def get_user(user_id: str) -> User:
     query = "SELECT * FROM users WHERE id = %s"
@@ -215,6 +224,7 @@ Use parameterized queries per Google Python Style Guide security guidelines.
 **Impact:** Shared mutable state causes unexpected behavior
 
 **Problem:**
+
 ```python
 def append_item(item, items=[]):
     items.append(item)
@@ -222,6 +232,7 @@ def append_item(item, items=[]):
 ```
 
 **Solution:**
+
 ```python
 def append_item(item, items=None):
     if items is None:
@@ -242,6 +253,7 @@ def append_item(item, items=None):
 **Category:** Code Structure
 
 **Current:**
+
 ```python
 if user is not None:
     if user.is_active:
@@ -249,6 +261,7 @@ if user is not None:
 ```
 
 **Suggested:**
+
 ```python
 if user is None:
     return
@@ -273,6 +286,7 @@ process(user)
 - Add mypy to CI pipeline for static type checking
 - Consider using pytest parametrize for test cases
 - Add ruff for automated linting and formatting
+
 ```
 
 ## Customization
@@ -310,6 +324,7 @@ Edit the `# OUTPUT FORMAT` section in `system.md` to customize the report struct
 ### Issue: Too many findings
 
 **Solution:** Focus on critical and high severity issues first:
+
 ```bash
 cat myfile.py | fabric --pattern python-review | grep -A 20 "## Critical Issues"
 ```

--- a/agents/python-review/agent.yaml
+++ b/agents/python-review/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: python-review
 version: 0.1.0
 description: Review Python code for correctness, performance, and maintainability, and apply fixes.

--- a/agents/python-review/references/python-review-criteria.md
+++ b/agents/python-review/references/python-review-criteria.md
@@ -35,6 +35,7 @@ Prefer clear, explicit code over magic or implicit behavior that requires deep u
 Choose straightforward solutions. If something is hard to explain, it's probably too complex.
 
 **Constructive Feedback**
+
 - Be educational, not critical
 - Explain the "why" behind suggestions
 - Provide concrete examples with code
@@ -83,6 +84,7 @@ from myproject.models import User
 ```
 
 **Rules:**
+
 - One import per line for regular imports
 - Multiple items OK for `from x import y, z`
 - Absolute imports preferred over relative imports
@@ -107,11 +109,13 @@ from myproject.models import User
 | Private | `__double_underscore` | `__name_mangled` |
 
 **Google Style Additions:**
+
 - Avoid single-character names except for counters (`i`, `j`, `k`) and exceptions (`e`)
 - Don't encode type information in names: `names` not `names_list`
 - Avoid dashes in module names
 
 **Good:**
+
 ```python
 def calculate_total_price(items: list[Item]) -> float:
     pass
@@ -124,6 +128,7 @@ class UserRepository:
 ```
 
 **Bad:**
+
 ```python
 def CalcTotalPrice(itemsList):  # Wrong case, type in name
     pass
@@ -135,6 +140,7 @@ class user_repository:  # Should be CapWords
 ### Whitespace Rules (PEP 8)
 
 **Good:**
+
 ```python
 spam(ham[1], {eggs: 2})
 x = 1
@@ -146,6 +152,7 @@ def complex(real, imag=0.0):
 ```
 
 **Bad:**
+
 ```python
 spam( ham[ 1 ], { eggs: 2 } )  # Extra whitespace
 x             = 1  # Aligned equals
@@ -158,6 +165,7 @@ def complex(real, imag = 0.0):  # Space around = in default
 ### Line Continuation
 
 **Preferred - implicit continuation:**
+
 ```python
 # Aligned with opening delimiter
 result = function_name(arg_one, arg_two,
@@ -192,6 +200,7 @@ income = (gross_wages
 ### Exception Patterns
 
 **Good:**
+
 ```python
 try:
     value = collection[key]
@@ -200,6 +209,7 @@ except KeyError as e:
 ```
 
 **Bad:**
+
 ```python
 try:
     # Too much code in try block
@@ -213,6 +223,7 @@ except:  # Bare except - catches everything including SystemExit
 ### Resource Cleanup
 
 **Use context managers:**
+
 ```python
 # Good
 with open(filename) as f:
@@ -224,6 +235,7 @@ with open(input_file) as fin, open(output_file, 'w') as fout:
 ```
 
 **Custom cleanup:**
+
 ```python
 # Good - contextlib for cleanup
 from contextlib import contextmanager
@@ -240,6 +252,7 @@ def managed_resource():
 ### Exception Design
 
 **Good:**
+
 ```python
 class ValidationError(Exception):
     """Raised when validation fails."""
@@ -250,6 +263,7 @@ class ValidationError(Exception):
 ```
 
 **Raising exceptions:**
+
 ```python
 # Good - specific exception with context
 if not user.is_active:
@@ -271,7 +285,7 @@ except FileNotFoundError as e:
 | Check | Severity | Rationale |
 |-------|----------|-----------|
 | Annotate public APIs | HIGH | Documentation and tooling |
-| Use `X | None` not `Optional[X]` (3.10+) | LOW | Modern syntax |
+| Use `X \| None` not `Optional[X]` (3.10+) | LOW | Modern syntax |
 | Annotate complex functions | MEDIUM | Clarity |
 | Import types correctly | MEDIUM | Avoid runtime overhead |
 
@@ -327,11 +341,13 @@ def first_or_none(items: Sequence[T]) -> T | None:
 ### Comprehensions (Google Style)
 
 **Rules:**
+
 - Use for simple transformations
 - Avoid multiple `for` clauses or complex filter expressions
 - Keep readable - if hard to understand, use a loop
 
 **Good:**
+
 ```python
 # Simple comprehension
 squares = [x * x for x in numbers]
@@ -344,6 +360,7 @@ user_map = {u.id: u for u in users}
 ```
 
 **Bad:**
+
 ```python
 # Too complex - use explicit loop
 result = [
@@ -368,6 +385,7 @@ first_match = next((x for x in items if predicate(x)), None)
 ### Mutability Concerns
 
 **Critical - mutable default arguments:**
+
 ```python
 # Bad - shared mutable default
 def append_to(item, target=[]):  # Bug!
@@ -383,6 +401,7 @@ def append_to(item, target=None):
 ```
 
 **Defensive copying:**
+
 ```python
 class DataHolder:
     def __init__(self, items: list[str]) -> None:
@@ -400,11 +419,13 @@ class DataHolder:
 ### Function Guidelines
 
 **Google Style - keep functions small and focused:**
+
 - Prefer functions under 40 lines
 - Single responsibility principle
 - Limit parameters (consider dataclass/dict for many args)
 
 **Good:**
+
 ```python
 def calculate_order_total(
     items: list[OrderItem],
@@ -465,6 +486,7 @@ class UserService:
 ### Properties (Google Style)
 
 Use properties when:
+
 - Access is cheap and straightforward
 - No side effects expected
 - Behavior is obvious from the name
@@ -497,6 +519,7 @@ class Circle:
 ### Early Returns
 
 **Good:**
+
 ```python
 def process_user(user: User | None) -> Result:
     if user is None:
@@ -513,6 +536,7 @@ def process_user(user: User | None) -> Result:
 ```
 
 **Bad - deep nesting:**
+
 ```python
 def process_user(user: User | None) -> Result:
     if user is not None:
@@ -530,6 +554,7 @@ def process_user(user: User | None) -> Result:
 ### Boolean Checks (PEP 8, Google Style)
 
 **Good:**
+
 ```python
 # Use truthiness for sequences
 if items:  # Not: if len(items) > 0
@@ -643,6 +668,7 @@ def copy_data(source: Readable, dest: Writable) -> int:
 | `+` in loop | Slow | Avoid |
 
 **Good:**
+
 ```python
 # f-strings for formatting
 message = f"User {user.name} logged in at {timestamp}"
@@ -656,6 +682,7 @@ logger.debug("Processing user %s", user_id)
 ```
 
 **Bad:**
+
 ```python
 # String concatenation in loop
 result = ""
@@ -753,6 +780,7 @@ if __name__ == '__main__':
 | Prefix internal globals with `_` | MEDIUM | Clear intent |
 
 **Good:**
+
 ```python
 # Constants are fine
 MAX_CONNECTIONS = 100
@@ -875,6 +903,7 @@ def process_username(username: str) -> str:
 ### SQL Queries
 
 **Good:**
+
 ```python
 # Parameterized query
 cursor.execute(
@@ -887,6 +916,7 @@ user = session.query(User).filter(User.id == user_id).first()
 ```
 
 **Bad:**
+
 ```python
 # SQL injection vulnerability!
 cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
@@ -896,6 +926,7 @@ cursor.execute("SELECT * FROM users WHERE name = '%s'" % name)
 ### Subprocess Security
 
 **Good:**
+
 ```python
 # shell=False with list arguments
 subprocess.run(["git", "status"], check=True)
@@ -910,6 +941,7 @@ result = subprocess.run(
 ```
 
 **Bad:**
+
 ```python
 # Command injection vulnerability!
 subprocess.run(f"git clone {url}", shell=True)
@@ -934,6 +966,7 @@ api_key = secrets_file.read_text().strip()
 ```
 
 **Bad:**
+
 ```python
 # Hardcoded secrets
 API_KEY = "sk-1234567890abcdef"  # Never do this!
@@ -1023,6 +1056,7 @@ class TestUserService:
 ### CRITICAL
 
 Issues that affect correctness, security, or cause crashes:
+
 - SQL injection vulnerabilities
 - Command injection vulnerabilities
 - Bare `except:` clauses
@@ -1033,6 +1067,7 @@ Issues that affect correctness, security, or cause crashes:
 ### HIGH
 
 Significant issues affecting reliability or maintainability:
+
 - Missing type annotations on public APIs
 - Poor error handling
 - Resource leaks (unclosed files, connections)
@@ -1042,6 +1077,7 @@ Significant issues affecting reliability or maintainability:
 ### MEDIUM
 
 Best practice violations:
+
 - PEP 8 style violations
 - Google Style Guide violations
 - Missing docstrings
@@ -1052,6 +1088,7 @@ Best practice violations:
 ### LOW
 
 Minor improvements:
+
 - Import ordering
 - Whitespace issues
 - Comment quality
@@ -1061,6 +1098,7 @@ Minor improvements:
 ### INFO
 
 Suggestions for optimization:
+
 - Performance improvements
 - Alternative patterns
 - Tooling recommendations

--- a/agents/python-review/references/python-review-criteria.md
+++ b/agents/python-review/references/python-review-criteria.md
@@ -55,14 +55,14 @@ Choose straightforward solutions. If something is hard to explain, it's probably
 
 ### PEP 8 Mandatory Checks
 
-| Check | Severity | Reference |
-|-------|----------|-----------|
-| 4 spaces per indentation level | HIGH | PEP 8 |
-| Maximum 79 characters per line | MEDIUM | PEP 8 |
-| Maximum 72 characters for docstrings/comments | LOW | PEP 8 |
-| Two blank lines around top-level definitions | MEDIUM | PEP 8 |
-| One blank line between methods | MEDIUM | PEP 8 |
-| No trailing whitespace | LOW | PEP 8 |
+| Check                                         | Severity | Reference |
+| --------------------------------------------- | -------- | --------- |
+| 4 spaces per indentation level                | HIGH     | PEP 8     |
+| Maximum 79 characters per line                | MEDIUM   | PEP 8     |
+| Maximum 72 characters for docstrings/comments | LOW      | PEP 8     |
+| Two blank lines around top-level definitions  | MEDIUM   | PEP 8     |
+| One blank line between methods                | MEDIUM   | PEP 8     |
+| No trailing whitespace                        | LOW      | PEP 8     |
 
 ### Import Organization
 
@@ -95,18 +95,18 @@ from myproject.models import User
 
 **PEP 8 Naming:**
 
-| Type | Convention | Example |
-|------|------------|---------|
-| Modules | `lowercase_underscore` | `user_service.py` |
-| Packages | `lowercase` | `mypackage` |
-| Classes | `CapWords` | `UserService` |
-| Exceptions | `CapWords` + `Error` suffix | `ValidationError` |
-| Functions | `lowercase_underscore` | `get_user()` |
-| Methods | `lowercase_underscore` | `calculate_total()` |
-| Constants | `UPPER_CASE_UNDERSCORE` | `MAX_RETRIES` |
-| Variables | `lowercase_underscore` | `user_count` |
-| Protected | `_single_underscore` | `_internal_value` |
-| Private | `__double_underscore` | `__name_mangled` |
+| Type       | Convention                  | Example             |
+| ---------- | --------------------------- | ------------------- |
+| Modules    | `lowercase_underscore`      | `user_service.py`   |
+| Packages   | `lowercase`                 | `mypackage`         |
+| Classes    | `CapWords`                  | `UserService`       |
+| Exceptions | `CapWords` + `Error` suffix | `ValidationError`   |
+| Functions  | `lowercase_underscore`      | `get_user()`        |
+| Methods    | `lowercase_underscore`      | `calculate_total()` |
+| Constants  | `UPPER_CASE_UNDERSCORE`     | `MAX_RETRIES`       |
+| Variables  | `lowercase_underscore`      | `user_count`        |
+| Protected  | `_single_underscore`        | `_internal_value`   |
+| Private    | `__double_underscore`       | `__name_mangled`    |
 
 **Google Style Additions:**
 
@@ -189,13 +189,13 @@ income = (gross_wages
 
 ### Critical Rules
 
-| Rule | Severity | Reference |
-|------|----------|-----------|
-| Never use bare `except:` | CRITICAL | PEP 8, Google |
-| Catch specific exceptions | HIGH | Google Style |
-| Minimize code in try block | HIGH | Google Style |
-| Use `finally` for cleanup | MEDIUM | Google Style |
-| Use `raise X from Y` for chaining | MEDIUM | PEP 8 |
+| Rule                              | Severity | Reference     |
+| --------------------------------- | -------- | ------------- |
+| Never use bare `except:`          | CRITICAL | PEP 8, Google |
+| Catch specific exceptions         | HIGH     | Google Style  |
+| Minimize code in try block        | HIGH     | Google Style  |
+| Use `finally` for cleanup         | MEDIUM   | Google Style  |
+| Use `raise X from Y` for chaining | MEDIUM   | PEP 8         |
 
 ### Exception Patterns
 
@@ -282,12 +282,12 @@ except FileNotFoundError as e:
 
 ### Guidelines (Google Style, PEP 484)
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| Annotate public APIs | HIGH | Documentation and tooling |
-| Use `X \| None` not `Optional[X]` (3.10+) | LOW | Modern syntax |
-| Annotate complex functions | MEDIUM | Clarity |
-| Import types correctly | MEDIUM | Avoid runtime overhead |
+| Check                                     | Severity | Rationale                 |
+| ----------------------------------------- | -------- | ------------------------- |
+| Annotate public APIs                      | HIGH     | Documentation and tooling |
+| Use `X \| None` not `Optional[X]` (3.10+) | LOW      | Modern syntax             |
+| Annotate complex functions                | MEDIUM   | Clarity                   |
+| Import types correctly                    | MEDIUM   | Avoid runtime overhead    |
 
 ### Basic Annotations
 
@@ -660,12 +660,12 @@ def copy_data(source: Readable, dest: Writable) -> int:
 
 ### String Operations
 
-| Pattern | Performance | Use Case |
-|---------|-------------|----------|
-| f-strings | Fastest | Simple formatting |
-| `str.join()` | Fast | Multiple concatenations |
-| `%` formatting | Medium | Logging with deferred evaluation |
-| `+` in loop | Slow | Avoid |
+| Pattern        | Performance | Use Case                         |
+| -------------- | ----------- | -------------------------------- |
+| f-strings      | Fastest     | Simple formatting                |
+| `str.join()`   | Fast        | Multiple concatenations          |
+| `%` formatting | Medium      | Logging with deferred evaluation |
+| `+` in loop    | Slow        | Avoid                            |
 
 **Good:**
 
@@ -773,11 +773,11 @@ if __name__ == '__main__':
 
 ### Global Variables
 
-| Check | Severity | Rationale |
-|-------|----------|-----------|
-| Avoid mutable global state | HIGH | Testing difficulty |
-| Constants are acceptable | LOW | Immutable values |
-| Prefix internal globals with `_` | MEDIUM | Clear intent |
+| Check                            | Severity | Rationale          |
+| -------------------------------- | -------- | ------------------ |
+| Avoid mutable global state       | HIGH     | Testing difficulty |
+| Constants are acceptable         | LOW      | Immutable values   |
+| Prefix internal globals with `_` | MEDIUM   | Clear intent       |
 
 **Good:**
 
@@ -864,12 +864,12 @@ class UserRepository:
 
 ### Comment Quality
 
-| Rule | Severity |
-|------|----------|
-| Document "why", not "what" | MEDIUM |
-| Keep comments updated | HIGH |
-| No commented-out code | LOW |
-| Use TODO format: `# TODO(username): description` | LOW |
+| Rule                                             | Severity |
+| ------------------------------------------------ | -------- |
+| Document "why", not "what"                       | MEDIUM   |
+| Keep comments updated                            | HIGH     |
+| No commented-out code                            | LOW      |
+| Use TODO format: `# TODO(username): description` | LOW      |
 
 ---
 
@@ -877,13 +877,13 @@ class UserRepository:
 
 ### Critical Checks
 
-| Check | Severity | Impact |
-|-------|----------|--------|
-| Input validation | CRITICAL | Injection attacks |
-| SQL parameterization | CRITICAL | SQL injection |
-| Subprocess shell=False | CRITICAL | Command injection |
-| Secret management | CRITICAL | Credential exposure |
-| HTTPS verification | HIGH | MITM attacks |
+| Check                  | Severity | Impact              |
+| ---------------------- | -------- | ------------------- |
+| Input validation       | CRITICAL | Injection attacks   |
+| SQL parameterization   | CRITICAL | SQL injection       |
+| Subprocess shell=False | CRITICAL | Command injection   |
+| Secret management      | CRITICAL | Credential exposure |
+| HTTPS verification     | HIGH     | MITM attacks        |
 
 ### Input Validation
 
@@ -978,22 +978,22 @@ API_KEY = "sk-1234567890abcdef"  # Never do this!
 
 ### Coverage Expectations
 
-| Type | Target | Priority |
-|------|--------|----------|
-| Unit tests | 80%+ | HIGH |
-| Integration tests | Critical paths | MEDIUM |
-| Property tests | Edge cases | LOW |
+| Type              | Target         | Priority |
+| ----------------- | -------------- | -------- |
+| Unit tests        | 80%+           | HIGH     |
+| Integration tests | Critical paths | MEDIUM   |
+| Property tests    | Edge cases     | LOW      |
 
-### Testing Tools (2025)
+### Testing Tools (2026)
 
-| Tool | Use Case |
-|------|----------|
-| `pytest` | Primary test framework |
-| `pytest-cov` | Coverage reporting |
-| `pytest-mock` | Mocking support |
-| `hypothesis` | Property-based testing |
-| `mypy` | Static type checking |
-| `ruff` | Linting and formatting |
+| Tool          | Use Case               |
+| ------------- | ---------------------- |
+| `pytest`      | Primary test framework |
+| `pytest-cov`  | Coverage reporting     |
+| `pytest-mock` | Mocking support        |
+| `hypothesis`  | Property-based testing |
+| `mypy`        | Static type checking   |
+| `ruff`        | Linting and formatting |
 
 ### Test Quality
 
@@ -1142,4 +1142,4 @@ Suggestions for optimization:
 
 ---
 
-*Last updated: 2026-01-18*
+_Last updated: 2026-01-18_

--- a/agents/python-review/system.md
+++ b/agents/python-review/system.md
@@ -87,12 +87,14 @@ Structure your review with clear sections:
 **Impact:** [Why it matters]
 
 **Problem:**
+
 ```python
 # Current code
 [problematic code snippet]
 ```
 
 **Solution:**
+
 ```python
 # Suggested fix
 [improved code snippet]
@@ -110,11 +112,13 @@ Structure your review with clear sections:
 **Category:** [category]
 
 **Current:**
+
 ```python
 [current approach]
 ```
 
 **Suggested:**
+
 ```python
 [better approach]
 ```

--- a/agents/python-review/system.md
+++ b/agents/python-review/system.md
@@ -1,6 +1,6 @@
 # IDENTITY and PURPOSE
 
-You are an expert Python code reviewer with deep knowledge of idiomatic Python patterns, best practices, and modern ecosystem standards (2025). Your role is to analyze Python code and provide constructive feedback focused on improving code quality, maintainability, and adherence to Python community conventions.
+You are an expert Python code reviewer with deep knowledge of idiomatic Python patterns, best practices, and modern ecosystem standards (2026). Your role is to analyze Python code and provide constructive feedback focused on improving code quality, maintainability, and adherence to Python community conventions.
 
 # KNOWLEDGE BASE
 

--- a/agents/python-tests/README.md
+++ b/agents/python-tests/README.md
@@ -149,6 +149,7 @@ Edit `system.md` to change the test generation behavior or add specific constrai
 ### Tests don't run
 
 Ensure pytest is installed:
+
 ```bash
 pip install pytest
 ```

--- a/agents/python-tests/agent.yaml
+++ b/agents/python-tests/agent.yaml
@@ -1,3 +1,4 @@
+---
 name: python-tests
 version: 0.1.0
 description: Create or improve Python tests and validate behavior with pytest or unittest.

--- a/agents/python-tests/references/python-testing-patterns.md
+++ b/agents/python-tests/references/python-testing-patterns.md
@@ -57,6 +57,7 @@ def test_double_with_ids(input_val, expected):
 ### When to Use Parametrized Tests
 
 **Good for:**
+
 - Functions with multiple valid inputs and outputs
 - Validation logic with many cases
 - Mathematical operations
@@ -64,6 +65,7 @@ def test_double_with_ids(input_val, expected):
 - Boundary testing
 
 **When not needed:**
+
 - Single test case with unique setup
 - Tests requiring different assertions
 - Complex integration scenarios
@@ -126,12 +128,14 @@ def database_connection():
 ### When to Use Fixtures
 
 **Good for:**
+
 - Object creation used by multiple tests
 - Resource setup and teardown
 - Sharing state within a scope
 - Parameterized setup
 
 **When not needed:**
+
 - Simple inline setup
 - One-off test data
 - When it obscures test clarity
@@ -277,6 +281,7 @@ def test_retry_on_failure(mocker):
 ### When to Mock
 
 **Good for:**
+
 - External API calls
 - Database operations
 - File system operations
@@ -285,6 +290,7 @@ def test_retry_on_failure(mocker):
 - Environment variables
 
 **When NOT to mock:**
+
 - Simple data classes
 - Standard library functions (usually)
 - Internal implementation details

--- a/cmd/squad/completion.go
+++ b/cmd/squad/completion.go
@@ -22,7 +22,11 @@ THE SOFTWARE.
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 var completionCmd = &cobra.Command{
 	Use:   "completion [bash|zsh|fish|powershell]",
@@ -49,7 +53,7 @@ Examples:
 		case "powershell":
 			return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
 		default:
-			return nil
+			return fmt.Errorf("unsupported shell type: %s", args[0])
 		}
 	},
 }

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -23,7 +23,7 @@ THE SOFTWARE.
 package main
 
 import (
-	"fmt" 
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +63,7 @@ This will create an XDG-compliant config file at:
 If a legacy config exists at ~/.squad/config.yaml, you'll be notified.
 If the file already exists, it will be overwritten only with --force.`,
 	RunE: runConfigInit,
+	Args: cobra.NoArgs,
 }
 
 var configShowCmd = &cobra.Command{
@@ -76,12 +77,14 @@ This shows the effective configuration after merging:
 - Environment variables
 - CLI flag overrides`,
 	RunE: runConfigShow,
+	Args: cobra.NoArgs,
 }
 
 var configPathCmd = &cobra.Command{
 	Use:   "path",
 	Short: "Show configuration file path",
 	RunE:  runConfigPath,
+	Args:  cobra.NoArgs,
 }
 
 var configSetCmd = &cobra.Command{

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -23,7 +23,7 @@ THE SOFTWARE.
 package main
 
 import (
-	"fmt"
+	"fmt" 
 	"os"
 	"path/filepath"
 	"strings"

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -197,8 +197,8 @@ func runConfigPath(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get config path: %w", err)
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), path)
-	return nil
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), path)
+	return err
 }
 
 func runConfigSet(cmd *cobra.Command, args []string) error {
@@ -273,6 +273,6 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("key not found: %s", args[0])
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), value)
-	return nil
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), value)
+	return err
 }

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -222,8 +222,13 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 
 	v.Set(args[0], args[1])
 
-	updated := v.AllSettings()
-	out, err := yaml.Marshal(updated)
+	// Unmarshal back into typed config to preserve structure and tags
+	var newCfg config.Config
+	if err := v.Unmarshal(&newCfg); err != nil {
+		return fmt.Errorf("failed to unmarshal updated config: %w", err)
+	}
+
+	out, err := yaml.Marshal(&newCfg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal updated config: %w", err)
 	}

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -36,8 +36,9 @@ import (
 )
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Manage squad configuration",
+	Use:     "config",
+	Aliases: []string{"cfg"},
+	Short:   "Manage squad configuration",
 	Long: `Manage squad's global configuration file.
 
 Configuration locations (searched in order):
@@ -115,8 +116,6 @@ Examples:
 	RunE: runConfigGet,
 }
 
-var configForce bool
-
 func init() {
 	configCmd.AddCommand(configInitCmd)
 	configCmd.AddCommand(configShowCmd)
@@ -124,7 +123,7 @@ func init() {
 	configCmd.AddCommand(configSetCmd)
 	configCmd.AddCommand(configGetCmd)
 
-	configInitCmd.Flags().BoolVarP(&configForce, "force", "f", false, "Overwrite existing config file")
+	configInitCmd.Flags().BoolP("force", "f", false, "Overwrite existing config file")
 }
 
 func runConfigInit(cmd *cobra.Command, args []string) error {
@@ -135,7 +134,8 @@ func runConfigInit(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 	if _, err := os.Stat(configPath); err == nil {
-		if !configForce {
+		force, _ := cmd.Flags().GetBool("force")
+		if !force {
 			return fmt.Errorf("config file already exists at %s (use --force to overwrite)", configPath)
 		}
 		logging.WarnContext(ctx, "Overwriting existing config file at %s", configPath)
@@ -161,6 +161,9 @@ func runConfigInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
 	if err := os.WriteFile(configPath, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
@@ -220,7 +223,11 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config into viper: %w", err)
 	}
 
-	v.Set(args[0], args[1])
+	var value any
+	if err := yaml.Unmarshal([]byte(args[1]), &value); err != nil {
+		return fmt.Errorf("failed to parse value: %w", err)
+	}
+	v.Set(args[0], value)
 
 	// Unmarshal back into typed config to preserve structure and tags
 	var newCfg config.Config
@@ -233,6 +240,9 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to marshal updated config: %w", err)
 	}
 
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
 	if err := os.WriteFile(configPath, out, 0o644); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}

--- a/cmd/squad/ollama.go
+++ b/cmd/squad/ollama.go
@@ -51,7 +51,12 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 	if err != nil {
 		return nil, err
 	}
-	tools := convertTools(opts.Tools)
+	// Ollama has no tool_choice parameter. When tool_choice is "none",
+	// omit tools entirely so the model cannot call them.
+	var tools []ollamaTool
+	if fmt.Sprintf("%v", opts.ToolChoice) != "none" {
+		tools = convertTools(opts.Tools)
+	}
 
 	reqBody := ollamaChatRequest{
 		Model:    o.model,

--- a/cmd/squad/ollama.go
+++ b/cmd/squad/ollama.go
@@ -47,7 +47,10 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 		opt(&opts)
 	}
 
-	chatMsgs := convertMessages(messages)
+	chatMsgs, err := convertMessages(messages)
+	if err != nil {
+		return nil, err
+	}
 	tools := convertTools(opts.Tools)
 
 	reqBody := ollamaChatRequest{
@@ -143,7 +146,7 @@ type ollamaChatResponse struct {
 
 // --- Conversion helpers ---
 
-func convertMessages(messages []llms.MessageContent) []ollamaMessage {
+func convertMessages(messages []llms.MessageContent) ([]ollamaMessage, error) {
 	out := make([]ollamaMessage, 0, len(messages))
 	for _, mc := range messages {
 		msg := ollamaMessage{Role: lcRoleToOllama(mc.Role)}
@@ -153,9 +156,11 @@ func convertMessages(messages []llms.MessageContent) []ollamaMessage {
 			case llms.TextContent:
 				msg.Content = pt.Text
 			case llms.ToolCall:
-				var args map[string]any
 				if pt.FunctionCall != nil {
-					_ = json.Unmarshal([]byte(pt.FunctionCall.Arguments), &args)
+					var args map[string]any
+					if err := json.Unmarshal([]byte(pt.FunctionCall.Arguments), &args); err != nil {
+						return nil, fmt.Errorf("failed to unmarshal tool call %q arguments: %w", pt.FunctionCall.Name, err)
+					}
 					msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
 						Function: ollamaFunctionCall{
 							Name:      pt.FunctionCall.Name,
@@ -164,14 +169,13 @@ func convertMessages(messages []llms.MessageContent) []ollamaMessage {
 					})
 				}
 			case llms.ToolCallResponse:
-				// Ollama expects tool results as role=tool messages with content
 				msg.Role = "tool"
 				msg.Content = pt.Content
 			}
 		}
 		out = append(out, msg)
 	}
-	return out
+	return out, nil
 }
 
 func convertTools(tools []llms.Tool) []ollamaTool {

--- a/cmd/squad/ollama.go
+++ b/cmd/squad/ollama.go
@@ -54,7 +54,7 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 	// Ollama has no tool_choice parameter. When tool_choice is "none",
 	// omit tools entirely so the model cannot call them.
 	var tools []ollamaTool
-	if fmt.Sprintf("%v", opts.ToolChoice) != "none" {
+	if opts.ToolChoice != "none" {
 		tools = convertTools(opts.Tools)
 	}
 
@@ -64,9 +64,11 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 		Tools:    tools,
 		Stream:   false,
 		Options: map[string]any{
-			"num_ctx":     o.numCtx,
-			"temperature": opts.Temperature,
+			"num_ctx": o.numCtx,
 		},
+	}
+	if opts.Temperature != 0 {
+		reqBody.Options["temperature"] = opts.Temperature
 	}
 	if opts.MaxTokens > 0 {
 		reqBody.Options["num_predict"] = opts.MaxTokens
@@ -159,7 +161,7 @@ func convertMessages(messages []llms.MessageContent) ([]ollamaMessage, error) {
 		for _, p := range mc.Parts {
 			switch pt := p.(type) {
 			case llms.TextContent:
-				msg.Content = pt.Text
+				msg.Content += pt.Text
 			case llms.ToolCall:
 				if pt.FunctionCall != nil {
 					var args map[string]any

--- a/cmd/squad/ollama.go
+++ b/cmd/squad/ollama.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// ollamaLLM implements llms.Model using Ollama's native /api/chat endpoint,
+// which supports both tool calling and the num_ctx parameter. The langchaingo
+// llms/ollama package does not support tool calls, and the OpenAI-compat
+// endpoint silently truncates to 4096 tokens.
+type ollamaLLM struct {
+	serverURL string
+	model     string
+	numCtx    int
+}
+
+// Verify interface compliance.
+var _ llms.Model = (*ollamaLLM)(nil)
+
+func newOllamaLLM(serverURL, model string, numCtx int) *ollamaLLM {
+	serverURL = strings.TrimSuffix(serverURL, "/v1")
+	serverURL = strings.TrimSuffix(serverURL, "/")
+	return &ollamaLLM{
+		serverURL: serverURL,
+		model:     model,
+		numCtx:    numCtx,
+	}
+}
+
+// Call implements the simple string-based call interface.
+func (o *ollamaLLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	return llms.GenerateFromSinglePrompt(ctx, o, prompt, options...)
+}
+
+// GenerateContent implements llms.Model via Ollama's native /api/chat endpoint.
+func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	opts := llms.CallOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	chatMsgs := convertMessages(messages)
+	tools := convertTools(opts.Tools)
+
+	reqBody := ollamaChatRequest{
+		Model:    o.model,
+		Messages: chatMsgs,
+		Tools:    tools,
+		Stream:   false,
+		Options: map[string]any{
+			"num_ctx":     o.numCtx,
+			"temperature": opts.Temperature,
+		},
+	}
+	if opts.MaxTokens > 0 {
+		reqBody.Options["num_predict"] = opts.MaxTokens
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ollama request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.serverURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ollama request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ollama response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var chatResp ollamaChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("failed to parse ollama response: %w", err)
+	}
+
+	return convertResponse(chatResp), nil
+}
+
+// --- Ollama native API types ---
+
+type ollamaChatRequest struct {
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Tools    []ollamaTool    `json:"tools,omitempty"`
+	Stream   bool            `json:"stream"`
+	Options  map[string]any  `json:"options,omitempty"`
+}
+
+type ollamaMessage struct {
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
+	ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
+}
+
+type ollamaToolCall struct {
+	Function ollamaFunctionCall `json:"function"`
+}
+
+type ollamaFunctionCall struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type ollamaTool struct {
+	Type     string             `json:"type"`
+	Function ollamaToolFunction `json:"function"`
+}
+
+type ollamaToolFunction struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Parameters  any    `json:"parameters"`
+}
+
+type ollamaChatResponse struct {
+	Model           string         `json:"model"`
+	Message         *ollamaMessage `json:"message,omitempty"`
+	Done            bool           `json:"done"`
+	PromptEvalCount int            `json:"prompt_eval_count,omitempty"`
+	EvalCount       int            `json:"eval_count,omitempty"`
+}
+
+// --- Conversion helpers ---
+
+func convertMessages(messages []llms.MessageContent) []ollamaMessage {
+	out := make([]ollamaMessage, 0, len(messages))
+	for _, mc := range messages {
+		msg := ollamaMessage{Role: lcRoleToOllama(mc.Role)}
+
+		for _, p := range mc.Parts {
+			switch pt := p.(type) {
+			case llms.TextContent:
+				msg.Content = pt.Text
+			case llms.ToolCall:
+				var args map[string]any
+				if pt.FunctionCall != nil {
+					_ = json.Unmarshal([]byte(pt.FunctionCall.Arguments), &args)
+					msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
+						Function: ollamaFunctionCall{
+							Name:      pt.FunctionCall.Name,
+							Arguments: args,
+						},
+					})
+				}
+			case llms.ToolCallResponse:
+				// Ollama expects tool results as role=tool messages with content
+				msg.Role = "tool"
+				msg.Content = pt.Content
+			}
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func convertTools(tools []llms.Tool) []ollamaTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]ollamaTool, 0, len(tools))
+	for _, t := range tools {
+		if t.Function == nil {
+			continue
+		}
+		out = append(out, ollamaTool{
+			Type: "function",
+			Function: ollamaToolFunction{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			},
+		})
+	}
+	return out
+}
+
+func convertResponse(resp ollamaChatResponse) *llms.ContentResponse {
+	choice := &llms.ContentChoice{
+		GenerationInfo: map[string]any{
+			"PromptTokens":     resp.PromptEvalCount,
+			"CompletionTokens": resp.EvalCount,
+			"TotalTokens":      resp.PromptEvalCount + resp.EvalCount,
+		},
+	}
+
+	if resp.Message != nil {
+		choice.Content = resp.Message.Content
+
+		for _, tc := range resp.Message.ToolCalls {
+			argsJSON, _ := json.Marshal(tc.Function.Arguments)
+			choice.ToolCalls = append(choice.ToolCalls, llms.ToolCall{
+				ID:   tc.Function.Name, // Ollama doesn't provide IDs; use name
+				Type: "function",
+				FunctionCall: &llms.FunctionCall{
+					Name:      tc.Function.Name,
+					Arguments: string(argsJSON),
+				},
+			})
+		}
+	}
+
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{choice}}
+}
+
+func lcRoleToOllama(role llms.ChatMessageType) string {
+	switch role {
+	case llms.ChatMessageTypeSystem:
+		return "system"
+	case llms.ChatMessageTypeAI:
+		return "assistant"
+	case llms.ChatMessageTypeHuman, llms.ChatMessageTypeGeneric:
+		return "user"
+	case llms.ChatMessageTypeTool:
+		return "tool"
+	default:
+		return "user"
+	}
+}

--- a/cmd/squad/openai_responses.go
+++ b/cmd/squad/openai_responses.go
@@ -97,7 +97,7 @@ func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPr
 	return "", fmt.Errorf("responses API tool loop ended after %d iterations with no usable response", maxToolIterations)
 }
 
-func newResponsesClient(apiKey, baseURL, organization string) *openai.Client {
+func newResponsesClient(apiKey, baseURL, organization string) openai.Client {
 	clientOpts := []option.RequestOption{option.WithAPIKey(apiKey)}
 	if organization != "" {
 		clientOpts = append(clientOpts, option.WithOrganization(organization))
@@ -105,13 +105,12 @@ func newResponsesClient(apiKey, baseURL, organization string) *openai.Client {
 	if baseURL != "" {
 		clientOpts = append(clientOpts, option.WithBaseURL(baseURL))
 	}
-	c := openai.NewClient(clientOpts...)
-	return &c
+	return openai.NewClient(clientOpts...)
 }
 
 // responsesToolLoop iterates the tool-calling loop, returning the final
 // response, any accumulated text, and an error.
-func responsesToolLoop(ctx context.Context, client *openai.Client, resp *responses.Response, handlers map[string]toolHandler, rc *responsesConfig) (*responses.Response, string, error) {
+func responsesToolLoop(ctx context.Context, client openai.Client, resp *responses.Response, handlers map[string]toolHandler, rc *responsesConfig) (*responses.Response, string, error) {
 	var repeat toolRepeatTracker
 	for i := 0; i < maxToolIterations; i++ {
 		calls := extractFunctionCalls(resp)
@@ -167,7 +166,7 @@ func checkResponsesRepeat(repeat *toolRepeatTracker, calls []responseFunctionCal
 	return false
 }
 
-func requestResponsesFinal(ctx context.Context, client *openai.Client, previousID, systemPrompt string, rc *responsesConfig) (string, error) {
+func requestResponsesFinal(ctx context.Context, client openai.Client, previousID, systemPrompt string, rc *responsesConfig) (string, error) {
 	if strings.TrimSpace(previousID) == "" {
 		return "", fmt.Errorf("missing previous response id")
 	}

--- a/cmd/squad/openai_responses.go
+++ b/cmd/squad/openai_responses.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cowdogmoo/squad/logging"
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// responseFunctionCall holds the parsed details of a function_call item
+// from the Responses API output.
+type responseFunctionCall struct {
+	ID        string // output item ID
+	CallID    string // unique call ID for pairing with output
+	Name      string // function name
+	Arguments string // JSON arguments string
+}
+
+// responsesConfig bundles the immutable parameters for a Responses API session.
+type responsesConfig struct {
+	model       string
+	tools       []responses.ToolUnionParam
+	temperature float64
+	maxTokens   int
+}
+
+func (rc *responsesConfig) applyOptionals(params *responses.ResponseNewParams) {
+	if rc.temperature >= 0 && supportsResponsesTemperature(rc.model) {
+		params.Temperature = openai.Float(rc.temperature)
+	}
+	if rc.maxTokens > 0 {
+		params.MaxOutputTokens = openai.Int(int64(rc.maxTokens))
+	}
+}
+
+// useResponsesAPI returns true when the Responses API path should be used
+// instead of LangChainGo's Chat Completions.
+func useResponsesAPI(provider, model string) bool {
+	provider = normalizeProvider(provider)
+	if provider == "openai-responses" {
+		return true
+	}
+	return provider == "openai" && strings.HasPrefix(model, "gpt-5")
+}
+
+// runWithToolsResponses drives a tool-calling loop using the OpenAI
+// Responses API. It reuses the same tool handlers from buildToolHandlers.
+func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPrompt, userPrompt, workingDir, organization string, temperature float64, maxTokens int) (string, error) {
+	client := newResponsesClient(apiKey, baseURL, organization)
+	handlers, toolDefs := buildToolHandlers(workingDir)
+	rc := responsesConfig{
+		model:       model,
+		tools:       convertToolsToResponses(toolDefs),
+		temperature: temperature,
+		maxTokens:   maxTokens,
+	}
+
+	params := responses.ResponseNewParams{
+		Model:        model,
+		Instructions: openai.String(systemPrompt),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String(userPrompt),
+		},
+		Tools:      rc.tools,
+		Truncation: responses.ResponseNewParamsTruncation("auto"),
+		ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsRequired),
+		},
+	}
+	rc.applyOptionals(&params)
+
+	logging.InfoContext(ctx, "responses API: initial request (model=%s)", model)
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("responses API call failed: %w", err)
+	}
+
+	resp, text, err := responsesToolLoop(ctx, client, resp, handlers, &rc)
+	if err != nil {
+		return text, err
+	}
+	if text != "" {
+		return text, nil
+	}
+
+	finalText, err := requestResponsesFinal(ctx, client, resp.ID, systemPrompt, &rc)
+	if err == nil && finalText != "" {
+		return finalText, nil
+	}
+	return "", fmt.Errorf("responses API tool loop ended after %d iterations with no usable response", maxToolIterations)
+}
+
+func newResponsesClient(apiKey, baseURL, organization string) *openai.Client {
+	clientOpts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if organization != "" {
+		clientOpts = append(clientOpts, option.WithOrganization(organization))
+	}
+	if baseURL != "" {
+		clientOpts = append(clientOpts, option.WithBaseURL(baseURL))
+	}
+	c := openai.NewClient(clientOpts...)
+	return &c
+}
+
+// responsesToolLoop iterates the tool-calling loop, returning the final
+// response, any accumulated text, and an error.
+func responsesToolLoop(ctx context.Context, client *openai.Client, resp *responses.Response, handlers map[string]toolHandler, rc *responsesConfig) (*responses.Response, string, error) {
+	var repeat toolRepeatTracker
+	for i := 0; i < maxToolIterations; i++ {
+		calls := extractFunctionCalls(resp)
+		if len(calls) == 0 {
+			text := resp.OutputText()
+			logging.InfoContext(ctx, "responses API: final response at iteration %d (%d bytes)", i, len(text))
+			return resp, text, nil
+		}
+
+		logging.InfoContext(ctx, "responses API: iteration %d with %d tool call(s)", i+1, len(calls))
+		if checkResponsesRepeat(&repeat, calls, ctx) {
+			break
+		}
+
+		outputs := executeAndBuildOutputs(ctx, calls, handlers)
+		params := responses.ResponseNewParams{
+			Model:              rc.model,
+			PreviousResponseID: openai.String(resp.ID),
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam(outputs),
+			},
+			Tools:      rc.tools,
+			Truncation: responses.ResponseNewParamsTruncation("auto"),
+		}
+		rc.applyOptionals(&params)
+
+		var err error
+		resp, err = client.Responses.New(ctx, params)
+		if err != nil {
+			return resp, "", fmt.Errorf("responses API follow-up failed at iteration %d: %w", i+1, err)
+		}
+	}
+
+	text := resp.OutputText()
+	if text != "" {
+		logging.InfoContext(ctx, "responses API: loop ended, returning partial text (%d bytes)", len(text))
+	}
+	return resp, text, nil
+}
+
+func checkResponsesRepeat(repeat *toolRepeatTracker, calls []responseFunctionCall, ctx context.Context) bool {
+	fakeToolCalls := make([]llms.ToolCall, len(calls))
+	for j, c := range calls {
+		fakeToolCalls[j] = llms.ToolCall{
+			FunctionCall: &llms.FunctionCall{Name: c.Name},
+		}
+	}
+	repeat.update(fakeToolCalls)
+	if repeat.exceeded() {
+		logging.InfoContext(ctx, "responses API: %s called %d times in a row, breaking", repeat.lastName, repeat.count)
+		return true
+	}
+	return false
+}
+
+func requestResponsesFinal(ctx context.Context, client *openai.Client, previousID, systemPrompt string, rc *responsesConfig) (string, error) {
+	if strings.TrimSpace(previousID) == "" {
+		return "", fmt.Errorf("missing previous response id")
+	}
+	params := responses.ResponseNewParams{
+		Model:              rc.model,
+		PreviousResponseID: openai.String(previousID),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Provide the final response. Do not call any tools."),
+		},
+		Instructions: openai.String(systemPrompt),
+		ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsNone),
+		},
+		Tools:      rc.tools,
+		Truncation: responses.ResponseNewParamsTruncation("auto"),
+	}
+	rc.applyOptionals(&params)
+
+	logging.InfoContext(ctx, "responses API: requesting final response with tool_choice=none")
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("responses API final call failed: %w", err)
+	}
+	text := resp.OutputText()
+	if text == "" {
+		return "", fmt.Errorf("responses API final call returned empty text")
+	}
+	logging.InfoContext(ctx, "responses API: final call produced response (%d bytes)", len(text))
+	return text, nil
+}
+
+func supportsResponsesTemperature(model string) bool {
+	return !strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-5")
+}
+
+// convertToolsToResponses converts langchaingo tool definitions to the
+// Responses API FunctionToolParam format.
+func convertToolsToResponses(tools []llms.Tool) []responses.ToolUnionParam {
+	out := make([]responses.ToolUnionParam, 0, len(tools))
+	for _, t := range tools {
+		if t.Function == nil {
+			continue
+		}
+		params, ok := t.Function.Parameters.(map[string]any)
+		if !ok {
+			params = map[string]any{}
+		}
+		out = append(out, responses.ToolUnionParam{
+			OfFunction: &responses.FunctionToolParam{
+				Name:        t.Function.Name,
+				Description: openai.String(t.Function.Description),
+				Parameters:  params,
+				Strict:      openai.Bool(false),
+			},
+		})
+	}
+	return out
+}
+
+// extractFunctionCalls pulls function_call items from a Responses API
+// response output.
+func extractFunctionCalls(resp *responses.Response) []responseFunctionCall {
+	if resp == nil {
+		return nil
+	}
+	var calls []responseFunctionCall
+	for _, item := range resp.Output {
+		if item.Type == "function_call" {
+			calls = append(calls, responseFunctionCall{
+				ID:        item.ID,
+				CallID:    item.CallID,
+				Name:      item.Name,
+				Arguments: item.Arguments,
+			})
+		}
+	}
+	return calls
+}
+
+// executeAndBuildOutputs runs each tool call through the existing handlers
+// and builds the input items for the next Responses API request.
+func executeAndBuildOutputs(ctx context.Context, calls []responseFunctionCall, handlers map[string]toolHandler) []responses.ResponseInputItemUnionParam {
+	outputs := make([]responses.ResponseInputItemUnionParam, 0, len(calls))
+	for _, call := range calls {
+		handler, ok := handlers[call.Name]
+		if !ok {
+			logging.DebugContext(ctx, "responses API: unknown tool %s", call.Name)
+			outputs = append(outputs, responses.ResponseInputItemUnionParam{
+				OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+					CallID: call.CallID,
+					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+						OfString: openai.String(fmt.Sprintf("unknown tool: %s", call.Name)),
+					},
+				},
+			})
+			continue
+		}
+
+		logging.DebugContext(ctx, "responses API: calling %s args=%s", call.Name, truncateString(call.Arguments, 200))
+		toolStart := time.Now()
+		result, err := handler.call(ctx, []byte(call.Arguments))
+		toolDuration := time.Since(toolStart)
+
+		var output string
+		if err != nil {
+			output = fmt.Sprintf("error: %v", err)
+			logging.DebugContext(ctx, "responses API: %s failed in %s: %v", call.Name, toolDuration.Round(time.Millisecond), err)
+		} else {
+			output = result
+			logging.DebugContext(ctx, "responses API: %s completed in %s (%d bytes)", call.Name, toolDuration.Round(time.Millisecond), len(result))
+		}
+
+		outputs = append(outputs, responses.ResponseInputItemUnionParam{
+			OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+				CallID: call.CallID,
+				Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+					OfString: openai.String(output),
+				},
+			},
+		})
+	}
+	return outputs
+}
+
+// resolveResponsesAPIKey determines the API key for the Responses API path,
+// checking CLI flag, config, and environment in order.
+func resolveResponsesAPIKey(cfgToken string) (string, error) {
+	key := pickString(runAPIKey, cfgToken)
+	if key == "" {
+		key = os.Getenv("OPENAI_API_KEY")
+	}
+	if key == "" {
+		return "", fmt.Errorf("API key required for OpenAI Responses API: use --api-key, config provider.token, or OPENAI_API_KEY env var")
+	}
+	return key, nil
+}

--- a/cmd/squad/openai_responses_test.go
+++ b/cmd/squad/openai_responses_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/cowdogmoo/squad/openairesponses"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/tmc/langchaingo/llms"
 )
@@ -28,9 +29,9 @@ func TestUseResponsesAPI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider+"/"+tt.model, func(t *testing.T) {
-			got := useResponsesAPI(tt.provider, tt.model)
+			got := openairesponses.UseResponsesAPI(tt.provider, tt.model)
 			if got != tt.want {
-				t.Errorf("useResponsesAPI(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
+				t.Errorf("UseResponsesAPI(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
 			}
 		})
 	}
@@ -69,7 +70,7 @@ func TestConvertToolsToResponses(t *testing.T) {
 		{Type: "function", Function: nil}, // should be skipped
 	}
 
-	result := convertToolsToResponses(tools)
+	result := openairesponses.ConvertTools(tools)
 	if len(result) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(result))
 	}
@@ -89,7 +90,7 @@ func TestConvertToolsToResponses(t *testing.T) {
 
 func TestExtractFunctionCalls(t *testing.T) {
 	t.Run("nil response", func(t *testing.T) {
-		calls := extractFunctionCalls(nil)
+		calls := openairesponses.ExtractFunctionCalls(nil)
 		if len(calls) != 0 {
 			t.Errorf("expected 0 calls, got %d", len(calls))
 		}
@@ -101,7 +102,7 @@ func TestExtractFunctionCalls(t *testing.T) {
 				{Type: "message", ID: "msg_1"},
 			},
 		}
-		calls := extractFunctionCalls(resp)
+		calls := openairesponses.ExtractFunctionCalls(resp)
 		if len(calls) != 0 {
 			t.Errorf("expected 0 calls, got %d", len(calls))
 		}
@@ -127,7 +128,7 @@ func TestExtractFunctionCalls(t *testing.T) {
 				},
 			},
 		}
-		calls := extractFunctionCalls(resp)
+		calls := openairesponses.ExtractFunctionCalls(resp)
 		if len(calls) != 2 {
 			t.Fatalf("expected 2 calls, got %d", len(calls))
 		}
@@ -136,55 +137,6 @@ func TestExtractFunctionCalls(t *testing.T) {
 		}
 		if calls[1].Name != "Bash" || calls[1].CallID != "call_def" {
 			t.Errorf("unexpected second call: %+v", calls[1])
-		}
-	})
-}
-
-func TestResolveResponsesAPIKey(t *testing.T) {
-	// Save and restore globals.
-	origKey := runAPIKey
-	t.Cleanup(func() { runAPIKey = origKey })
-
-	t.Run("from flag", func(t *testing.T) {
-		runAPIKey = "flag-key"
-		key, err := resolveResponsesAPIKey("")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if key != "flag-key" {
-			t.Errorf("expected flag-key, got %s", key)
-		}
-	})
-
-	t.Run("from config", func(t *testing.T) {
-		runAPIKey = ""
-		key, err := resolveResponsesAPIKey("config-key")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if key != "config-key" {
-			t.Errorf("expected config-key, got %s", key)
-		}
-	})
-
-	t.Run("from env", func(t *testing.T) {
-		runAPIKey = ""
-		t.Setenv("OPENAI_API_KEY", "env-key")
-		key, err := resolveResponsesAPIKey("")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if key != "env-key" {
-			t.Errorf("expected env-key, got %s", key)
-		}
-	})
-
-	t.Run("missing", func(t *testing.T) {
-		runAPIKey = ""
-		t.Setenv("OPENAI_API_KEY", "")
-		_, err := resolveResponsesAPIKey("")
-		if err == nil {
-			t.Fatal("expected error for missing key")
 		}
 	})
 }

--- a/cmd/squad/openai_responses_test.go
+++ b/cmd/squad/openai_responses_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestUseResponsesAPI(t *testing.T) {
+	tests := []struct {
+		provider string
+		model    string
+		want     bool
+	}{
+		{"openai", "gpt-5.2", true},
+		{"openai", "gpt-5", true},
+		{"openai", "gpt-5.1-mini", true},
+		{"openai", "gpt-4o", false},
+		{"openai", "gpt-4.1", false},
+		{"openai", "o3", false},
+		{"openai-responses", "gpt-4o", true},
+		{"openai-responses", "o3", true},
+		{"OpenAI-Responses", "anything", true},
+		{"anthropic", "claude-sonnet-4-20250514", false},
+		{"ollama", "llama3", false},
+		{"", "gpt-5.2", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.model, func(t *testing.T) {
+			got := useResponsesAPI(tt.provider, tt.model)
+			if got != tt.want {
+				t.Errorf("useResponsesAPI(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToolsToResponses(t *testing.T) {
+	tools := []llms.Tool{
+		{
+			Type: "function",
+			Function: &llms.FunctionDefinition{
+				Name:        "Read",
+				Description: "Read a file.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path": map[string]any{"type": "string"},
+					},
+					"required": []string{"path"},
+				},
+			},
+		},
+		{
+			Type: "function",
+			Function: &llms.FunctionDefinition{
+				Name:        "Bash",
+				Description: "Run a command.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"command": map[string]any{"type": "string"},
+					},
+					"required": []string{"command"},
+				},
+			},
+		},
+		{Type: "function", Function: nil}, // should be skipped
+	}
+
+	result := convertToolsToResponses(tools)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(result))
+	}
+
+	// Verify first tool.
+	if result[0].OfFunction == nil {
+		t.Fatal("expected OfFunction to be set")
+	}
+	if result[0].OfFunction.Name != "Read" {
+		t.Errorf("expected name Read, got %s", result[0].OfFunction.Name)
+	}
+	params, ok := result[0].OfFunction.Parameters["type"]
+	if !ok || params != "object" {
+		t.Error("expected parameters.type = object")
+	}
+}
+
+func TestExtractFunctionCalls(t *testing.T) {
+	t.Run("nil response", func(t *testing.T) {
+		calls := extractFunctionCalls(nil)
+		if len(calls) != 0 {
+			t.Errorf("expected 0 calls, got %d", len(calls))
+		}
+	})
+
+	t.Run("no function calls", func(t *testing.T) {
+		resp := &responses.Response{
+			Output: []responses.ResponseOutputItemUnion{
+				{Type: "message", ID: "msg_1"},
+			},
+		}
+		calls := extractFunctionCalls(resp)
+		if len(calls) != 0 {
+			t.Errorf("expected 0 calls, got %d", len(calls))
+		}
+	})
+
+	t.Run("with function calls", func(t *testing.T) {
+		resp := &responses.Response{
+			Output: []responses.ResponseOutputItemUnion{
+				{
+					Type:      "function_call",
+					ID:        "fc_1",
+					CallID:    "call_abc",
+					Name:      "Read",
+					Arguments: `{"path":"main.go"}`,
+				},
+				{Type: "message", ID: "msg_1"},
+				{
+					Type:      "function_call",
+					ID:        "fc_2",
+					CallID:    "call_def",
+					Name:      "Bash",
+					Arguments: `{"command":"go build"}`,
+				},
+			},
+		}
+		calls := extractFunctionCalls(resp)
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls, got %d", len(calls))
+		}
+		if calls[0].Name != "Read" || calls[0].CallID != "call_abc" {
+			t.Errorf("unexpected first call: %+v", calls[0])
+		}
+		if calls[1].Name != "Bash" || calls[1].CallID != "call_def" {
+			t.Errorf("unexpected second call: %+v", calls[1])
+		}
+	})
+}
+
+func TestResolveResponsesAPIKey(t *testing.T) {
+	// Save and restore globals.
+	origKey := runAPIKey
+	t.Cleanup(func() { runAPIKey = origKey })
+
+	t.Run("from flag", func(t *testing.T) {
+		runAPIKey = "flag-key"
+		key, err := resolveResponsesAPIKey("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != "flag-key" {
+			t.Errorf("expected flag-key, got %s", key)
+		}
+	})
+
+	t.Run("from config", func(t *testing.T) {
+		runAPIKey = ""
+		key, err := resolveResponsesAPIKey("config-key")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != "config-key" {
+			t.Errorf("expected config-key, got %s", key)
+		}
+	})
+
+	t.Run("from env", func(t *testing.T) {
+		runAPIKey = ""
+		t.Setenv("OPENAI_API_KEY", "env-key")
+		key, err := resolveResponsesAPIKey("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != "env-key" {
+			t.Errorf("expected env-key, got %s", key)
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		runAPIKey = ""
+		t.Setenv("OPENAI_API_KEY", "")
+		_, err := resolveResponsesAPIKey("")
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+	})
+}

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -112,11 +112,17 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	if err := v.BindPFlag("log.format", cmd.Root().PersistentFlags().Lookup("log-format")); err != nil {
 		return fmt.Errorf("failed to bind log-format flag: %w", err)
 	}
+	if err := v.BindPFlag("quiet", cmd.Root().PersistentFlags().Lookup("quiet")); err != nil {
+		return fmt.Errorf("failed to bind quiet flag: %w", err)
+	}
+	if err := v.BindPFlag("verbose", cmd.Root().PersistentFlags().Lookup("verbose")); err != nil {
+		return fmt.Errorf("failed to bind verbose flag: %w", err)
+	}
 
 	logLevel := v.GetString("log.level")
 	logFormat := v.GetString("log.format")
-	quiet, _ := cmd.Flags().GetBool("quiet")
-	verbose, _ := cmd.Flags().GetBool("verbose")
+	quiet := v.GetBool("quiet")
+	verbose := v.GetBool("verbose")
 
 	if err := logging.Initialize(logLevel, logFormat, quiet, verbose); err != nil {
 		return fmt.Errorf("failed to initialize logging: %w", err)

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -26,6 +26,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"strings"
 
 	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
@@ -39,6 +42,7 @@ type configKeyType struct{}
 var (
 	configKey = configKeyType{}
 	cfgFile   string
+	appViper  *viper.Viper
 )
 
 var rootCmd = &cobra.Command{
@@ -65,6 +69,9 @@ func init() {
 
 // Execute runs the root command.
 func Execute() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	rootCmd.SetContext(ctx)
 	return rootCmd.Execute()
 }
 
@@ -90,6 +97,7 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	}
 
 	v := viper.New()
+	appViper = v
 
 	v.SetDefault("log.level", cfg.Log.Level)
 	v.SetDefault("log.format", cfg.Log.Format)
@@ -99,13 +107,16 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	v.SetDefault("provider.api_version", cfg.Provider.APIVersion)
 	v.SetDefault("provider.api_type", cfg.Provider.APIType)
 	v.SetDefault("provider.openai_compat_max_tokens", cfg.Provider.OpenAICompatMaxTokens)
+	v.SetDefault("provider.token", cfg.Provider.Token)
 	v.SetDefault("model.default", cfg.Model.Default)
 	v.SetDefault("model.temperature", cfg.Model.Temperature)
 	v.SetDefault("model.max_tokens", cfg.Model.MaxTokens)
 
 	v.SetEnvPrefix("SQUAD")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
+	// Bind persistent (root) flags.
 	if err := v.BindPFlag("log.level", cmd.Root().PersistentFlags().Lookup("log-level")); err != nil {
 		return fmt.Errorf("failed to bind log-level flag: %w", err)
 	}
@@ -119,10 +130,17 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to bind verbose flag: %w", err)
 	}
 
+	// Bind run command flags so Viper can resolve them via env/config.
+	bindRunFlags(v)
+
 	logLevel := v.GetString("log.level")
 	logFormat := v.GetString("log.format")
 	quiet := v.GetBool("quiet")
 	verbose := v.GetBool("verbose")
+
+	if quiet && verbose {
+		return fmt.Errorf("--quiet and --verbose cannot be used together")
+	}
 
 	if err := logging.Initialize(logLevel, logFormat, quiet, verbose); err != nil {
 		return fmt.Errorf("failed to initialize logging: %w", err)
@@ -136,6 +154,7 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	cfg.Provider.APIVersion = v.GetString("provider.api_version")
 	cfg.Provider.APIType = v.GetString("provider.api_type")
 	cfg.Provider.OpenAICompatMaxTokens = v.GetBool("provider.openai_compat_max_tokens")
+	cfg.Provider.Token = v.GetString("provider.token")
 	cfg.Model.Default = v.GetString("model.default")
 	cfg.Model.Temperature = v.GetFloat64("model.temperature")
 	cfg.Model.MaxTokens = v.GetInt("model.max_tokens")

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -127,40 +127,59 @@ var runCmd = &cobra.Command{
 		temperature := pickFloat(runTemperature, cfg.Model.Temperature)
 		maxTokens := pickInt(runMaxTokens, cfg.Model.MaxTokens)
 
-		llm, err := buildLLM(provider, model, cfg)
-		if err != nil {
-			return err
-		}
-
-		callOpts := []llms.CallOption{
-			llms.WithTemperature(temperature),
-		}
-
-		if maxTokens > 0 {
-			if isOpenAICompatProvider(provider) {
-				useLegacy := provider != "openai" || runOpenAICompatMax || cfg.Provider.OpenAICompatMaxTokens
-				if useLegacy {
-					callOpts = append(callOpts, llms.WithMaxTokens(maxTokens), openai.WithLegacyMaxTokensField())
-				} else {
-					callOpts = append(callOpts, openai.WithMaxCompletionTokens(maxTokens))
-				}
-			} else {
-				callOpts = append(callOpts, llms.WithMaxTokens(maxTokens))
-			}
-		}
-
 		systemPrompt := bundle.System
 		if runSystem != "" {
 			systemPrompt += "\n\n## System Override\n\n" + strings.TrimSpace(runSystem) + "\n"
 		}
 
-		logging.InfoContext(cmd.Context(), "model call started (provider=%s model=%s)", provider, model)
-		modelStart := time.Now()
-		response, err := runWithTools(cmd.Context(), llm, systemPrompt, bundle.User, bundle.WorkDir, callOpts...)
-		if err != nil {
-			return fmt.Errorf("model call failed: %w", err)
+		var response string
+
+		if useResponsesAPI(provider, model) {
+			apiKey, err := resolveResponsesAPIKey(cfg.Provider.Token)
+			if err != nil {
+				return err
+			}
+			baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
+			org := pickString(runOrg, cfg.Provider.Organization)
+
+			logging.InfoContext(cmd.Context(), "model call started via Responses API (provider=%s model=%s)", provider, model)
+			modelStart := time.Now()
+			response, err = runWithToolsResponses(cmd.Context(), apiKey, baseURL, model, systemPrompt, bundle.User, bundle.WorkDir, org, temperature, maxTokens)
+			if err != nil {
+				return fmt.Errorf("model call failed: %w", err)
+			}
+			logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
+		} else {
+			llm, err := buildLLM(provider, model, cfg)
+			if err != nil {
+				return err
+			}
+
+			callOpts := []llms.CallOption{
+				llms.WithTemperature(temperature),
+			}
+
+			if maxTokens > 0 {
+				if isOpenAICompatProvider(provider) {
+					useLegacy := provider != "openai" || runOpenAICompatMax || cfg.Provider.OpenAICompatMaxTokens
+					if useLegacy {
+						callOpts = append(callOpts, llms.WithMaxTokens(maxTokens), openai.WithLegacyMaxTokensField())
+					} else {
+						callOpts = append(callOpts, openai.WithMaxCompletionTokens(maxTokens))
+					}
+				} else {
+					callOpts = append(callOpts, llms.WithMaxTokens(maxTokens))
+				}
+			}
+
+			logging.InfoContext(cmd.Context(), "model call started (provider=%s model=%s)", provider, model)
+			modelStart := time.Now()
+			response, err = runWithTools(cmd.Context(), llm, systemPrompt, bundle.User, bundle.WorkDir, callOpts...)
+			if err != nil {
+				return fmt.Errorf("model call failed: %w", err)
+			}
+			logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
 		}
-		logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
 
 		if runRequireActionable {
 			if err := validateActionableResponse(response); err != nil {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -92,7 +92,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		bundle, bundleWorkingDir, err := buildAgentBundle(agentsDir, runAgent, prompt, workingDir)
+		bundle, err := buildAgentBundle(agentsDir, runAgent, prompt, workingDir)
 		if err != nil {
 			return err
 		}
@@ -100,13 +100,13 @@ var runCmd = &cobra.Command{
 		logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", runAgent, runProvider, runModel)
 
 		if runPrintBundle {
-			if _, err := io.Copy(cmd.OutOrStdout(), bytes.NewReader(bundle)); err != nil {
+			if _, err := io.Copy(cmd.OutOrStdout(), bytes.NewReader(bundle.Combined)); err != nil {
 				return err
 			}
 		}
 
 		if runBundleOut != "" {
-			if err := os.WriteFile(runBundleOut, bundle, 0o644); err != nil {
+			if err := os.WriteFile(runBundleOut, bundle.Combined, 0o644); err != nil {
 				return fmt.Errorf("failed to write bundle: %w", err)
 			}
 			logging.InfoContext(cmd.Context(), "bundle written to %s", runBundleOut)
@@ -148,14 +148,14 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		fullPrompt := string(bundle)
+		systemPrompt := bundle.System
 		if runSystem != "" {
-			fullPrompt = injectSystemOverride(fullPrompt, runSystem)
+			systemPrompt += "\n\n## System Override\n\n" + strings.TrimSpace(runSystem) + "\n"
 		}
 
 		logging.InfoContext(cmd.Context(), "model call started (provider=%s model=%s)", provider, model)
 		modelStart := time.Now()
-		response, err := runWithTools(cmd.Context(), llm, fullPrompt, bundleWorkingDir, callOpts...)
+		response, err := runWithTools(cmd.Context(), llm, systemPrompt, bundle.User, bundle.WorkDir, callOpts...)
 		if err != nil {
 			return fmt.Errorf("model call failed: %w", err)
 		}
@@ -229,6 +229,13 @@ type agentManifest struct {
 	References []string `yaml:"references"`
 }
 
+type agentBundle struct {
+	System   string // wrapper + system prompt + references
+	User     string // user request only
+	Combined []byte // concatenated for --print-bundle/--bundle-out
+	WorkDir  string
+}
+
 func readPrompt(cmd *cobra.Command, args []string) (string, error) {
 	if len(args) > 0 {
 		return strings.Join(args, " "), nil
@@ -268,29 +275,29 @@ func resolveAgentsDir(explicit string) (string, error) {
 	return filepath.Join(home, ".config", "squad", "agents"), nil
 }
 
-func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) ([]byte, string, error) {
+func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) (*agentBundle, error) {
 	agentPath := filepath.Join(agentsDir, agentName)
 	manifestPath := filepath.Join(agentPath, "agent.yaml")
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read agent manifest: %w", err)
+		return nil, fmt.Errorf("failed to read agent manifest: %w", err)
 	}
 
 	var manifest agentManifest
 	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, "", fmt.Errorf("failed to parse agent manifest: %w", err)
+		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
 	}
 
 	entryPath := filepath.Join(agentPath, manifest.EntryPoint)
 	systemData, err := os.ReadFile(entryPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read system prompt: %w", err)
+		return nil, fmt.Errorf("failed to read system prompt: %w", err)
 	}
 
 	wrapperPath := filepath.Join(agentPath, manifest.Wrapper)
 	wrapperData, err := os.ReadFile(wrapperPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read agent wrapper: %w", err)
+		return nil, fmt.Errorf("failed to read agent wrapper: %w", err)
 	}
 
 	var refs []string
@@ -301,33 +308,42 @@ func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) ([]byte, 
 		refPath := filepath.Join(agentPath, ref)
 		refData, err := os.ReadFile(refPath)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to read reference %s: %w", ref, err)
+			return nil, fmt.Errorf("failed to read reference %s: %w", ref, err)
 		}
 		refs = append(refs, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(string(refData))))
 	}
 
-	var buf bytes.Buffer
-	buf.WriteString("# Squad Agent Bundle\n\n")
-	buf.WriteString(fmt.Sprintf("Agent: %s (%s)\n", manifest.Name, manifest.Version))
-	buf.WriteString(fmt.Sprintf("Working Directory: %s\n\n", workingDir))
-	buf.WriteString("## Agent Wrapper\n\n")
-	buf.Write(wrapperData)
-	buf.WriteString("\n\n## System Prompt\n\n")
-	buf.Write(systemData)
+	// Build the system message content (wrapper + system prompt + references).
+	var sys bytes.Buffer
+	sys.WriteString("# Squad Agent Bundle\n\n")
+	sys.WriteString(fmt.Sprintf("Agent: %s (%s)\n", manifest.Name, manifest.Version))
+	sys.WriteString(fmt.Sprintf("Working Directory: %s\n\n", workingDir))
+	sys.WriteString("## Agent Wrapper\n\n")
+	sys.Write(wrapperData)
+	sys.WriteString("\n\n## System Prompt\n\n")
+	sys.Write(systemData)
 
 	if len(refs) > 0 {
-		buf.WriteString("\n\n## References\n\n")
+		sys.WriteString("\n\n## References\n\n")
 		for _, ref := range refs {
-			buf.WriteString(ref)
-			buf.WriteString("\n")
+			sys.WriteString(ref)
+			sys.WriteString("\n")
 		}
 	}
 
-	buf.WriteString("\n\n## User Request\n\n")
-	buf.WriteString(prompt)
-	buf.WriteString("\n")
+	// Build the combined output for --print-bundle/--bundle-out.
+	var combined bytes.Buffer
+	combined.Write(sys.Bytes())
+	combined.WriteString("\n\n## User Request\n\n")
+	combined.WriteString(prompt)
+	combined.WriteString("\n")
 
-	return buf.Bytes(), workingDir, nil
+	return &agentBundle{
+		System:   sys.String(),
+		User:     prompt,
+		Combined: combined.Bytes(),
+		WorkDir:  workingDir,
+	}, nil
 }
 
 func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
@@ -435,15 +451,6 @@ func pickInt(value, fallback int) int {
 		return value
 	}
 	return fallback
-}
-
-func injectSystemOverride(bundle, system string) string {
-	injection := "\n\n## System Override\n\n" + strings.TrimSpace(system) + "\n"
-	needle := "\n\n## User Request\n\n"
-	if strings.Contains(bundle, needle) {
-		return strings.Replace(bundle, needle, injection+needle, 1)
-	}
-	return bundle + injection
 }
 
 func validateActionableResponse(response string) error {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -24,11 +24,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
@@ -59,6 +62,8 @@ var (
 	runPrintBundle       bool
 	runDryRun            bool
 	runRequireActionable bool
+	runApply             bool
+	runApplyFallback     bool
 )
 
 var runCmd = &cobra.Command{
@@ -114,7 +119,7 @@ var runCmd = &cobra.Command{
 			return fmt.Errorf("config not available in context")
 		}
 
-		provider := pickString(runProvider, cfg.Provider.Default)
+		provider := normalizeProvider(pickString(runProvider, cfg.Provider.Default))
 		model := pickString(runModel, cfg.Model.Default)
 		temperature := pickFloat(runTemperature, cfg.Model.Temperature)
 		maxTokens := pickInt(runMaxTokens, cfg.Model.MaxTokens)
@@ -128,16 +133,17 @@ var runCmd = &cobra.Command{
 			llms.WithTemperature(temperature),
 		}
 
-		if provider == "openai" {
-			if maxTokens > 0 {
-				if runOpenAICompatMax || cfg.Provider.OpenAICompatMaxTokens {
+		if maxTokens > 0 {
+			if isOpenAICompatProvider(provider) {
+				useLegacy := provider != "openai" || runOpenAICompatMax || cfg.Provider.OpenAICompatMaxTokens
+				if useLegacy {
 					callOpts = append(callOpts, llms.WithMaxTokens(maxTokens), openai.WithLegacyMaxTokensField())
 				} else {
 					callOpts = append(callOpts, openai.WithMaxCompletionTokens(maxTokens))
 				}
+			} else {
+				callOpts = append(callOpts, llms.WithMaxTokens(maxTokens))
 			}
-		} else if maxTokens > 0 {
-			callOpts = append(callOpts, llms.WithMaxTokens(maxTokens))
 		}
 
 		fullPrompt := string(bundle)
@@ -145,15 +151,30 @@ var runCmd = &cobra.Command{
 			fullPrompt = injectSystemOverride(fullPrompt, runSystem)
 		}
 
+		logging.InfoContext(cmd.Context(), "model call started (provider=%s model=%s)", provider, model)
+		modelStart := time.Now()
 		response, err := runWithTools(cmd.Context(), llm, fullPrompt, bundleWorkingDir, callOpts...)
 		if err != nil {
 			return fmt.Errorf("model call failed: %w", err)
 		}
+		logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
 
 		if runRequireActionable {
 			if err := validateActionableResponse(response); err != nil {
 				return err
 			}
+		}
+
+		if runApply {
+			diff, err := extractUnifiedDiff(response)
+			if err != nil {
+				return err
+			}
+			logging.InfoContext(cmd.Context(), "applying diff (%d bytes)", len(diff))
+			if err := applyUnifiedDiff(cmd.Context(), workingDir, diff); err != nil {
+				return err
+			}
+			logging.InfoContext(cmd.Context(), "diff applied to %s", workingDir)
 		}
 
 		if runPrint || runOutput == "" {
@@ -193,6 +214,8 @@ func init() {
 	runCmd.Flags().BoolVar(&runPrintBundle, "print-bundle", false, "Print agent bundle to stdout")
 	runCmd.Flags().BoolVar(&runDryRun, "dry-run", false, "Build bundle and exit without calling the model")
 	runCmd.Flags().BoolVar(&runRequireActionable, "require-actionable", true, "Require actionable output (diff/files/no changes)")
+	runCmd.Flags().BoolVar(&runApply, "apply", false, "Apply unified diff from the response to the working directory")
+	runCmd.Flags().BoolVar(&runApplyFallback, "apply-fallback", false, "Fallback to patch(1) if git apply fails (may create .rej/.orig)")
 }
 
 type agentManifest struct {
@@ -305,23 +328,38 @@ func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) ([]byte, 
 }
 
 func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
+	provider = normalizeProvider(provider)
 	switch provider {
-	case "openai", "":
-		opts := []openai.Option{}
-		if model != "" {
-			opts = append(opts, openai.WithModel(model))
-		}
+	case "openai", "", "ollama":
+		return buildOpenAICompatLLM(provider, model, cfg)
+	default:
+		return nil, fmt.Errorf("provider not implemented: %s", provider)
+	}
+}
 
-		baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
-		if baseURL != "" {
-			opts = append(opts, openai.WithBaseURL(baseURL))
-		}
+func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
+	opts := []openai.Option{}
+	if model != "" {
+		opts = append(opts, openai.WithModel(model))
+	}
 
-		token := pickString(runAPIKey, cfg.Provider.Token)
-		if token != "" {
-			opts = append(opts, openai.WithToken(token))
-		}
+	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
+	if baseURL == "" && provider == "ollama" {
+		baseURL = "http://localhost:11434/v1"
+	}
+	if baseURL != "" {
+		opts = append(opts, openai.WithBaseURL(baseURL))
+	}
 
+	token := pickString(runAPIKey, cfg.Provider.Token)
+	if token == "" && provider == "ollama" {
+		token = "ollama"
+	}
+	if token != "" {
+		opts = append(opts, openai.WithToken(token))
+	}
+
+	if provider == "openai" || provider == "" {
 		org := pickString(runOrg, cfg.Provider.Organization)
 		if org != "" {
 			opts = append(opts, openai.WithOrganization(org))
@@ -336,11 +374,17 @@ func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 		if apiType == "azure" {
 			opts = append(opts, openai.WithAPIType(openai.APITypeAzure))
 		}
-
-		return openai.New(opts...)
-	default:
-		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
+
+	return openai.New(opts...)
+}
+
+func normalizeProvider(provider string) string {
+	return strings.ToLower(strings.TrimSpace(provider))
+}
+
+func isOpenAICompatProvider(provider string) bool {
+	return provider == "" || provider == "openai" || provider == "ollama"
 }
 
 func pickString(value, fallback string) string {
@@ -385,4 +429,98 @@ func validateActionableResponse(response string) error {
 		return nil
 	}
 	return fmt.Errorf("response is not actionable: missing diff, files touched, or no changes section (disable with --require-actionable=false)")
+}
+
+func extractUnifiedDiff(response string) (string, error) {
+	const fence = "```diff"
+	const altFence = "```patch"
+	const endFence = "```"
+	var blocks []string
+	for {
+		start := strings.Index(response, fence)
+		useFence := fence
+		if start == -1 {
+			start = strings.Index(response, altFence)
+			useFence = altFence
+		}
+		if start == -1 {
+			break
+		}
+		response = response[start+len(useFence):]
+		end := strings.Index(response, endFence)
+		if end == -1 {
+			block := strings.TrimSpace(response)
+			if block != "" {
+				blocks = append(blocks, block)
+			}
+			break
+		}
+		block := strings.TrimSpace(response[:end])
+		if block != "" {
+			blocks = append(blocks, block)
+		}
+		response = response[end+len(endFence):]
+	}
+	if len(blocks) == 0 {
+		return "", fmt.Errorf("apply requires a unified diff block (```diff ... ```)")
+	}
+	diff := strings.Join(blocks, "\n")
+	if !looksLikeDiff(diff) {
+		return "", fmt.Errorf("diff block does not look like a unified diff (missing diff headers)")
+	}
+	return diff, nil
+}
+
+func applyUnifiedDiff(ctx context.Context, workingDir, diff string) error {
+	if strings.TrimSpace(diff) == "" {
+		return fmt.Errorf("diff content is empty")
+	}
+
+	gitErr := applyWithGit(ctx, workingDir, diff)
+	if gitErr == nil {
+		return nil
+	}
+
+	if !runApplyFallback {
+		return fmt.Errorf("failed to apply diff with git: %v", gitErr)
+	}
+
+	patchErr := applyWithPatch(ctx, workingDir, diff)
+	if patchErr == nil {
+		return nil
+	}
+
+	return fmt.Errorf("failed to apply diff with git or patch: %v; %v", gitErr, patchErr)
+}
+
+func looksLikeDiff(diff string) bool {
+	if strings.Contains(diff, "diff --git ") {
+		return true
+	}
+	if strings.Contains(diff, "--- a/") && strings.Contains(diff, "+++ b/") {
+		return true
+	}
+	return false
+}
+
+func applyWithGit(ctx context.Context, workingDir, diff string) error {
+	cmd := exec.CommandContext(ctx, "git", "apply", "--whitespace=nowarn", "--recount", "-")
+	cmd.Dir = workingDir
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git apply failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func applyWithPatch(ctx context.Context, workingDir, diff string) error {
+	cmd := exec.CommandContext(ctx, "patch", "-p1")
+	cmd.Dir = workingDir
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("patch failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -66,6 +66,7 @@ var (
 	runApply             bool
 	runApplyFallback     bool
 	runNumCtx            int
+	runMode              string
 )
 
 var runCmd = &cobra.Command{
@@ -219,14 +220,22 @@ func init() {
 	runCmd.Flags().BoolVar(&runApply, "apply", false, "Apply unified diff from the response to the working directory")
 	runCmd.Flags().BoolVar(&runApplyFallback, "apply-fallback", false, "Fallback to patch(1) if git apply fails (may create .rej/.orig)")
 	runCmd.Flags().IntVar(&runNumCtx, "num-ctx", 32768, "Context window size for Ollama models")
+	runCmd.Flags().StringVar(&runMode, "mode", "", "Agent mode override (e.g. readonly)")
+}
+
+type agentModeOverride struct {
+	EntryPoint string   `yaml:"entrypoint,omitempty"`
+	Wrapper    string   `yaml:"wrapper,omitempty"`
+	References []string `yaml:"references,omitempty"`
 }
 
 type agentManifest struct {
-	Name       string   `yaml:"name"`
-	Version    string   `yaml:"version"`
-	EntryPoint string   `yaml:"entrypoint"`
-	Wrapper    string   `yaml:"wrapper"`
-	References []string `yaml:"references"`
+	Name       string                       `yaml:"name"`
+	Version    string                       `yaml:"version"`
+	EntryPoint string                       `yaml:"entrypoint"`
+	Wrapper    string                       `yaml:"wrapper"`
+	References []string                     `yaml:"references"`
+	Modes      map[string]agentModeOverride `yaml:"modes,omitempty"`
 }
 
 type agentBundle struct {
@@ -286,6 +295,22 @@ func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) (*agentBu
 	var manifest agentManifest
 	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
+	}
+
+	if runMode != "" {
+		override, ok := manifest.Modes[runMode]
+		if !ok {
+			return nil, fmt.Errorf("agent %q has no mode %q", agentName, runMode)
+		}
+		if override.EntryPoint != "" {
+			manifest.EntryPoint = override.EntryPoint
+		}
+		if override.Wrapper != "" {
+			manifest.Wrapper = override.Wrapper
+		}
+		if len(override.References) > 0 {
+			manifest.References = override.References
+		}
 	}
 
 	entryPath := filepath.Join(agentPath, manifest.EntryPoint)

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -33,13 +33,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cowdogmoo/squad/config"
+	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/ollama"
+	"github.com/cowdogmoo/squad/openairesponses"
+	"github.com/cowdogmoo/squad/tools"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
 	"github.com/tmc/langchaingo/llms/openai"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -69,154 +72,104 @@ var (
 	runMode              string
 )
 
+// RunOptions holds the resolved configuration for a single run invocation.
+type RunOptions struct {
+	Agent             string
+	AgentsDir         string
+	WorkingDir        string
+	APIKey            string
+	BaseURL           string
+	Org               string
+	APIVersion        string
+	APIType           string
+	OpenAICompatMax   bool
+	Provider          string
+	Model             string
+	Temperature       float64
+	MaxTokens         int
+	System            string
+	Output            string
+	Print             bool
+	BundleOut         string
+	PrintBundle       bool
+	DryRun            bool
+	RequireActionable bool
+	Apply             bool
+	ApplyFallback     bool
+	NumCtx            int
+	Mode              string
+}
+
+// newRunOptions creates a RunOptions by copying from the current CLI flag globals.
+func newRunOptions() *RunOptions {
+	return &RunOptions{
+		Agent:             runAgent,
+		AgentsDir:         runAgentsDir,
+		WorkingDir:        runWorkingDir,
+		APIKey:            runAPIKey,
+		BaseURL:           runBaseURL,
+		Org:               runOrg,
+		APIVersion:        runAPIVersion,
+		APIType:           runAPIType,
+		OpenAICompatMax:   runOpenAICompatMax,
+		Provider:          runProvider,
+		Model:             runModel,
+		Temperature:       runTemperature,
+		MaxTokens:         runMaxTokens,
+		System:            runSystem,
+		Output:            runOutput,
+		Print:             runPrint,
+		BundleOut:         runBundleOut,
+		PrintBundle:       runPrintBundle,
+		DryRun:            runDryRun,
+		RequireActionable: runRequireActionable,
+		Apply:             runApply,
+		ApplyFallback:     runApplyFallback,
+		NumCtx:            runNumCtx,
+		Mode:              runMode,
+	}
+}
+
+// bindRunFlags binds the run command's flags to Viper keys so that env vars
+// and config file values participate in precedence resolution.
+func bindRunFlags(v *viper.Viper) {
+	flags := runCmd.Flags()
+	_ = v.BindPFlag("provider.default", flags.Lookup("provider"))
+	_ = v.BindPFlag("model.default", flags.Lookup("model"))
+	_ = v.BindPFlag("model.temperature", flags.Lookup("temperature"))
+	_ = v.BindPFlag("model.max_tokens", flags.Lookup("max-tokens"))
+	_ = v.BindPFlag("provider.base_url", flags.Lookup("base-url"))
+	_ = v.BindPFlag("provider.organization", flags.Lookup("organization"))
+	_ = v.BindPFlag("provider.api_version", flags.Lookup("api-version"))
+	_ = v.BindPFlag("provider.api_type", flags.Lookup("api-type"))
+	_ = v.BindPFlag("provider.openai_compat_max_tokens", flags.Lookup("openai-compat-max-tokens"))
+	_ = v.BindPFlag("provider.token", flags.Lookup("api-key"))
+}
+
 var runCmd = &cobra.Command{
-	Use:   "run [prompt]",
-	Short: "Run an agent workflow",
-	Args:  cobra.ArbitraryArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if runAgent == "" {
-			return fmt.Errorf("--agent is required")
-		}
-
-		prompt, err := readPrompt(cmd, args)
-		if err != nil {
-			return err
-		}
-
-		workingDir, err := resolveWorkingDir(runWorkingDir)
-		if err != nil {
-			return err
-		}
-
-		agentsDir, err := resolveAgentsDir(runAgentsDir)
-		if err != nil {
-			return err
-		}
-
-		bundle, err := buildAgentBundle(agentsDir, runAgent, prompt, workingDir)
-		if err != nil {
-			return err
-		}
-
-		logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", runAgent, runProvider, runModel)
-
-		if runPrintBundle {
-			if _, err := io.Copy(cmd.OutOrStdout(), bytes.NewReader(bundle.Combined)); err != nil {
-				return err
-			}
-		}
-
-		if runBundleOut != "" {
-			if err := os.WriteFile(runBundleOut, bundle.Combined, 0o644); err != nil {
-				return fmt.Errorf("failed to write bundle: %w", err)
-			}
-			logging.InfoContext(cmd.Context(), "bundle written to %s", runBundleOut)
-		}
-
-		if runDryRun {
+	Use:     "run [prompt]",
+	Aliases: []string{"r"},
+	Short:   "Run an agent workflow",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
 			return nil
 		}
-
-		cfg := configFromContext(cmd)
-		if cfg == nil {
-			return fmt.Errorf("config not available in context")
+		if hasPipedInput(cmd.InOrStdin()) {
+			return nil
 		}
-
-		provider := normalizeProvider(pickString(runProvider, cfg.Provider.Default))
-		model := pickString(runModel, cfg.Model.Default)
-		temperature := pickFloat(runTemperature, cfg.Model.Temperature)
-		maxTokens := pickInt(runMaxTokens, cfg.Model.MaxTokens)
-
-		systemPrompt := bundle.System
-		if runSystem != "" {
-			systemPrompt += "\n\n## System Override\n\n" + strings.TrimSpace(runSystem) + "\n"
-		}
-
-		var response string
-
-		if useResponsesAPI(provider, model) {
-			apiKey, err := resolveResponsesAPIKey(cfg.Provider.Token)
-			if err != nil {
-				return err
-			}
-			baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
-			org := pickString(runOrg, cfg.Provider.Organization)
-
-			logging.InfoContext(cmd.Context(), "model call started via Responses API (provider=%s model=%s)", provider, model)
-			modelStart := time.Now()
-			response, err = runWithToolsResponses(cmd.Context(), apiKey, baseURL, model, systemPrompt, bundle.User, bundle.WorkDir, org, temperature, maxTokens)
-			if err != nil {
-				return fmt.Errorf("model call failed: %w", err)
-			}
-			logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
-		} else {
-			llm, err := buildLLM(provider, model, cfg)
-			if err != nil {
-				return err
-			}
-
-			callOpts := []llms.CallOption{
-				llms.WithTemperature(temperature),
-			}
-
-			if maxTokens > 0 {
-				if isOpenAICompatProvider(provider) {
-					useLegacy := provider != "openai" || runOpenAICompatMax || cfg.Provider.OpenAICompatMaxTokens
-					if useLegacy {
-						callOpts = append(callOpts, llms.WithMaxTokens(maxTokens), openai.WithLegacyMaxTokensField())
-					} else {
-						callOpts = append(callOpts, openai.WithMaxCompletionTokens(maxTokens))
-					}
-				} else {
-					callOpts = append(callOpts, llms.WithMaxTokens(maxTokens))
-				}
-			}
-
-			logging.InfoContext(cmd.Context(), "model call started (provider=%s model=%s)", provider, model)
-			modelStart := time.Now()
-			response, err = runWithTools(cmd.Context(), llm, systemPrompt, bundle.User, bundle.WorkDir, callOpts...)
-			if err != nil {
-				return fmt.Errorf("model call failed: %w", err)
-			}
-			logging.InfoContext(cmd.Context(), "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
-		}
-
-		if runRequireActionable {
-			if err := validateActionableResponse(response); err != nil {
-				return err
-			}
-		}
-
-		if runApply {
-			diff, err := extractUnifiedDiff(response)
-			if err != nil {
-				return err
-			}
-			logging.InfoContext(cmd.Context(), "applying diff (%d bytes)", len(diff))
-			if err := applyUnifiedDiff(cmd.Context(), workingDir, diff); err != nil {
-				return err
-			}
-			logging.InfoContext(cmd.Context(), "diff applied to %s", workingDir)
-		}
-
-		if runPrint || runOutput == "" {
-			if _, err := fmt.Fprintln(cmd.OutOrStdout(), response); err != nil {
-				return err
-			}
-		}
-
-		if runOutput != "" {
-			if err := os.WriteFile(runOutput, []byte(response), 0o644); err != nil {
-				return fmt.Errorf("failed to write response: %w", err)
-			}
-			logging.InfoContext(cmd.Context(), "response written to %s", runOutput)
-		}
-		return nil
+		return fmt.Errorf("prompt is required (pass args or pipe stdin)")
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := newRunOptions()
+		return executeRun(cmd, args, opts)
 	},
 }
 
 func init() {
 	runCmd.Flags().StringVar(&runAgent, "agent", "", "Agent name (e.g. go-cobra)")
+	if err := runCmd.MarkFlagRequired("agent"); err != nil {
+		panic(err)
+	}
 	runCmd.Flags().StringVar(&runAgentsDir, "agents-dir", "", "Agents directory (default: ./agents, then ~/.config/squad/agents)")
 	runCmd.Flags().StringVar(&runWorkingDir, "working-dir", "", "Working directory (default: current working directory)")
 	runCmd.Flags().StringVar(&runAPIKey, "api-key", "", "API key (overrides env/config)")
@@ -240,31 +193,222 @@ func init() {
 	runCmd.Flags().BoolVar(&runApplyFallback, "apply-fallback", false, "Fallback to patch(1) if git apply fails (may create .rej/.orig)")
 	runCmd.Flags().IntVar(&runNumCtx, "num-ctx", 32768, "Context window size for Ollama models")
 	runCmd.Flags().StringVar(&runMode, "mode", "", "Agent mode override (e.g. readonly)")
+
+	runCmd.MarkFlagsMutuallyExclusive("dry-run", "apply")
+
+	// Dynamic completions for --agent (scan agents directories).
+	_ = runCmd.RegisterFlagCompletionFunc("agent", completeAgentNames)
+	// Static completions for --provider.
+	_ = runCmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
-// agentModeOverride represents an override for agent mode configuration in the manifest.
-type agentModeOverride struct {
-	EntryPoint string   `yaml:"entrypoint,omitempty"`
-	Wrapper    string   `yaml:"wrapper,omitempty"`
-	References []string `yaml:"references,omitempty"`
+// executeRun contains the full run command logic, parameterized by RunOptions.
+func executeRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
+	prompt, err := readPrompt(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	workingDir, err := resolveWorkingDir(opts.WorkingDir)
+	if err != nil {
+		return err
+	}
+
+	bundle, err := prepareBundle(cmd, opts, prompt, workingDir)
+	if err != nil {
+		return err
+	}
+	if bundle == nil {
+		return nil // dry-run
+	}
+
+	tools.ResetEditsApplied()
+	response, err := invokeModel(cmd, opts, bundle)
+	if err != nil {
+		return err
+	}
+
+	return handleResponse(cmd, opts, response, workingDir)
 }
 
-// agentManifest represents the structure of an agent's manifest file.
-type agentManifest struct {
-	Name       string                       `yaml:"name"`
-	Version    string                       `yaml:"version"`
-	EntryPoint string                       `yaml:"entrypoint"`
-	Wrapper    string                       `yaml:"wrapper"`
-	References []string                     `yaml:"references"`
-	Modes      map[string]agentModeOverride `yaml:"modes,omitempty"`
+// prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
+func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir string) (*agent.Bundle, error) {
+	agentsDir, err := resolveAgentsDir(opts.AgentsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle, err := agent.BuildBundle(agentsDir, opts.Agent, prompt, workingDir, opts.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", opts.Agent, opts.Provider, opts.Model)
+
+	if opts.PrintBundle {
+		if _, err := io.Copy(cmd.OutOrStdout(), bytes.NewReader(bundle.Combined)); err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.BundleOut != "" {
+		if err := os.WriteFile(opts.BundleOut, bundle.Combined, 0o644); err != nil {
+			return nil, fmt.Errorf("failed to write bundle: %w", err)
+		}
+		logging.InfoContext(cmd.Context(), "bundle written to %s", opts.BundleOut)
+	}
+
+	if opts.DryRun {
+		return nil, nil
+	}
+
+	if configFromContext(cmd) == nil {
+		return nil, fmt.Errorf("config not available in context")
+	}
+
+	return bundle, nil
 }
 
-// agentBundle contains the assembled system, user, and combined prompt content for an agent run.
-type agentBundle struct {
-	System   string // wrapper + system prompt + references
-	User     string // user request only
-	Combined []byte // concatenated for --print-bundle/--bundle-out
-	WorkDir  string
+// invokeModel resolves provider settings and calls the appropriate model backend.
+func invokeModel(cmd *cobra.Command, opts *RunOptions, bundle *agent.Bundle) (string, error) {
+	v := appViper
+	provider := normalizeProvider(v.GetString("provider.default"))
+	model := v.GetString("model.default")
+	temperature := v.GetFloat64("model.temperature")
+	maxTokens := v.GetInt("model.max_tokens")
+
+	systemPrompt := bundle.System
+	if opts.System != "" {
+		systemPrompt += "\n\n## System Override\n\n" + strings.TrimSpace(opts.System) + "\n"
+	}
+
+	return callModel(cmd.Context(), v, provider, model, systemPrompt, bundle, temperature, maxTokens)
+}
+
+// handleResponse validates, applies, and writes the model response.
+func handleResponse(cmd *cobra.Command, opts *RunOptions, response, workingDir string) error {
+	if opts.RequireActionable {
+		if err := validateActionableResponse(response); err != nil {
+			return err
+		}
+	}
+
+	if opts.Apply {
+		if err := applyResponseDiff(cmd.Context(), response, workingDir, opts.ApplyFallback); err != nil {
+			return err
+		}
+	}
+
+	return writeResponse(cmd, response, opts)
+}
+
+// callModel dispatches the prompt to the appropriate model backend and returns the response.
+func callModel(ctx context.Context, v *viper.Viper, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int) (string, error) {
+	if openairesponses.UseResponsesAPI(provider, model) {
+		return callResponsesAPI(ctx, v, model, systemPrompt, bundle, temperature, maxTokens)
+	}
+	return callLangChainLLM(ctx, v, provider, model, systemPrompt, bundle, temperature, maxTokens)
+}
+
+// callResponsesAPI runs the prompt via the OpenAI Responses API.
+func callResponsesAPI(ctx context.Context, v *viper.Viper, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int) (string, error) {
+	apiKey := v.GetString("provider.token")
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("API key required for OpenAI Responses API: use --api-key, config provider.token, or OPENAI_API_KEY env var")
+	}
+
+	logging.InfoContext(ctx, "model call started via Responses API (model=%s)", model)
+	modelStart := time.Now()
+	response, err := openairesponses.RunWithTools(ctx, apiKey, v.GetString("provider.base_url"), model, systemPrompt, bundle.User, bundle.WorkDir, v.GetString("provider.organization"), temperature, maxTokens)
+	if err != nil {
+		return "", fmt.Errorf("model call failed: %w", err)
+	}
+	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
+	return response, nil
+}
+
+// callLangChainLLM runs the prompt via a LangChain-compatible LLM.
+func callLangChainLLM(ctx context.Context, v *viper.Viper, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int) (string, error) {
+	llm, err := buildLLM(provider, model)
+	if err != nil {
+		return "", err
+	}
+
+	callOpts := buildCallOpts(v, provider, temperature, maxTokens)
+
+	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
+	modelStart := time.Now()
+	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, callOpts...)
+	if err != nil {
+		return "", fmt.Errorf("model call failed: %w", err)
+	}
+	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
+	return response, nil
+}
+
+// buildCallOpts constructs LLM call options from provider settings.
+func buildCallOpts(v *viper.Viper, provider string, temperature float64, maxTokens int) []llms.CallOption {
+	callOpts := []llms.CallOption{
+		llms.WithTemperature(temperature),
+	}
+	if maxTokens <= 0 {
+		return callOpts
+	}
+	if !isOpenAICompatProvider(provider) {
+		return append(callOpts, llms.WithMaxTokens(maxTokens))
+	}
+	useLegacy := provider != "openai" || v.GetBool("provider.openai_compat_max_tokens")
+	if useLegacy {
+		return append(callOpts, llms.WithMaxTokens(maxTokens), openai.WithLegacyMaxTokensField())
+	}
+	return append(callOpts, openai.WithMaxCompletionTokens(maxTokens))
+}
+
+// applyResponseDiff extracts and applies a unified diff from the model response.
+func applyResponseDiff(ctx context.Context, response, workingDir string, fallback bool) error {
+	diff, err := extractUnifiedDiff(response)
+	if err != nil {
+		if responseIndicatesNoChanges(response) {
+			logging.InfoContext(ctx, "no changes reported; skipping apply")
+			return nil
+		}
+		if tools.EditsApplied() {
+			logging.InfoContext(ctx, "edits already applied via tools; skipping diff apply")
+			return nil
+		}
+		return err
+	}
+	if tools.EditsApplied() {
+		logging.InfoContext(ctx, "edits already applied via tools; skipping diff apply")
+		return nil
+	}
+	logging.InfoContext(ctx, "applying diff (%d bytes)", len(diff))
+	if err := applyUnifiedDiff(ctx, workingDir, diff, fallback); err != nil {
+		return err
+	}
+	logging.InfoContext(ctx, "diff applied to %s", workingDir)
+	return nil
+}
+
+// writeResponse outputs the model response to stdout and/or a file.
+func writeResponse(cmd *cobra.Command, response string, opts *RunOptions) error {
+	if opts.Print || opts.Output == "" {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), response); err != nil {
+			return err
+		}
+	}
+	if opts.Output != "" {
+		if err := os.WriteFile(opts.Output, []byte(response), 0o644); err != nil {
+			return fmt.Errorf("failed to write response: %w", err)
+		}
+		logging.InfoContext(cmd.Context(), "response written to %s", opts.Output)
+	}
+	return nil
 }
 
 func readPrompt(cmd *cobra.Command, args []string) (string, error) {
@@ -281,6 +425,20 @@ func readPrompt(cmd *cobra.Command, args []string) (string, error) {
 		return "", fmt.Errorf("prompt is required (pass args or pipe stdin)")
 	}
 	return prompt, nil
+}
+
+func hasPipedInput(r io.Reader) bool {
+	if f, ok := r.(*os.File); ok {
+		fi, err := f.Stat()
+		if err != nil {
+			return false
+		}
+		return (fi.Mode() & os.ModeCharDevice) == 0
+	}
+	if b, ok := r.(*bytes.Buffer); ok {
+		return b.Len() > 0
+	}
+	return false
 }
 
 func resolveWorkingDir(dir string) (string, error) {
@@ -306,216 +464,108 @@ func resolveAgentsDir(explicit string) (string, error) {
 	return filepath.Join(home, ".config", "squad", "agents"), nil
 }
 
-// buildAgentBundle assembles the agent bundle from manifest, system prompt, wrapper, and references.
-func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) (*agentBundle, error) {
-	agentPath := filepath.Join(agentsDir, agentName)
-	manifestPath := filepath.Join(agentPath, "agent.yaml")
-	manifestData, err := os.ReadFile(manifestPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read agent manifest: %w", err)
-	}
-
-	var manifest agentManifest
-	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
-	}
-
-	if runMode != "" {
-		override, ok := manifest.Modes[runMode]
-		if !ok {
-			return nil, fmt.Errorf("agent %q has no mode %q", agentName, runMode)
-		}
-		if override.EntryPoint != "" {
-			manifest.EntryPoint = override.EntryPoint
-		}
-		if override.Wrapper != "" {
-			manifest.Wrapper = override.Wrapper
-		}
-		if len(override.References) > 0 {
-			manifest.References = override.References
-		}
-	}
-
-	entryPath := filepath.Join(agentPath, manifest.EntryPoint)
-	systemData, err := os.ReadFile(entryPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read system prompt: %w", err)
-	}
-
-	wrapperPath := filepath.Join(agentPath, manifest.Wrapper)
-	wrapperData, err := os.ReadFile(wrapperPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read agent wrapper: %w", err)
-	}
-
-	var refs []string
-	for _, ref := range manifest.References {
-		if strings.TrimSpace(ref) == "" {
-			continue
-		}
-		refPath := filepath.Join(agentPath, ref)
-		refData, err := os.ReadFile(refPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read reference %s: %w", ref, err)
-		}
-		refs = append(refs, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(string(refData))))
-	}
-
-	// Build the system message content (wrapper + system prompt + references).
-	var sys bytes.Buffer
-	sys.WriteString("# Squad Agent Bundle\n\n")
-	sys.WriteString(fmt.Sprintf("Agent: %s (%s)\n", manifest.Name, manifest.Version))
-	sys.WriteString(fmt.Sprintf("Working Directory: %s\n\n", workingDir))
-	sys.WriteString("## Agent Wrapper\n\n")
-	sys.Write(wrapperData)
-	sys.WriteString("\n\n## System Prompt\n\n")
-	sys.Write(systemData)
-
-	if len(refs) > 0 {
-		sys.WriteString("\n\n## References\n\n")
-		for _, ref := range refs {
-			sys.WriteString(ref)
-			sys.WriteString("\n")
-		}
-	}
-
-	// Build the combined output for --print-bundle/--bundle-out.
-	var combined bytes.Buffer
-	combined.Write(sys.Bytes())
-	combined.WriteString("\n\n## User Request\n\n")
-	combined.WriteString(prompt)
-	combined.WriteString("\n")
-
-	return &agentBundle{
-		System:   sys.String(),
-		User:     prompt,
-		Combined: combined.Bytes(),
-		WorkDir:  workingDir,
-	}, nil
-}
-
 // buildLLM constructs an LLM model instance based on the provider and configuration.
-func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
+func buildLLM(provider, model string) (llms.Model, error) {
 	provider = normalizeProvider(provider)
 	switch provider {
 	case "ollama":
-		return buildNativeOllamaLLM(model, cfg), nil
+		return buildNativeOllamaLLM(model), nil
 	case "openai", "":
-		return buildOpenAICompatLLM(provider, model, cfg)
+		return buildOpenAICompatLLM(provider, model)
 	case "anthropic":
-		return buildAnthropicLLM(model, cfg)
+		return buildAnthropicLLM(model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
 }
 
-// buildOpenAICompatLLM creates an OpenAI-compatible LLM model with the given configuration.
-func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
-	opts := []openai.Option{}
+func buildOpenAICompatLLM(provider, model string) (llms.Model, error) {
+	v := appViper
+	oaiOpts := []openai.Option{}
 	if model != "" {
-		opts = append(opts, openai.WithModel(model))
+		oaiOpts = append(oaiOpts, openai.WithModel(model))
 	}
 
-	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
-	if baseURL != "" {
-		opts = append(opts, openai.WithBaseURL(baseURL))
+	if baseURL := v.GetString("provider.base_url"); baseURL != "" {
+		oaiOpts = append(oaiOpts, openai.WithBaseURL(baseURL))
 	}
 
-	token := pickString(runAPIKey, cfg.Provider.Token)
-	if token != "" {
-		opts = append(opts, openai.WithToken(token))
+	if token := v.GetString("provider.token"); token != "" {
+		oaiOpts = append(oaiOpts, openai.WithToken(token))
 	}
 
 	if provider == "openai" || provider == "" {
-		org := pickString(runOrg, cfg.Provider.Organization)
-		if org != "" {
-			opts = append(opts, openai.WithOrganization(org))
+		if org := v.GetString("provider.organization"); org != "" {
+			oaiOpts = append(oaiOpts, openai.WithOrganization(org))
 		}
 
-		apiVersion := pickString(runAPIVersion, cfg.Provider.APIVersion)
-		if apiVersion != "" {
-			opts = append(opts, openai.WithAPIVersion(apiVersion))
+		if apiVersion := v.GetString("provider.api_version"); apiVersion != "" {
+			oaiOpts = append(oaiOpts, openai.WithAPIVersion(apiVersion))
 		}
 
-		apiType := strings.ToLower(pickString(runAPIType, cfg.Provider.APIType))
-		if apiType == "azure" {
-			opts = append(opts, openai.WithAPIType(openai.APITypeAzure))
+		if apiType := strings.ToLower(v.GetString("provider.api_type")); apiType == "azure" {
+			oaiOpts = append(oaiOpts, openai.WithAPIType(openai.APITypeAzure))
 		}
 	}
 
-	return openai.New(opts...)
+	return openai.New(oaiOpts...)
 }
 
-// buildAnthropicLLM creates an Anthropic LLM model with the given configuration.
-func buildAnthropicLLM(model string, cfg *config.Config) (llms.Model, error) {
-	opts := []anthropic.Option{}
+func buildAnthropicLLM(model string) (llms.Model, error) {
+	v := appViper
+	aOpts := []anthropic.Option{}
 	if model != "" {
-		opts = append(opts, anthropic.WithModel(model))
+		aOpts = append(aOpts, anthropic.WithModel(model))
 	}
 
-	token := pickString(runAPIKey, cfg.Provider.Token)
-	if token != "" {
-		opts = append(opts, anthropic.WithToken(token))
+	if token := v.GetString("provider.token"); token != "" {
+		aOpts = append(aOpts, anthropic.WithToken(token))
 	}
 
-	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
-	if baseURL != "" {
-		opts = append(opts, anthropic.WithBaseURL(baseURL))
+	if baseURL := v.GetString("provider.base_url"); baseURL != "" {
+		aOpts = append(aOpts, anthropic.WithBaseURL(baseURL))
 	}
 
-	return anthropic.New(opts...)
+	return anthropic.New(aOpts...)
 }
 
 func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
-func buildNativeOllamaLLM(model string, cfg *config.Config) llms.Model {
-	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
+func buildNativeOllamaLLM(model string) llms.Model {
+	v := appViper
+	baseURL := v.GetString("provider.base_url")
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	}
-	numCtx := pickInt(runNumCtx, 32768)
-	return newOllamaLLM(baseURL, model, numCtx)
+	numCtx := runNumCtx
+	if numCtx <= 0 {
+		numCtx = 32768
+	}
+	return ollama.New(baseURL, model, numCtx)
 }
 
 func isOpenAICompatProvider(provider string) bool {
 	return provider == "" || provider == "openai"
 }
 
-func pickString(value, fallback string) string {
-	if strings.TrimSpace(value) != "" {
-		return value
-	}
-	return fallback
-}
-
-func pickFloat(value, fallback float64) float64 {
-	if value >= 0 {
-		return value
-	}
-	return fallback
-}
-
-func pickInt(value, fallback int) int {
-	if value >= 0 {
-		return value
-	}
-	return fallback
-}
-
 func validateActionableResponse(response string) error {
+	if tools.EditsApplied() {
+		return nil
+	}
+	if _, err := extractUnifiedDiff(response); err == nil {
+		return nil
+	}
 	lower := strings.ToLower(response)
-	if strings.Contains(response, "```diff") {
-		return nil
-	}
-	if strings.Contains(lower, "files touched") {
-		return nil
-	}
-	if strings.Contains(lower, "no changes") {
+	if strings.Contains(lower, "files touched") || strings.Contains(lower, "no changes") {
 		return nil
 	}
 	return fmt.Errorf("response is not actionable: missing diff, files touched, or no changes section (disable with --require-actionable=false)")
+}
+
+func responseIndicatesNoChanges(response string) bool {
+	return strings.Contains(strings.ToLower(response), "no changes")
 }
 
 func extractUnifiedDiff(response string) (string, error) {
@@ -558,7 +608,7 @@ func extractUnifiedDiff(response string) (string, error) {
 	return diff, nil
 }
 
-func applyUnifiedDiff(ctx context.Context, workingDir, diff string) error {
+func applyUnifiedDiff(ctx context.Context, workingDir, diff string, applyFallback bool) error {
 	if strings.TrimSpace(diff) == "" {
 		return fmt.Errorf("diff content is empty")
 	}
@@ -568,8 +618,8 @@ func applyUnifiedDiff(ctx context.Context, workingDir, diff string) error {
 		return nil
 	}
 
-	if !runApplyFallback {
-		return fmt.Errorf("failed to apply diff with git: %v", gitErr)
+	if !applyFallback {
+		return fmt.Errorf("failed to apply diff with git: %v (hint: retry with --apply-fallback)", gitErr)
 	}
 
 	patchErr := applyWithPatch(ctx, workingDir, diff)
@@ -599,6 +649,28 @@ func applyWithGit(ctx context.Context, workingDir, diff string) error {
 		return fmt.Errorf("git apply failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func completeAgentNames(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	dirs := []string{"agents"}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".config", "squad", "agents"))
+	}
+	var names []string
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() && !seen[e.Name()] && strings.HasPrefix(e.Name(), toComplete) {
+				seen[e.Name()] = true
+				names = append(names, e.Name())
+			}
+		}
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
 func applyWithPatch(ctx context.Context, workingDir, diff string) error {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -65,6 +65,7 @@ var (
 	runRequireActionable bool
 	runApply             bool
 	runApplyFallback     bool
+	runNumCtx            int
 )
 
 var runCmd = &cobra.Command{
@@ -217,6 +218,7 @@ func init() {
 	runCmd.Flags().BoolVar(&runRequireActionable, "require-actionable", true, "Require actionable output (diff/files/no changes)")
 	runCmd.Flags().BoolVar(&runApply, "apply", false, "Apply unified diff from the response to the working directory")
 	runCmd.Flags().BoolVar(&runApplyFallback, "apply-fallback", false, "Fallback to patch(1) if git apply fails (may create .rej/.orig)")
+	runCmd.Flags().IntVar(&runNumCtx, "num-ctx", 32768, "Context window size for Ollama models")
 }
 
 type agentManifest struct {
@@ -331,7 +333,9 @@ func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) ([]byte, 
 func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 	provider = normalizeProvider(provider)
 	switch provider {
-	case "openai", "", "ollama":
+	case "ollama":
+		return buildNativeOllamaLLM(model, cfg), nil
+	case "openai", "":
 		return buildOpenAICompatLLM(provider, model, cfg)
 	case "anthropic":
 		return buildAnthropicLLM(model, cfg)
@@ -347,17 +351,11 @@ func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Mode
 	}
 
 	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
-	if baseURL == "" && provider == "ollama" {
-		baseURL = "http://localhost:11434/v1"
-	}
 	if baseURL != "" {
 		opts = append(opts, openai.WithBaseURL(baseURL))
 	}
 
 	token := pickString(runAPIKey, cfg.Provider.Token)
-	if token == "" && provider == "ollama" {
-		token = "ollama"
-	}
 	if token != "" {
 		opts = append(opts, openai.WithToken(token))
 	}
@@ -405,8 +403,17 @@ func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
+func buildNativeOllamaLLM(model string, cfg *config.Config) llms.Model {
+	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	}
+	numCtx := pickInt(runNumCtx, 32768)
+	return newOllamaLLM(baseURL, model, numCtx)
+}
+
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai" || provider == "ollama"
+	return provider == "" || provider == "openai"
 }
 
 func pickString(value, fallback string) string {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -223,12 +223,14 @@ func init() {
 	runCmd.Flags().StringVar(&runMode, "mode", "", "Agent mode override (e.g. readonly)")
 }
 
+// agentModeOverride represents an override for agent mode configuration in the manifest.
 type agentModeOverride struct {
 	EntryPoint string   `yaml:"entrypoint,omitempty"`
 	Wrapper    string   `yaml:"wrapper,omitempty"`
 	References []string `yaml:"references,omitempty"`
 }
 
+// agentManifest represents the structure of an agent's manifest file.
 type agentManifest struct {
 	Name       string                       `yaml:"name"`
 	Version    string                       `yaml:"version"`
@@ -238,6 +240,7 @@ type agentManifest struct {
 	Modes      map[string]agentModeOverride `yaml:"modes,omitempty"`
 }
 
+// agentBundle contains the assembled system, user, and combined prompt content for an agent run.
 type agentBundle struct {
 	System   string // wrapper + system prompt + references
 	User     string // user request only
@@ -284,6 +287,7 @@ func resolveAgentsDir(explicit string) (string, error) {
 	return filepath.Join(home, ".config", "squad", "agents"), nil
 }
 
+// buildAgentBundle assembles the agent bundle from manifest, system prompt, wrapper, and references.
 func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) (*agentBundle, error) {
 	agentPath := filepath.Join(agentsDir, agentName)
 	manifestPath := filepath.Join(agentPath, "agent.yaml")
@@ -371,6 +375,7 @@ func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) (*agentBu
 	}, nil
 }
 
+// buildLLM constructs an LLM model instance based on the provider and configuration.
 func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 	provider = normalizeProvider(provider)
 	switch provider {
@@ -385,6 +390,7 @@ func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 	}
 }
 
+// buildOpenAICompatLLM creates an OpenAI-compatible LLM model with the given configuration.
 func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 	opts := []openai.Option{}
 	if model != "" {
@@ -421,6 +427,7 @@ func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Mode
 	return openai.New(opts...)
 }
 
+// buildAnthropicLLM creates an Anthropic LLM model with the given configuration.
 func buildAnthropicLLM(model string, cfg *config.Config) (llms.Model, error) {
 	opts := []anthropic.Option{}
 	if model != "" {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -41,7 +41,7 @@ import (
 var (
 	runAgent             string
 	runAgentsDir         string
-	runRepo              string
+	runWorkingDir        string
 	runAPIKey            string
 	runBaseURL           string
 	runOrg               string
@@ -75,7 +75,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		repoPath, err := resolveRepo(runRepo)
+		workingDir, err := resolveWorkingDir(runWorkingDir)
 		if err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		bundle, err := buildAgentBundle(agentsDir, runAgent, prompt, repoPath)
+		bundle, bundleWorkingDir, err := buildAgentBundle(agentsDir, runAgent, prompt, workingDir)
 		if err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ var runCmd = &cobra.Command{
 			fullPrompt = injectSystemOverride(fullPrompt, runSystem)
 		}
 
-		response, err := llms.GenerateFromSinglePrompt(cmd.Context(), llm, fullPrompt, callOpts...)
+		response, err := runWithTools(cmd.Context(), llm, fullPrompt, bundleWorkingDir, callOpts...)
 		if err != nil {
 			return fmt.Errorf("model call failed: %w", err)
 		}
@@ -175,7 +175,7 @@ var runCmd = &cobra.Command{
 func init() {
 	runCmd.Flags().StringVar(&runAgent, "agent", "", "Agent name (e.g. go-cobra)")
 	runCmd.Flags().StringVar(&runAgentsDir, "agents-dir", "", "Agents directory (default: ./agents, then ~/.config/squad/agents)")
-	runCmd.Flags().StringVar(&runRepo, "repo", "", "Repo path (default: current working directory)")
+	runCmd.Flags().StringVar(&runWorkingDir, "working-dir", "", "Working directory (default: current working directory)")
 	runCmd.Flags().StringVar(&runAPIKey, "api-key", "", "API key (overrides env/config)")
 	runCmd.Flags().StringVar(&runBaseURL, "base-url", "", "Base URL override for provider")
 	runCmd.Flags().StringVar(&runOrg, "organization", "", "Organization ID (OpenAI-compatible)")
@@ -219,11 +219,11 @@ func readPrompt(cmd *cobra.Command, args []string) (string, error) {
 	return prompt, nil
 }
 
-func resolveRepo(repo string) (string, error) {
-	if repo == "" {
+func resolveWorkingDir(dir string) (string, error) {
+	if dir == "" {
 		return os.Getwd()
 	}
-	return filepath.Abs(repo)
+	return filepath.Abs(dir)
 }
 
 func resolveAgentsDir(explicit string) (string, error) {
@@ -242,29 +242,29 @@ func resolveAgentsDir(explicit string) (string, error) {
 	return filepath.Join(home, ".config", "squad", "agents"), nil
 }
 
-func buildAgentBundle(agentsDir, agentName, prompt, repoPath string) ([]byte, error) {
+func buildAgentBundle(agentsDir, agentName, prompt, workingDir string) ([]byte, string, error) {
 	agentPath := filepath.Join(agentsDir, agentName)
 	manifestPath := filepath.Join(agentPath, "agent.yaml")
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read agent manifest: %w", err)
+		return nil, "", fmt.Errorf("failed to read agent manifest: %w", err)
 	}
 
 	var manifest agentManifest
 	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
+		return nil, "", fmt.Errorf("failed to parse agent manifest: %w", err)
 	}
 
 	entryPath := filepath.Join(agentPath, manifest.EntryPoint)
 	systemData, err := os.ReadFile(entryPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read system prompt: %w", err)
+		return nil, "", fmt.Errorf("failed to read system prompt: %w", err)
 	}
 
 	wrapperPath := filepath.Join(agentPath, manifest.Wrapper)
 	wrapperData, err := os.ReadFile(wrapperPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read agent wrapper: %w", err)
+		return nil, "", fmt.Errorf("failed to read agent wrapper: %w", err)
 	}
 
 	var refs []string
@@ -275,7 +275,7 @@ func buildAgentBundle(agentsDir, agentName, prompt, repoPath string) ([]byte, er
 		refPath := filepath.Join(agentPath, ref)
 		refData, err := os.ReadFile(refPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read reference %s: %w", ref, err)
+			return nil, "", fmt.Errorf("failed to read reference %s: %w", ref, err)
 		}
 		refs = append(refs, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(string(refData))))
 	}
@@ -283,7 +283,7 @@ func buildAgentBundle(agentsDir, agentName, prompt, repoPath string) ([]byte, er
 	var buf bytes.Buffer
 	buf.WriteString("# Squad Agent Bundle\n\n")
 	buf.WriteString(fmt.Sprintf("Agent: %s (%s)\n", manifest.Name, manifest.Version))
-	buf.WriteString(fmt.Sprintf("Repo: %s\n\n", repoPath))
+	buf.WriteString(fmt.Sprintf("Working Directory: %s\n\n", workingDir))
 	buf.WriteString("## Agent Wrapper\n\n")
 	buf.Write(wrapperData)
 	buf.WriteString("\n\n## System Prompt\n\n")
@@ -301,7 +301,7 @@ func buildAgentBundle(agentsDir, agentName, prompt, repoPath string) ([]byte, er
 	buf.WriteString(prompt)
 	buf.WriteString("\n")
 
-	return buf.Bytes(), nil
+	return buf.Bytes(), workingDir, nil
 }
 
 func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/spf13/cobra"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic"
 	"github.com/tmc/langchaingo/llms/openai"
 	"gopkg.in/yaml.v3"
 )
@@ -332,6 +333,8 @@ func buildLLM(provider, model string, cfg *config.Config) (llms.Model, error) {
 	switch provider {
 	case "openai", "", "ollama":
 		return buildOpenAICompatLLM(provider, model, cfg)
+	case "anthropic":
+		return buildAnthropicLLM(model, cfg)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -377,6 +380,25 @@ func buildOpenAICompatLLM(provider, model string, cfg *config.Config) (llms.Mode
 	}
 
 	return openai.New(opts...)
+}
+
+func buildAnthropicLLM(model string, cfg *config.Config) (llms.Model, error) {
+	opts := []anthropic.Option{}
+	if model != "" {
+		opts = append(opts, anthropic.WithModel(model))
+	}
+
+	token := pickString(runAPIKey, cfg.Provider.Token)
+	if token != "" {
+		opts = append(opts, anthropic.WithToken(token))
+	}
+
+	baseURL := pickString(runBaseURL, cfg.Provider.BaseURL)
+	if baseURL != "" {
+		opts = append(opts, anthropic.WithBaseURL(baseURL))
+	}
+
+	return anthropic.New(opts...)
 }
 
 func normalizeProvider(provider string) string {

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupTestAgent creates a temporary agent directory with the given manifest
+// YAML and supporting files. Returns the agents dir path.
+func setupTestAgent(t *testing.T, name, manifestYAML string, files map[string]string) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, name)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifestYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for relPath, content := range files {
+		full := filepath.Join(agentDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return agentsDir
+}
+
+func TestBuildAgentBundle_DefaultMode(t *testing.T) {
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - refs/criteria.md
+modes:
+  readonly:
+    entrypoint: system-ro.md
+    wrapper: agent-ro.md
+`
+	files := map[string]string{
+		"system.md":        "default system prompt",
+		"agent.md":         "default wrapper",
+		"system-ro.md":     "readonly system prompt",
+		"agent-ro.md":      "readonly wrapper",
+		"refs/criteria.md": "review criteria content",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	// Save and restore runMode.
+	origMode := runMode
+	runMode = ""
+	t.Cleanup(func() { runMode = origMode })
+
+	bundle, err := buildAgentBundle(agentsDir, "test-agent", "review this", "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(bundle.System, "default system prompt") {
+		t.Error("expected default system prompt in bundle")
+	}
+	if !strings.Contains(bundle.System, "default wrapper") {
+		t.Error("expected default wrapper in bundle")
+	}
+	if strings.Contains(bundle.System, "readonly system prompt") {
+		t.Error("did not expect readonly system prompt in default mode")
+	}
+	if !strings.Contains(bundle.System, "review criteria content") {
+		t.Error("expected references in bundle")
+	}
+	if !strings.Contains(string(bundle.Combined), "review this") {
+		t.Error("expected user prompt in combined bundle")
+	}
+}
+
+func TestBuildAgentBundle_ReadonlyMode(t *testing.T) {
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - refs/criteria.md
+modes:
+  readonly:
+    entrypoint: system-ro.md
+    wrapper: agent-ro.md
+`
+	files := map[string]string{
+		"system.md":        "default system prompt",
+		"agent.md":         "default wrapper",
+		"system-ro.md":     "readonly system prompt",
+		"agent-ro.md":      "readonly wrapper",
+		"refs/criteria.md": "review criteria content",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	origMode := runMode
+	runMode = "readonly"
+	t.Cleanup(func() { runMode = origMode })
+
+	bundle, err := buildAgentBundle(agentsDir, "test-agent", "review this", "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(bundle.System, "readonly system prompt") {
+		t.Error("expected readonly system prompt in bundle")
+	}
+	if !strings.Contains(bundle.System, "readonly wrapper") {
+		t.Error("expected readonly wrapper in bundle")
+	}
+	if strings.Contains(bundle.System, "default system prompt") {
+		t.Error("did not expect default system prompt in readonly mode")
+	}
+	// References should still be inherited from defaults.
+	if !strings.Contains(bundle.System, "review criteria content") {
+		t.Error("expected default references to be inherited in readonly mode")
+	}
+}
+
+func TestBuildAgentBundle_ModeOverridesReferences(t *testing.T) {
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - refs/default-ref.md
+modes:
+  custom:
+    references:
+      - refs/custom-ref.md
+`
+	files := map[string]string{
+		"system.md":           "system prompt",
+		"agent.md":            "wrapper",
+		"refs/default-ref.md": "default reference",
+		"refs/custom-ref.md":  "custom reference",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	origMode := runMode
+	runMode = "custom"
+	t.Cleanup(func() { runMode = origMode })
+
+	bundle, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(bundle.System, "custom reference") {
+		t.Error("expected custom reference in bundle")
+	}
+	if strings.Contains(bundle.System, "default reference") {
+		t.Error("did not expect default reference when mode overrides references")
+	}
+}
+
+func TestBuildAgentBundle_NonexistentMode(t *testing.T) {
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+modes:
+  readonly:
+    entrypoint: system-ro.md
+`
+	files := map[string]string{
+		"system.md":    "system prompt",
+		"agent.md":     "wrapper",
+		"system-ro.md": "readonly system prompt",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	origMode := runMode
+	runMode = "nonexistent"
+	t.Cleanup(func() { runMode = origMode })
+
+	_, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	if err == nil {
+		t.Fatal("expected error for nonexistent mode")
+	}
+	if !strings.Contains(err.Error(), `has no mode "nonexistent"`) {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildAgentBundle_NoModesField(t *testing.T) {
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+`
+	files := map[string]string{
+		"system.md": "system prompt",
+		"agent.md":  "wrapper",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	origMode := runMode
+	runMode = "anything"
+	t.Cleanup(func() { runMode = origMode })
+
+	_, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	if err == nil {
+		t.Fatal("expected error when requesting mode on agent with no modes")
+	}
+	if !strings.Contains(err.Error(), `has no mode "anything"`) {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildAgentBundle_PartialOverride(t *testing.T) {
+	// Mode only overrides entrypoint, wrapper stays default.
+	manifest := `
+name: test-agent
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+modes:
+  lite:
+    entrypoint: system-lite.md
+`
+	files := map[string]string{
+		"system.md":      "default system",
+		"agent.md":       "default wrapper",
+		"system-lite.md": "lite system",
+	}
+	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
+
+	origMode := runMode
+	runMode = "lite"
+	t.Cleanup(func() { runMode = origMode })
+
+	bundle, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(bundle.System, "lite system") {
+		t.Error("expected lite system prompt")
+	}
+	if !strings.Contains(bundle.System, "default wrapper") {
+		t.Error("expected default wrapper to be preserved")
+	}
+}

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
 )
 
 // setupTestAgent creates a temporary agent directory with the given manifest
@@ -75,12 +77,7 @@ modes:
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	// Save and restore runMode.
-	origMode := runMode
-	runMode = ""
-	t.Cleanup(func() { runMode = origMode })
-
-	bundle, err := buildAgentBundle(agentsDir, "test-agent", "review this", "/tmp")
+	bundle, err := agent.BuildBundle(agentsDir, "test-agent", "review this", "/tmp", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,11 +121,7 @@ modes:
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	origMode := runMode
-	runMode = "readonly"
-	t.Cleanup(func() { runMode = origMode })
-
-	bundle, err := buildAgentBundle(agentsDir, "test-agent", "review this", "/tmp")
+	bundle, err := agent.BuildBundle(agentsDir, "test-agent", "review this", "/tmp", "readonly")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,11 +162,7 @@ modes:
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	origMode := runMode
-	runMode = "custom"
-	t.Cleanup(func() { runMode = origMode })
-
-	bundle, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	bundle, err := agent.BuildBundle(agentsDir, "test-agent", "test", "/tmp", "custom")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,11 +192,7 @@ modes:
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	origMode := runMode
-	runMode = "nonexistent"
-	t.Cleanup(func() { runMode = origMode })
-
-	_, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	_, err := agent.BuildBundle(agentsDir, "test-agent", "test", "/tmp", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent mode")
 	}
@@ -229,11 +214,7 @@ wrapper: agent.md
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	origMode := runMode
-	runMode = "anything"
-	t.Cleanup(func() { runMode = origMode })
-
-	_, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	_, err := agent.BuildBundle(agentsDir, "test-agent", "test", "/tmp", "anything")
 	if err == nil {
 		t.Fatal("expected error when requesting mode on agent with no modes")
 	}
@@ -260,11 +241,7 @@ modes:
 	}
 	agentsDir := setupTestAgent(t, "test-agent", manifest, files)
 
-	origMode := runMode
-	runMode = "lite"
-	t.Cleanup(func() { runMode = origMode })
-
-	bundle, err := buildAgentBundle(agentsDir, "test-agent", "test", "/tmp")
+	bundle, err := agent.BuildBundle(agentsDir, "test-agent", "test", "/tmp", "lite")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -22,13 +22,25 @@ const maxToolIterations = 100
 const maxToolOutput = 64 * 1024
 const maxSameToolRepeat = 10
 
+// mutatingTools are tools that legitimately chain in long sequences
+// (e.g. a judge applying many edits). The repetition guard uses a
+// higher threshold for these to avoid breaking valid workflows.
+var mutatingTools = map[string]bool{
+	"Edit":  true,
+	"Write": true,
+}
+
+const maxMutatingToolRepeat = 50
+
 type toolHandler struct {
 	def  llms.Tool
 	call func(ctx context.Context, rawArgs []byte) (string, error)
 }
 
 // toolRepeatTracker detects when the model is stuck calling the same
-// tool repeatedly (e.g. Bash in a loop).
+// tool repeatedly (e.g. Bash in a loop). Mutating tools like Edit and
+// Write get a higher threshold since sequential edits are expected
+// behavior for agents applying fixes.
 type toolRepeatTracker struct {
 	lastName string
 	count    int
@@ -48,7 +60,11 @@ func (t *toolRepeatTracker) update(calls []llms.ToolCall) {
 }
 
 func (t *toolRepeatTracker) exceeded() bool {
-	return t.count >= maxSameToolRepeat
+	limit := maxSameToolRepeat
+	if mutatingTools[t.lastName] {
+		limit = maxMutatingToolRepeat
+	}
+	return t.count >= limit
 }
 
 func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, callOpts ...llms.CallOption) (string, error) {

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -50,6 +50,9 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 		}
 
 		choice := response.Choices[0]
+		if gi := choice.GenerationInfo; gi != nil {
+			logging.DebugContext(ctx, "generation info: %v", gi)
+		}
 		if len(choice.ToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
 			return choice.Content, nil

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -1,0 +1,538 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+const maxToolIterations = 24
+const maxToolOutput = 64 * 1024
+
+type toolHandler struct {
+	def  llms.Tool
+	call func(ctx context.Context, rawArgs []byte) (string, error)
+}
+
+func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
+	handlers, toolDefs := buildToolHandlers(workingDir)
+	callOpts = append(callOpts, llms.WithTools(toolDefs))
+
+	messages := []llms.MessageContent{
+		{
+			Role:  llms.ChatMessageTypeHuman,
+			Parts: []llms.ContentPart{llms.TextPart(prompt)},
+		},
+	}
+
+	for i := 0; i < maxToolIterations; i++ {
+		response, err := llm.GenerateContent(ctx, messages, callOpts...)
+		if err != nil {
+			return "", err
+		}
+		if response == nil || len(response.Choices) == 0 {
+			return "", fmt.Errorf("model returned no choices")
+		}
+
+		choice := response.Choices[0]
+		if len(choice.ToolCalls) == 0 {
+			return choice.Content, nil
+		}
+
+		toolCallParts := make([]llms.ContentPart, 0, len(choice.ToolCalls))
+		for _, toolCall := range choice.ToolCalls {
+			toolCallParts = append(toolCallParts, llms.ToolCall{
+				ID:           toolCall.ID,
+				Type:         toolCall.Type,
+				FunctionCall: toolCall.FunctionCall,
+			})
+		}
+		messages = append(messages, llms.MessageContent{
+			Role:  llms.ChatMessageTypeAI,
+			Parts: toolCallParts,
+		})
+
+		for _, toolCall := range choice.ToolCalls {
+			toolResponse := llms.ToolCallResponse{
+				ToolCallID: toolCall.ID,
+			}
+			if toolCall.FunctionCall == nil {
+				toolResponse.Content = "tool call missing function definition"
+			} else if handler, ok := handlers[toolCall.FunctionCall.Name]; ok {
+				toolResponse.Name = toolCall.FunctionCall.Name
+				output, err := handler.call(ctx, []byte(toolCall.FunctionCall.Arguments))
+				if err != nil {
+					toolResponse.Content = fmt.Sprintf("error: %v", err)
+				} else {
+					toolResponse.Content = output
+				}
+			} else {
+				toolResponse.Content = fmt.Sprintf("unknown tool: %s", toolCall.FunctionCall.Name)
+			}
+
+			messages = append(messages, llms.MessageContent{
+				Role:  llms.ChatMessageTypeTool,
+				Parts: []llms.ContentPart{toolResponse},
+			})
+		}
+	}
+
+	return "", fmt.Errorf("tool loop exceeded %d iterations", maxToolIterations)
+}
+
+func buildToolHandlers(workingDir string) (map[string]toolHandler, []llms.Tool) {
+	handlers := map[string]toolHandler{}
+
+	add := func(handler toolHandler) {
+		name := handler.def.Function.Name
+		handlers[name] = handler
+	}
+
+	add(toolHandler{def: toolDefinitionRead(), call: readTool(workingDir)})
+	add(toolHandler{def: toolDefinitionWrite(), call: writeTool(workingDir)})
+	add(toolHandler{def: toolDefinitionEdit(), call: editTool(workingDir)})
+	add(toolHandler{def: toolDefinitionGlob(), call: globTool(workingDir)})
+	add(toolHandler{def: toolDefinitionGrep(), call: grepTool(workingDir)})
+	add(toolHandler{def: toolDefinitionBash(), call: bashTool(workingDir)})
+
+	toolDefs := make([]llms.Tool, 0, len(handlers))
+	for _, handler := range handlers {
+		toolDefs = append(toolDefs, handler.def)
+	}
+	sort.Slice(toolDefs, func(i, j int) bool {
+		return toolDefs[i].Function.Name < toolDefs[j].Function.Name
+	})
+
+	return handlers, toolDefs
+}
+
+func toolDefinitionRead() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Read",
+			Description: "Read a text file and return its contents.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{"type": "string", "description": "Path to the file."},
+				},
+				"required": []string{"path"},
+			},
+		},
+	}
+}
+
+func toolDefinitionWrite() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Write",
+			Description: "Write content to a file, creating directories as needed.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":    map[string]any{"type": "string", "description": "Path to the file."},
+					"content": map[string]any{"type": "string", "description": "File contents."},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+	}
+}
+
+func toolDefinitionEdit() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Edit",
+			Description: "Replace text in a file.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":        map[string]any{"type": "string", "description": "Path to the file."},
+					"old":         map[string]any{"type": "string", "description": "Text to replace."},
+					"new":         map[string]any{"type": "string", "description": "Replacement text."},
+					"replace_all": map[string]any{"type": "boolean", "description": "Replace all occurrences."},
+				},
+				"required": []string{"path", "old", "new"},
+			},
+		},
+	}
+}
+
+func toolDefinitionGlob() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Glob",
+			Description: "Find files matching a glob pattern (supports **).",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"pattern": map[string]any{"type": "string", "description": "Glob pattern (e.g. **/*.go)."},
+				},
+				"required": []string{"pattern"},
+			},
+		},
+	}
+}
+
+func toolDefinitionGrep() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Grep",
+			Description: "Search for a regex pattern in files under a path.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"pattern": map[string]any{"type": "string", "description": "Regex pattern to search for."},
+					"path":    map[string]any{"type": "string", "description": "File or directory path. Default: ."},
+				},
+				"required": []string{"pattern"},
+			},
+		},
+	}
+}
+
+func toolDefinitionBash() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "Bash",
+			Description: "Run a shell command in the working directory.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command": map[string]any{"type": "string", "description": "Shell command to run."},
+				},
+				"required": []string{"command"},
+			},
+		},
+	}
+}
+
+func readTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Path string `json:"path"`
+	}
+	return func(_ context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		path, err := resolvePath(workingDir, payload.Path)
+		if err != nil {
+			return "", err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+}
+
+func writeTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	return func(_ context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		path, err := resolvePath(workingDir, payload.Path)
+		if err != nil {
+			return "", err
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(path, []byte(payload.Content), 0o644); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("wrote %s (%d bytes)", filepath.ToSlash(payload.Path), len(payload.Content)), nil
+	}
+}
+
+func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Path       string `json:"path"`
+		Old        string `json:"old"`
+		New        string `json:"new"`
+		ReplaceAll bool   `json:"replace_all"`
+	}
+	return func(_ context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		path, err := resolvePath(workingDir, payload.Path)
+		if err != nil {
+			return "", err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		content := string(data)
+		if !strings.Contains(content, payload.Old) {
+			return "", fmt.Errorf("text not found in %s", payload.Path)
+		}
+		var updated string
+		replaced := 1
+		if payload.ReplaceAll {
+			replaced = strings.Count(content, payload.Old)
+			updated = strings.ReplaceAll(content, payload.Old, payload.New)
+		} else {
+			updated = strings.Replace(content, payload.Old, payload.New, 1)
+		}
+		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("updated %s (%d replacement(s))", filepath.ToSlash(payload.Path), replaced), nil
+	}
+}
+
+func globTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Pattern string `json:"pattern"`
+	}
+	return func(_ context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		pattern := strings.TrimSpace(payload.Pattern)
+		if pattern == "" {
+			return "", fmt.Errorf("pattern is required")
+		}
+		matcher, err := newGlobMatcher(pattern)
+		if err != nil {
+			return "", err
+		}
+		var matches []string
+		err = filepath.WalkDir(workingDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(workingDir, path)
+			if err != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if matcher.Match(rel) {
+				matches = append(matches, rel)
+			}
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+		sort.Strings(matches)
+		if len(matches) == 0 {
+			return "no matches", nil
+		}
+		return strings.Join(matches, "\n"), nil
+	}
+}
+
+func grepTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path"`
+	}
+	return func(_ context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		pattern := strings.TrimSpace(payload.Pattern)
+		if pattern == "" {
+			return "", fmt.Errorf("pattern is required")
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return "", fmt.Errorf("invalid regex: %w", err)
+		}
+		searchPath := payload.Path
+		if strings.TrimSpace(searchPath) == "" {
+			searchPath = "."
+		}
+		resolved, err := resolvePath(workingDir, searchPath)
+		if err != nil {
+			return "", err
+		}
+
+		var matches []string
+		visit := func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return nil
+			}
+			defer file.Close()
+			rel, err := filepath.Rel(workingDir, path)
+			if err != nil {
+				rel = path
+			}
+			scanner := bufio.NewScanner(file)
+			lineNum := 1
+			for scanner.Scan() {
+				line := scanner.Text()
+				if re.MatchString(line) {
+					matches = append(matches, fmt.Sprintf("%s:%d:%s", filepath.ToSlash(rel), lineNum, line))
+				}
+				lineNum++
+			}
+			return nil
+		}
+
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() {
+			if err := filepath.Walk(resolved, visit); err != nil {
+				return "", err
+			}
+		} else {
+			if err := visit(resolved, info, nil); err != nil {
+				return "", err
+			}
+		}
+
+		if len(matches) == 0 {
+			return "no matches", nil
+		}
+		return strings.Join(matches, "\n"), nil
+	}
+}
+
+func bashTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Command string `json:"command"`
+	}
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		command := strings.TrimSpace(payload.Command)
+		if command == "" {
+			return "", fmt.Errorf("command is required")
+		}
+		cmd := exec.CommandContext(ctx, "bash", "-lc", command)
+		cmd.Dir = workingDir
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		if err := cmd.Run(); err != nil {
+			output := limitOutput(buf.Bytes())
+			return string(output), fmt.Errorf("command failed: %w", err)
+		}
+		return string(limitOutput(buf.Bytes())), nil
+	}
+}
+
+func resolvePath(workingDir, input string) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	var joined string
+	if filepath.IsAbs(input) {
+		joined = filepath.Clean(input)
+	} else {
+		joined = filepath.Join(workingDir, input)
+	}
+	abs, err := filepath.Abs(joined)
+	if err != nil {
+		return "", err
+	}
+	wd, err := filepath.Abs(workingDir)
+	if err != nil {
+		return "", err
+	}
+	if abs != wd && !strings.HasPrefix(abs, wd+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside working directory", input)
+	}
+	return abs, nil
+}
+
+func limitOutput(data []byte) []byte {
+	if len(data) <= maxToolOutput {
+		return data
+	}
+	head := data[:maxToolOutput]
+	return append(head, []byte("\n...output truncated\n")...)
+}
+
+type globMatcher struct {
+	re *regexp.Regexp
+}
+
+func newGlobMatcher(pattern string) (*globMatcher, error) {
+	normalized := filepath.ToSlash(pattern)
+	regex, err := globToRegex(normalized)
+	if err != nil {
+		return nil, err
+	}
+	re, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, err
+	}
+	return &globMatcher{re: re}, nil
+}
+
+func (g *globMatcher) Match(path string) bool {
+	return g.re.MatchString(path)
+}
+
+func globToRegex(pattern string) (string, error) {
+	var buf strings.Builder
+	buf.WriteString("^")
+	runes := []rune(pattern)
+	for i := 0; i < len(runes); i++ {
+		ch := runes[i]
+		if ch == '*' {
+			if i+1 < len(runes) && runes[i+1] == '*' {
+				buf.WriteString(".*")
+				i++
+			} else {
+				buf.WriteString(`[^/]*`)
+			}
+			continue
+		}
+		if ch == '?' {
+			buf.WriteString(".")
+			continue
+		}
+		if strings.ContainsRune(`.+()|[]{}^$\\`, ch) {
+			buf.WriteString(`\`)
+		}
+		buf.WriteRune(ch)
+	}
+	buf.WriteString("$")
+	return buf.String(), nil
+}

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -20,10 +20,35 @@ import (
 
 const maxToolIterations = 100
 const maxToolOutput = 64 * 1024
+const maxSameToolRepeat = 10
 
 type toolHandler struct {
 	def  llms.Tool
 	call func(ctx context.Context, rawArgs []byte) (string, error)
+}
+
+// toolRepeatTracker detects when the model is stuck calling the same
+// tool repeatedly (e.g. Bash in a loop).
+type toolRepeatTracker struct {
+	lastName string
+	count    int
+}
+
+func (t *toolRepeatTracker) update(calls []llms.ToolCall) {
+	name := ""
+	if len(calls) == 1 && calls[0].FunctionCall != nil {
+		name = calls[0].FunctionCall.Name
+	}
+	if name != "" && name == t.lastName {
+		t.count++
+	} else {
+		t.count = 1
+		t.lastName = name
+	}
+}
+
+func (t *toolRepeatTracker) exceeded() bool {
+	return t.count >= maxSameToolRepeat
 }
 
 func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
@@ -31,18 +56,24 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
+	lastContent, messages := toolLoop(ctx, llm, messages, handlers, callOpts)
 
+	return finishToolLoop(ctx, llm, messages, lastContent, callOpts)
+}
+
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent) {
 	var lastContent string
+	var repeat toolRepeatTracker
 	for i := 0; i < maxToolIterations; i++ {
 		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
 		iterStart := time.Now()
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
 		iterDuration := time.Since(iterStart)
 		if err != nil {
-			return "", err
+			return lastContent, messages
 		}
 		if response == nil || len(response.Choices) == 0 {
-			return "", fmt.Errorf("model returned no choices")
+			return lastContent, messages
 		}
 
 		choice := response.Choices[0]
@@ -54,24 +85,33 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		}
 		if len(choice.ToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
-			return choice.Content, nil
+			return choice.Content, messages
 		}
 		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
+
+		repeat.update(choice.ToolCalls)
+		if repeat.exceeded() {
+			logging.InfoContext(ctx, "model called %s %d times in a row, breaking tool loop", repeat.lastName, repeat.count)
+			break
+		}
 
 		messages = appendToolCallMessage(messages, choice.ToolCalls, ctx)
 		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
 	}
+	return lastContent, messages
+}
 
-	// Hit the iteration limit. Try one final call without tools to force
-	// the model to produce a text response with whatever it has so far.
-	logging.InfoContext(ctx, "tool loop hit %d iterations, requesting final response without tools", maxToolIterations)
-	noToolOpts := make([]llms.CallOption, 0, len(callOpts)+1)
-	noToolOpts = append(noToolOpts, callOpts...)
-	noToolOpts = append(noToolOpts, llms.WithTools([]llms.Tool{}))
+func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, callOpts []llms.CallOption) (string, error) {
+	// Hit the iteration or repetition limit. Make one final call with
+	// tool_choice="none" to force the model to produce a text summary.
+	logging.InfoContext(ctx, "tool loop ended, requesting final response with tool_choice=none")
+	finalOpts := make([]llms.CallOption, len(callOpts), len(callOpts)+1)
+	copy(finalOpts, callOpts)
+	finalOpts = append(finalOpts, llms.WithToolChoice("none"))
 
-	response, err := llm.GenerateContent(ctx, messages, noToolOpts...)
+	response, err := llm.GenerateContent(ctx, messages, finalOpts...)
 	if err == nil && response != nil && len(response.Choices) > 0 && response.Choices[0].Content != "" {
-		logging.InfoContext(ctx, "final no-tools call produced response (%d bytes)", len(response.Choices[0].Content))
+		logging.InfoContext(ctx, "final call produced response (%d bytes)", len(response.Choices[0].Content))
 		return response.Choices[0].Content, nil
 	}
 
@@ -81,7 +121,7 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		return lastContent, nil
 	}
 
-	return "", fmt.Errorf("tool loop exceeded %d iterations with no usable response", maxToolIterations)
+	return "", fmt.Errorf("tool loop ended after %d iterations with no usable response", maxToolIterations)
 }
 
 func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent {

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -30,6 +30,12 @@ var mutatingTools = map[string]bool{
 	"Write": true,
 }
 
+var highRepeatTools = map[string]bool{
+	"Read": true,
+	"Glob": true,
+	"Grep": true,
+}
+
 const maxMutatingToolRepeat = 50
 
 type toolHandler struct {
@@ -61,6 +67,9 @@ func (t *toolRepeatTracker) update(calls []llms.ToolCall) {
 
 func (t *toolRepeatTracker) exceeded() bool {
 	limit := maxSameToolRepeat
+	if highRepeatTools[t.lastName] {
+		limit = maxToolIterations
+	}
 	if mutatingTools[t.lastName] {
 		limit = maxMutatingToolRepeat
 	}

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/tmc/langchaingo/llms"
@@ -38,7 +39,9 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 
 	for i := 0; i < maxToolIterations; i++ {
 		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
+		iterStart := time.Now()
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
+		iterDuration := time.Since(iterStart)
 		if err != nil {
 			return "", err
 		}
@@ -48,9 +51,10 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 
 		choice := response.Choices[0]
 		if len(choice.ToolCalls) == 0 {
-			logging.InfoContext(ctx, "model returned final response (no tool calls)")
+			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
 			return choice.Content, nil
 		}
+		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
 
 		toolNames := make([]string, 0, len(choice.ToolCalls))
 		toolCallParts := make([]llms.ContentPart, 0, len(choice.ToolCalls))
@@ -80,14 +84,20 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 				toolResponse.Content = "tool call missing function definition"
 			} else if handler, ok := handlers[toolCall.FunctionCall.Name]; ok {
 				toolResponse.Name = toolCall.FunctionCall.Name
+				logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, truncateString(toolCall.FunctionCall.Arguments, 200))
+				toolStart := time.Now()
 				output, err := handler.call(ctx, []byte(toolCall.FunctionCall.Arguments))
+				toolDuration := time.Since(toolStart)
 				if err != nil {
 					toolResponse.Content = fmt.Sprintf("error: %v", err)
+					logging.DebugContext(ctx, "tool %s failed in %s: %v", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), err)
 				} else {
 					toolResponse.Content = output
+					logging.DebugContext(ctx, "tool %s completed in %s (output-bytes=%d)", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), len(output))
 				}
 			} else {
 				toolResponse.Content = fmt.Sprintf("unknown tool: %s", toolCall.FunctionCall.Name)
+				logging.DebugContext(ctx, "unknown tool requested: %s", toolCall.FunctionCall.Name)
 			}
 
 			messages = append(messages, llms.MessageContent{
@@ -557,4 +567,11 @@ func globToRegex(pattern string) (string, error) {
 	}
 	buf.WriteString("$")
 	return buf.String(), nil
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -26,16 +26,11 @@ type toolHandler struct {
 	call func(ctx context.Context, rawArgs []byte) (string, error)
 }
 
-func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
+func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
 	handlers, toolDefs := buildToolHandlers(workingDir)
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
-	messages := []llms.MessageContent{
-		{
-			Role:  llms.ChatMessageTypeHuman,
-			Parts: []llms.ContentPart{llms.TextPart(prompt)},
-		},
-	}
+	messages := buildInitialMessages(systemPrompt, userPrompt)
 
 	for i := 0; i < maxToolIterations; i++ {
 		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
@@ -59,58 +54,90 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 		}
 		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
 
-		toolNames := make([]string, 0, len(choice.ToolCalls))
-		toolCallParts := make([]llms.ContentPart, 0, len(choice.ToolCalls))
-		for _, toolCall := range choice.ToolCalls {
-			if toolCall.FunctionCall != nil && toolCall.FunctionCall.Name != "" {
-				toolNames = append(toolNames, toolCall.FunctionCall.Name)
-			}
-			toolCallParts = append(toolCallParts, llms.ToolCall{
-				ID:           toolCall.ID,
-				Type:         toolCall.Type,
-				FunctionCall: toolCall.FunctionCall,
-			})
-		}
-		if len(toolNames) > 0 {
-			logging.InfoContext(ctx, "tool calls requested: %s", strings.Join(toolNames, ", "))
-		}
-		messages = append(messages, llms.MessageContent{
-			Role:  llms.ChatMessageTypeAI,
-			Parts: toolCallParts,
-		})
-
-		for _, toolCall := range choice.ToolCalls {
-			toolResponse := llms.ToolCallResponse{
-				ToolCallID: toolCall.ID,
-			}
-			if toolCall.FunctionCall == nil {
-				toolResponse.Content = "tool call missing function definition"
-			} else if handler, ok := handlers[toolCall.FunctionCall.Name]; ok {
-				toolResponse.Name = toolCall.FunctionCall.Name
-				logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, truncateString(toolCall.FunctionCall.Arguments, 200))
-				toolStart := time.Now()
-				output, err := handler.call(ctx, []byte(toolCall.FunctionCall.Arguments))
-				toolDuration := time.Since(toolStart)
-				if err != nil {
-					toolResponse.Content = fmt.Sprintf("error: %v", err)
-					logging.DebugContext(ctx, "tool %s failed in %s: %v", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), err)
-				} else {
-					toolResponse.Content = output
-					logging.DebugContext(ctx, "tool %s completed in %s (output-bytes=%d)", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), len(output))
-				}
-			} else {
-				toolResponse.Content = fmt.Sprintf("unknown tool: %s", toolCall.FunctionCall.Name)
-				logging.DebugContext(ctx, "unknown tool requested: %s", toolCall.FunctionCall.Name)
-			}
-
-			messages = append(messages, llms.MessageContent{
-				Role:  llms.ChatMessageTypeTool,
-				Parts: []llms.ContentPart{toolResponse},
-			})
-		}
+		messages = appendToolCallMessage(messages, choice.ToolCalls, ctx)
+		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
 	}
 
 	return "", fmt.Errorf("tool loop exceeded %d iterations", maxToolIterations)
+}
+
+func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent {
+	messages := []llms.MessageContent{}
+	if systemPrompt != "" {
+		messages = append(messages, llms.MessageContent{
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{llms.TextPart(systemPrompt)},
+		})
+	}
+	messages = append(messages, llms.MessageContent{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart(userPrompt)},
+	})
+	return messages
+}
+
+func appendToolCallMessage(messages []llms.MessageContent, toolCalls []llms.ToolCall, ctx context.Context) []llms.MessageContent {
+	toolNames := make([]string, 0, len(toolCalls))
+	toolCallParts := make([]llms.ContentPart, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if toolCall.FunctionCall != nil && toolCall.FunctionCall.Name != "" {
+			toolNames = append(toolNames, toolCall.FunctionCall.Name)
+		}
+		toolCallParts = append(toolCallParts, llms.ToolCall{
+			ID:           toolCall.ID,
+			Type:         toolCall.Type,
+			FunctionCall: toolCall.FunctionCall,
+		})
+	}
+	if len(toolNames) > 0 {
+		logging.InfoContext(ctx, "tool calls requested: %s", strings.Join(toolNames, ", "))
+	}
+	return append(messages, llms.MessageContent{
+		Role:  llms.ChatMessageTypeAI,
+		Parts: toolCallParts,
+	})
+}
+
+func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]toolHandler) []llms.MessageContent {
+	for _, toolCall := range toolCalls {
+		toolResponse := executeToolCall(ctx, toolCall, handlers)
+		messages = append(messages, llms.MessageContent{
+			Role:  llms.ChatMessageTypeTool,
+			Parts: []llms.ContentPart{toolResponse},
+		})
+	}
+	return messages
+}
+
+func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[string]toolHandler) llms.ToolCallResponse {
+	toolResponse := llms.ToolCallResponse{
+		ToolCallID: toolCall.ID,
+	}
+	if toolCall.FunctionCall == nil {
+		toolResponse.Content = "tool call missing function definition"
+		return toolResponse
+	}
+
+	handler, ok := handlers[toolCall.FunctionCall.Name]
+	if !ok {
+		toolResponse.Content = fmt.Sprintf("unknown tool: %s", toolCall.FunctionCall.Name)
+		logging.DebugContext(ctx, "unknown tool requested: %s", toolCall.FunctionCall.Name)
+		return toolResponse
+	}
+
+	toolResponse.Name = toolCall.FunctionCall.Name
+	logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, truncateString(toolCall.FunctionCall.Arguments, 200))
+	toolStart := time.Now()
+	output, err := handler.call(ctx, []byte(toolCall.FunctionCall.Arguments))
+	toolDuration := time.Since(toolStart)
+	if err != nil {
+		toolResponse.Content = fmt.Sprintf("error: %v", err)
+		logging.DebugContext(ctx, "tool %s failed in %s: %v", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), err)
+	} else {
+		toolResponse.Content = output
+		logging.DebugContext(ctx, "tool %s completed in %s (output-bytes=%d)", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), len(output))
+	}
+	return toolResponse
 }
 
 func buildToolHandlers(workingDir string) (map[string]toolHandler, []llms.Tool) {
@@ -293,10 +320,10 @@ func writeTool(workingDir string) func(ctx context.Context, rawArgs []byte) (str
 
 func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
 	type args struct {
-		Path       string `json:"path"`
-		Old        string `json:"old"`
-		New        string `json:"new"`
-		ReplaceAll bool   `json:"replace_all"`
+		Path       string   `json:"path"`
+		Old        string   `json:"old"`
+		New        string   `json:"new"`
+		ReplaceAll flexBool `json:"replace_all"`
 	}
 	return func(_ context.Context, rawArgs []byte) (string, error) {
 		var payload args
@@ -317,7 +344,7 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		}
 		var updated string
 		replaced := 1
-		if payload.ReplaceAll {
+		if bool(payload.ReplaceAll) {
 			replaced = strings.Count(content, payload.Old)
 			updated = strings.ReplaceAll(content, payload.Old, payload.New)
 		} else {
@@ -489,6 +516,31 @@ func bashTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		}
 		return string(limitOutput(buf.Bytes())), nil
 	}
+}
+
+// flexBool unmarshals both JSON booleans and string representations
+// ("true"/"false") that LLMs sometimes produce for boolean fields.
+type flexBool bool
+
+func (b *flexBool) UnmarshalJSON(data []byte) error {
+	// Try bool first.
+	var v bool
+	if err := json.Unmarshal(data, &v); err == nil {
+		*b = flexBool(v)
+		return nil
+	}
+	// Fall back to string.
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("replace_all must be bool or string, got %s", string(data))
+	}
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes":
+		*b = true
+	default:
+		*b = false
+	}
+	return nil
 }
 
 func resolvePath(workingDir, input string) (string, error) {

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -56,15 +56,18 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
-	lastContent, messages, done := toolLoop(ctx, llm, messages, handlers, callOpts)
+	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, callOpts)
 	if done {
 		return lastContent, nil
+	}
+	if loopErr != nil {
+		return lastContent, loopErr
 	}
 
 	return finishToolLoop(ctx, llm, messages, lastContent, callOpts)
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
 	var lastContent string
 	var repeat toolRepeatTracker
 	for i := 0; i < maxToolIterations; i++ {
@@ -73,10 +76,12 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
 		iterDuration := time.Since(iterStart)
 		if err != nil {
-			return lastContent, messages, false
+			logging.InfoContext(ctx, "model call failed in %s: %v", iterDuration.Round(time.Millisecond), err)
+			return lastContent, messages, fmt.Errorf("GenerateContent failed: %w", err), false
 		}
 		if response == nil || len(response.Choices) == 0 {
-			return lastContent, messages, false
+			logging.InfoContext(ctx, "model returned empty response in %s", iterDuration.Round(time.Millisecond))
+			return lastContent, messages, fmt.Errorf("model returned empty response"), false
 		}
 
 		choice := response.Choices[0]
@@ -88,7 +93,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		}
 		if len(choice.ToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
-			return choice.Content, messages, true
+			return choice.Content, messages, nil, true
 		}
 		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
 
@@ -101,7 +106,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		messages = appendToolCallMessage(messages, choice.ToolCalls, ctx)
 		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
 	}
-	return lastContent, messages, false
+	return lastContent, messages, nil, false
 }
 
 func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, callOpts []llms.CallOption) (string, error) {

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cowdogmoo/squad/logging"
 	"github.com/tmc/langchaingo/llms"
 )
 
@@ -36,6 +37,7 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 	}
 
 	for i := 0; i < maxToolIterations; i++ {
+		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
 		if err != nil {
 			return "", err
@@ -46,16 +48,24 @@ func runWithTools(ctx context.Context, llm llms.Model, prompt, workingDir string
 
 		choice := response.Choices[0]
 		if len(choice.ToolCalls) == 0 {
+			logging.InfoContext(ctx, "model returned final response (no tool calls)")
 			return choice.Content, nil
 		}
 
+		toolNames := make([]string, 0, len(choice.ToolCalls))
 		toolCallParts := make([]llms.ContentPart, 0, len(choice.ToolCalls))
 		for _, toolCall := range choice.ToolCalls {
+			if toolCall.FunctionCall != nil && toolCall.FunctionCall.Name != "" {
+				toolNames = append(toolNames, toolCall.FunctionCall.Name)
+			}
 			toolCallParts = append(toolCallParts, llms.ToolCall{
 				ID:           toolCall.ID,
 				Type:         toolCall.Type,
 				FunctionCall: toolCall.FunctionCall,
 			})
+		}
+		if len(toolNames) > 0 {
+			logging.InfoContext(ctx, "tool calls requested: %s", strings.Join(toolNames, ", "))
 		}
 		messages = append(messages, llms.MessageContent{
 			Role:  llms.ChatMessageTypeAI,

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -32,6 +32,7 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
 
+	var lastContent string
 	for i := 0; i < maxToolIterations; i++ {
 		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
 		iterStart := time.Now()
@@ -48,6 +49,9 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		if gi := choice.GenerationInfo; gi != nil {
 			logging.DebugContext(ctx, "generation info: %v", gi)
 		}
+		if choice.Content != "" {
+			lastContent = choice.Content
+		}
 		if len(choice.ToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
 			return choice.Content, nil
@@ -58,7 +62,26 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
 	}
 
-	return "", fmt.Errorf("tool loop exceeded %d iterations", maxToolIterations)
+	// Hit the iteration limit. Try one final call without tools to force
+	// the model to produce a text response with whatever it has so far.
+	logging.InfoContext(ctx, "tool loop hit %d iterations, requesting final response without tools", maxToolIterations)
+	noToolOpts := make([]llms.CallOption, 0, len(callOpts)+1)
+	noToolOpts = append(noToolOpts, callOpts...)
+	noToolOpts = append(noToolOpts, llms.WithTools([]llms.Tool{}))
+
+	response, err := llm.GenerateContent(ctx, messages, noToolOpts...)
+	if err == nil && response != nil && len(response.Choices) > 0 && response.Choices[0].Content != "" {
+		logging.InfoContext(ctx, "final no-tools call produced response (%d bytes)", len(response.Choices[0].Content))
+		return response.Choices[0].Content, nil
+	}
+
+	// Fall back to any text content accumulated during the loop.
+	if lastContent != "" {
+		logging.InfoContext(ctx, "returning last partial content (%d bytes)", len(lastContent))
+		return lastContent, nil
+	}
+
+	return "", fmt.Errorf("tool loop exceeded %d iterations with no usable response", maxToolIterations)
 }
 
 func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent {

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-const maxToolIterations = 24
+const maxToolIterations = 100
 const maxToolOutput = 64 * 1024
 
 type toolHandler struct {
@@ -390,53 +390,65 @@ func grepTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 			return "", err
 		}
 
-		var matches []string
-		visit := func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if info.IsDir() {
-				return nil
-			}
-			file, err := os.Open(path)
-			if err != nil {
-				return nil
-			}
-			defer file.Close()
-			rel, err := filepath.Rel(workingDir, path)
-			if err != nil {
-				rel = path
-			}
-			scanner := bufio.NewScanner(file)
-			lineNum := 1
-			for scanner.Scan() {
-				line := scanner.Text()
-				if re.MatchString(line) {
-					matches = append(matches, fmt.Sprintf("%s:%d:%s", filepath.ToSlash(rel), lineNum, line))
-				}
-				lineNum++
-			}
-			return nil
-		}
-
-		info, err := os.Stat(resolved)
+		matches, err := grepSearchPath(workingDir, resolved, re)
 		if err != nil {
 			return "", err
-		}
-		if info.IsDir() {
-			if err := filepath.Walk(resolved, visit); err != nil {
-				return "", err
-			}
-		} else {
-			if err := visit(resolved, info, nil); err != nil {
-				return "", err
-			}
 		}
 
 		if len(matches) == 0 {
 			return "no matches", nil
 		}
 		return strings.Join(matches, "\n"), nil
+	}
+}
+
+func grepSearchPath(workingDir, resolved string, re *regexp.Regexp) ([]string, error) {
+	var matches []string
+	visit := grepVisitFile(workingDir, re, &matches)
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		if err := filepath.Walk(resolved, visit); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := visit(resolved, info, nil); err != nil {
+			return nil, err
+		}
+	}
+	return matches, nil
+}
+
+func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer file.Close()
+		rel, err := filepath.Rel(workingDir, path)
+		if err != nil {
+			rel = path
+		}
+		scanner := bufio.NewScanner(file)
+		lineNum := 1
+		for scanner.Scan() {
+			line := scanner.Text()
+			if re.MatchString(line) {
+				*matches = append(*matches, fmt.Sprintf("%s:%d:%s", filepath.ToSlash(rel), lineNum, line))
+			}
+			lineNum++
+		}
+		return nil
 	}
 }
 

--- a/cmd/squad/tools.go
+++ b/cmd/squad/tools.go
@@ -56,12 +56,15 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
-	lastContent, messages := toolLoop(ctx, llm, messages, handlers, callOpts)
+	lastContent, messages, done := toolLoop(ctx, llm, messages, handlers, callOpts)
+	if done {
+		return lastContent, nil
+	}
 
 	return finishToolLoop(ctx, llm, messages, lastContent, callOpts)
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent, bool) {
 	var lastContent string
 	var repeat toolRepeatTracker
 	for i := 0; i < maxToolIterations; i++ {
@@ -70,10 +73,10 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
 		iterDuration := time.Since(iterStart)
 		if err != nil {
-			return lastContent, messages
+			return lastContent, messages, false
 		}
 		if response == nil || len(response.Choices) == 0 {
-			return lastContent, messages
+			return lastContent, messages, false
 		}
 
 		choice := response.Choices[0]
@@ -85,7 +88,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		}
 		if len(choice.ToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
-			return choice.Content, messages
+			return choice.Content, messages, true
 		}
 		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
 
@@ -98,7 +101,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		messages = appendToolCallMessage(messages, choice.ToolCalls, ctx)
 		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
 	}
-	return lastContent, messages
+	return lastContent, messages, false
 }
 
 func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, callOpts []llms.CallOption) (string, error) {

--- a/cmd/squad/version.go
+++ b/cmd/squad/version.go
@@ -55,9 +55,11 @@ func init() {
 }
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information",
-	Long:  "Display the version, commit hash, and build date of squad.",
+	Use:     "version",
+	Aliases: []string{"v"},
+	Short:   "Print version information",
+	Long:    "Display the version, commit hash, and build date of squad.",
+	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("squad version %s\n", version)
 		fmt.Printf("  commit: %s\n", commit)

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ type ProviderConfig struct {
 	APIVersion            string `mapstructure:"api_version" yaml:"api_version"`
 	APIType               string `mapstructure:"api_type" yaml:"api_type"`
 	OpenAICompatMaxTokens bool   `mapstructure:"openai_compat_max_tokens" yaml:"openai_compat_max_tokens"`
-	Token                 string `mapstructure:"token" yaml:"-"`
+	Token                 string `mapstructure:"token" yaml:"token"`
 }
 
 // ModelConfig holds model defaults.
@@ -129,7 +129,7 @@ func loadConfigWithViper(setup func(*viper.Viper) error) (*Config, error) {
 	}
 
 	cfg := Defaults()
-	if err := v.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("config unmarshal failed: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/squad
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/fatih/color v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/openai/openai-go/v3 v3.17.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/tmc/langchaingo v0.1.14
@@ -26,6 +27,10 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/openai/openai-go/v3 v3.17.0 h1:CfTkmQoItolSyW+bHOUF190KuX5+1Zv6MC0Gb4wAwy8=
+github.com/openai/openai-go/v3 v3.17.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
@@ -56,6 +58,16 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/langchaingo v0.1.14 h1:o1qWBPigAIuFvrG6cjTFo0cZPFEZ47ZqpOYMjM15yZc=
 github.com/tmc/langchaingo v0.1.14/go.mod h1:aKKYXYoqhIDEv7WKdpnnCLRaqXic69cX9MnDUk72378=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -183,7 +183,7 @@ func (l *CustomLogger) Error(firstArg interface{}, args ...interface{}) {
 		format = fmt.Sprintf("%v", v)
 	}
 
-	l.log(ErrorLevel, format, args...)
+	l.log(ErrorLevel, "%s", format)
 }
 
 func DetermineLogLevel(levelStr string) slog.Level {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -172,10 +172,10 @@ func (l *CustomLogger) Error(firstArg interface{}, args ...interface{}) {
 	var format string
 	switch v := firstArg.(type) {
 	case error:
-		if len(args) == 0 {
-			format = v.Error()
-		} else {
-			format = fmt.Sprintf(v.Error(), args...)
+		// Treat error as a value, not a format string
+		format = v.Error()
+		if len(args) > 0 {
+			format = fmt.Sprintf("%s %v", format, args)
 		}
 	case string:
 		format = v

--- a/ollama/ollama.go
+++ b/ollama/ollama.go
@@ -1,4 +1,4 @@
-package main
+package ollama
 
 import (
 	"bytes"
@@ -12,23 +12,22 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-// ollamaLLM implements llms.Model using Ollama's native /api/chat endpoint,
-// which supports both tool calling and the num_ctx parameter. The langchaingo
-// llms/ollama package does not support tool calls, and the OpenAI-compat
-// endpoint silently truncates to 4096 tokens.
-type ollamaLLM struct {
+// LLM implements llms.Model using Ollama's native /api/chat endpoint,
+// which supports both tool calling and the num_ctx parameter.
+type LLM struct {
 	serverURL string
 	model     string
 	numCtx    int
 }
 
 // Verify interface compliance.
-var _ llms.Model = (*ollamaLLM)(nil)
+var _ llms.Model = (*LLM)(nil)
 
-func newOllamaLLM(serverURL, model string, numCtx int) *ollamaLLM {
+// New creates a new Ollama LLM client.
+func New(serverURL, model string, numCtx int) *LLM {
 	serverURL = strings.TrimSuffix(serverURL, "/v1")
 	serverURL = strings.TrimSuffix(serverURL, "/")
-	return &ollamaLLM{
+	return &LLM{
 		serverURL: serverURL,
 		model:     model,
 		numCtx:    numCtx,
@@ -36,12 +35,12 @@ func newOllamaLLM(serverURL, model string, numCtx int) *ollamaLLM {
 }
 
 // Call implements the simple string-based call interface.
-func (o *ollamaLLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
 	return llms.GenerateFromSinglePrompt(ctx, o, prompt, options...)
 }
 
 // GenerateContent implements llms.Model via Ollama's native /api/chat endpoint.
-func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
 	opts := llms.CallOptions{}
 	for _, opt := range options {
 		opt(&opts)
@@ -51,14 +50,12 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 	if err != nil {
 		return nil, err
 	}
-	// Ollama has no tool_choice parameter. When tool_choice is "none",
-	// omit tools entirely so the model cannot call them.
 	var tools []ollamaTool
 	if opts.ToolChoice != "none" {
 		tools = convertTools(opts.Tools)
 	}
 
-	reqBody := ollamaChatRequest{
+	reqBody := chatRequest{
 		Model:    o.model,
 		Messages: chatMsgs,
 		Tools:    tools,
@@ -99,7 +96,7 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 		return nil, fmt.Errorf("ollama returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 
-	var chatResp ollamaChatResponse
+	var chatResp chatResponse
 	if err := json.Unmarshal(respBody, &chatResp); err != nil {
 		return nil, fmt.Errorf("failed to parse ollama response: %w", err)
 	}
@@ -109,7 +106,7 @@ func (o *ollamaLLM) GenerateContent(ctx context.Context, messages []llms.Message
 
 // --- Ollama native API types ---
 
-type ollamaChatRequest struct {
+type chatRequest struct {
 	Model    string          `json:"model"`
 	Messages []ollamaMessage `json:"messages"`
 	Tools    []ollamaTool    `json:"tools,omitempty"`
@@ -143,7 +140,7 @@ type ollamaToolFunction struct {
 	Parameters  any    `json:"parameters"`
 }
 
-type ollamaChatResponse struct {
+type chatResponse struct {
 	Model           string         `json:"model"`
 	Message         *ollamaMessage `json:"message,omitempty"`
 	Done            bool           `json:"done"`
@@ -176,11 +173,19 @@ func convertMessages(messages []llms.MessageContent) ([]ollamaMessage, error) {
 					})
 				}
 			case llms.ToolCallResponse:
-				msg.Role = "tool"
-				msg.Content = pt.Content
+				if msg.Content != "" || len(msg.ToolCalls) > 0 {
+					if msg.Role == "" {
+						msg.Role = "assistant"
+					}
+					out = append(out, msg)
+					msg = ollamaMessage{}
+				}
+				out = append(out, ollamaMessage{Role: "tool", Content: pt.Content})
 			}
 		}
-		out = append(out, msg)
+		if msg.Role != "" || msg.Content != "" || len(msg.ToolCalls) > 0 {
+			out = append(out, msg)
+		}
 	}
 	return out, nil
 }
@@ -206,7 +211,7 @@ func convertTools(tools []llms.Tool) []ollamaTool {
 	return out
 }
 
-func convertResponse(resp ollamaChatResponse) *llms.ContentResponse {
+func convertResponse(resp chatResponse) *llms.ContentResponse {
 	choice := &llms.ContentChoice{
 		GenerationInfo: map[string]any{
 			"PromptTokens":     resp.PromptEvalCount,
@@ -218,10 +223,13 @@ func convertResponse(resp ollamaChatResponse) *llms.ContentResponse {
 	if resp.Message != nil {
 		choice.Content = resp.Message.Content
 
-		for _, tc := range resp.Message.ToolCalls {
-			argsJSON, _ := json.Marshal(tc.Function.Arguments)
+		for i, tc := range resp.Message.ToolCalls {
+			argsJSON, err := json.Marshal(tc.Function.Arguments)
+			if err != nil {
+				continue
+			}
 			choice.ToolCalls = append(choice.ToolCalls, llms.ToolCall{
-				ID:   tc.Function.Name, // Ollama doesn't provide IDs; use name
+				ID:   fmt.Sprintf("%s-%d", tc.Function.Name, i),
 				Type: "function",
 				FunctionCall: &llms.FunctionCall{
 					Name:      tc.Function.Name,

--- a/ollama/ollama.go
+++ b/ollama/ollama.go
@@ -40,7 +40,7 @@ func (o *LLM) Call(ctx context.Context, prompt string, options ...llms.CallOptio
 }
 
 // GenerateContent implements llms.Model via Ollama's native /api/chat endpoint.
-func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (resp *llms.ContentResponse, retErr error) {
 	opts := llms.CallOptions{}
 	for _, opt := range options {
 		opt(&opts)
@@ -82,18 +82,22 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	httpResp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("ollama request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if cerr := httpResp.Body.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close response body: %w", cerr)
+		}
+	}()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ollama response: %w", err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("ollama returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama returned %d: %s", httpResp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 
 	var chatResp chatResponse

--- a/openairesponses/responses.go
+++ b/openairesponses/responses.go
@@ -1,65 +1,63 @@
-package main
+package openairesponses
 
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/tools"
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/tmc/langchaingo/llms"
 )
 
-// responseFunctionCall holds the parsed details of a function_call item
+// FunctionCall holds the parsed details of a function_call item
 // from the Responses API output.
-type responseFunctionCall struct {
-	ID        string // output item ID
-	CallID    string // unique call ID for pairing with output
-	Name      string // function name
-	Arguments string // JSON arguments string
+type FunctionCall struct {
+	ID        string
+	CallID    string
+	Name      string
+	Arguments string
 }
 
-// responsesConfig bundles the immutable parameters for a Responses API session.
-type responsesConfig struct {
-	model       string
-	tools       []responses.ToolUnionParam
-	temperature float64
-	maxTokens   int
+// Config bundles the immutable parameters for a Responses API session.
+type Config struct {
+	Model       string
+	Tools       []responses.ToolUnionParam
+	Temperature float64
+	MaxTokens   int
 }
 
-func (rc *responsesConfig) applyOptionals(params *responses.ResponseNewParams) {
-	if rc.temperature >= 0 && supportsResponsesTemperature(rc.model) {
-		params.Temperature = openai.Float(rc.temperature)
+func (rc *Config) applyOptionals(params *responses.ResponseNewParams) {
+	if rc.Temperature >= 0 && supportsTemperature(rc.Model) {
+		params.Temperature = openai.Float(rc.Temperature)
 	}
-	if rc.maxTokens > 0 {
-		params.MaxOutputTokens = openai.Int(int64(rc.maxTokens))
+	if rc.MaxTokens > 0 {
+		params.MaxOutputTokens = openai.Int(int64(rc.MaxTokens))
 	}
 }
 
-// useResponsesAPI returns true when the Responses API path should be used
-// instead of LangChainGo's Chat Completions.
-func useResponsesAPI(provider, model string) bool {
-	provider = normalizeProvider(provider)
+// UseResponsesAPI returns true when the Responses API path should be used.
+func UseResponsesAPI(provider, model string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
 	if provider == "openai-responses" {
 		return true
 	}
 	return provider == "openai" && strings.HasPrefix(model, "gpt-5")
 }
 
-// runWithToolsResponses drives a tool-calling loop using the OpenAI
-// Responses API. It reuses the same tool handlers from buildToolHandlers.
-func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPrompt, userPrompt, workingDir, organization string, temperature float64, maxTokens int) (string, error) {
-	client := newResponsesClient(apiKey, baseURL, organization)
-	handlers, toolDefs := buildToolHandlers(workingDir)
-	rc := responsesConfig{
-		model:       model,
-		tools:       convertToolsToResponses(toolDefs),
-		temperature: temperature,
-		maxTokens:   maxTokens,
+// RunWithTools drives a tool-calling loop using the OpenAI Responses API.
+func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, userPrompt, workingDir, organization string, temperature float64, maxTokens int) (string, error) {
+	client := newClient(apiKey, baseURL, organization)
+	handlers, toolDefs := tools.BuildHandlers(workingDir)
+	rc := Config{
+		Model:       model,
+		Tools:       ConvertTools(toolDefs),
+		Temperature: temperature,
+		MaxTokens:   maxTokens,
 	}
 
 	params := responses.ResponseNewParams{
@@ -68,7 +66,7 @@ func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPr
 		Input: responses.ResponseNewParamsInputUnion{
 			OfString: openai.String(userPrompt),
 		},
-		Tools:      rc.tools,
+		Tools:      rc.Tools,
 		Truncation: responses.ResponseNewParamsTruncation("auto"),
 		ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
 			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsRequired),
@@ -82,7 +80,7 @@ func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPr
 		return "", fmt.Errorf("responses API call failed: %w", err)
 	}
 
-	resp, text, err := responsesToolLoop(ctx, client, resp, handlers, &rc)
+	resp, text, err := toolLoop(ctx, client, resp, handlers, &rc)
 	if err != nil {
 		return text, err
 	}
@@ -90,14 +88,14 @@ func runWithToolsResponses(ctx context.Context, apiKey, baseURL, model, systemPr
 		return text, nil
 	}
 
-	finalText, err := requestResponsesFinal(ctx, client, resp.ID, systemPrompt, &rc)
+	finalText, err := requestFinal(ctx, client, resp.ID, systemPrompt, &rc)
 	if err == nil && finalText != "" {
 		return finalText, nil
 	}
-	return "", fmt.Errorf("responses API tool loop ended after %d iterations with no usable response", maxToolIterations)
+	return "", fmt.Errorf("responses API tool loop ended after %d iterations with no usable response", tools.MaxToolIterations)
 }
 
-func newResponsesClient(apiKey, baseURL, organization string) openai.Client {
+func newClient(apiKey, baseURL, organization string) openai.Client {
 	clientOpts := []option.RequestOption{option.WithAPIKey(apiKey)}
 	if organization != "" {
 		clientOpts = append(clientOpts, option.WithOrganization(organization))
@@ -108,12 +106,10 @@ func newResponsesClient(apiKey, baseURL, organization string) openai.Client {
 	return openai.NewClient(clientOpts...)
 }
 
-// responsesToolLoop iterates the tool-calling loop, returning the final
-// response, any accumulated text, and an error.
-func responsesToolLoop(ctx context.Context, client openai.Client, resp *responses.Response, handlers map[string]toolHandler, rc *responsesConfig) (*responses.Response, string, error) {
-	var repeat toolRepeatTracker
-	for i := 0; i < maxToolIterations; i++ {
-		calls := extractFunctionCalls(resp)
+func toolLoop(ctx context.Context, client openai.Client, resp *responses.Response, handlers map[string]tools.Handler, rc *Config) (*responses.Response, string, error) {
+	var repeat tools.RepeatTracker
+	for i := 0; i < tools.MaxToolIterations; i++ {
+		calls := ExtractFunctionCalls(resp)
 		if len(calls) == 0 {
 			text := resp.OutputText()
 			logging.InfoContext(ctx, "responses API: final response at iteration %d (%d bytes)", i, len(text))
@@ -121,18 +117,18 @@ func responsesToolLoop(ctx context.Context, client openai.Client, resp *response
 		}
 
 		logging.InfoContext(ctx, "responses API: iteration %d with %d tool call(s)", i+1, len(calls))
-		if checkResponsesRepeat(&repeat, calls, ctx) {
+		if checkRepeat(&repeat, calls, ctx) {
 			break
 		}
 
 		outputs := executeAndBuildOutputs(ctx, calls, handlers)
 		params := responses.ResponseNewParams{
-			Model:              rc.model,
+			Model:              rc.Model,
 			PreviousResponseID: openai.String(resp.ID),
 			Input: responses.ResponseNewParamsInputUnion{
 				OfInputItemList: responses.ResponseInputParam(outputs),
 			},
-			Tools:      rc.tools,
+			Tools:      rc.Tools,
 			Truncation: responses.ResponseNewParamsTruncation("auto"),
 		}
 		rc.applyOptionals(&params)
@@ -151,27 +147,30 @@ func responsesToolLoop(ctx context.Context, client openai.Client, resp *response
 	return resp, text, nil
 }
 
-func checkResponsesRepeat(repeat *toolRepeatTracker, calls []responseFunctionCall, ctx context.Context) bool {
+func checkRepeat(repeat *tools.RepeatTracker, calls []FunctionCall, ctx context.Context) bool {
 	fakeToolCalls := make([]llms.ToolCall, len(calls))
 	for j, c := range calls {
 		fakeToolCalls[j] = llms.ToolCall{
-			FunctionCall: &llms.FunctionCall{Name: c.Name},
+			FunctionCall: &llms.FunctionCall{
+				Name:      c.Name,
+				Arguments: c.Arguments,
+			},
 		}
 	}
-	repeat.update(fakeToolCalls)
-	if repeat.exceeded() {
-		logging.InfoContext(ctx, "responses API: %s called %d times in a row, breaking", repeat.lastName, repeat.count)
+	repeat.Update(fakeToolCalls)
+	if repeat.Exceeded() {
+		logging.InfoContext(ctx, "responses API: %s called %d times in a row, breaking", repeat.LastName, repeat.Count)
 		return true
 	}
 	return false
 }
 
-func requestResponsesFinal(ctx context.Context, client openai.Client, previousID, systemPrompt string, rc *responsesConfig) (string, error) {
+func requestFinal(ctx context.Context, client openai.Client, previousID, systemPrompt string, rc *Config) (string, error) {
 	if strings.TrimSpace(previousID) == "" {
 		return "", fmt.Errorf("missing previous response id")
 	}
 	params := responses.ResponseNewParams{
-		Model:              rc.model,
+		Model:              rc.Model,
 		PreviousResponseID: openai.String(previousID),
 		Input: responses.ResponseNewParamsInputUnion{
 			OfString: openai.String("Provide the final response. Do not call any tools."),
@@ -180,7 +179,7 @@ func requestResponsesFinal(ctx context.Context, client openai.Client, previousID
 		ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
 			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsNone),
 		},
-		Tools:      rc.tools,
+		Tools:      rc.Tools,
 		Truncation: responses.ResponseNewParamsTruncation("auto"),
 	}
 	rc.applyOptionals(&params)
@@ -198,15 +197,15 @@ func requestResponsesFinal(ctx context.Context, client openai.Client, previousID
 	return text, nil
 }
 
-func supportsResponsesTemperature(model string) bool {
+func supportsTemperature(model string) bool {
 	return !strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-5")
 }
 
-// convertToolsToResponses converts langchaingo tool definitions to the
+// ConvertTools converts langchaingo tool definitions to the
 // Responses API FunctionToolParam format.
-func convertToolsToResponses(tools []llms.Tool) []responses.ToolUnionParam {
-	out := make([]responses.ToolUnionParam, 0, len(tools))
-	for _, t := range tools {
+func ConvertTools(toolDefs []llms.Tool) []responses.ToolUnionParam {
+	out := make([]responses.ToolUnionParam, 0, len(toolDefs))
+	for _, t := range toolDefs {
 		if t.Function == nil {
 			continue
 		}
@@ -226,16 +225,15 @@ func convertToolsToResponses(tools []llms.Tool) []responses.ToolUnionParam {
 	return out
 }
 
-// extractFunctionCalls pulls function_call items from a Responses API
-// response output.
-func extractFunctionCalls(resp *responses.Response) []responseFunctionCall {
-	if resp == nil {
+// ExtractFunctionCalls pulls function_call items from a Responses API response.
+func ExtractFunctionCalls(resp *responses.Response) []FunctionCall {
+	if resp == nil || resp.Output == nil {
 		return nil
 	}
-	var calls []responseFunctionCall
+	var calls []FunctionCall
 	for _, item := range resp.Output {
 		if item.Type == "function_call" {
-			calls = append(calls, responseFunctionCall{
+			calls = append(calls, FunctionCall{
 				ID:        item.ID,
 				CallID:    item.CallID,
 				Name:      item.Name,
@@ -246,9 +244,7 @@ func extractFunctionCalls(resp *responses.Response) []responseFunctionCall {
 	return calls
 }
 
-// executeAndBuildOutputs runs each tool call through the existing handlers
-// and builds the input items for the next Responses API request.
-func executeAndBuildOutputs(ctx context.Context, calls []responseFunctionCall, handlers map[string]toolHandler) []responses.ResponseInputItemUnionParam {
+func executeAndBuildOutputs(ctx context.Context, calls []FunctionCall, handlers map[string]tools.Handler) []responses.ResponseInputItemUnionParam {
 	outputs := make([]responses.ResponseInputItemUnionParam, 0, len(calls))
 	for _, call := range calls {
 		handler, ok := handlers[call.Name]
@@ -265,9 +261,9 @@ func executeAndBuildOutputs(ctx context.Context, calls []responseFunctionCall, h
 			continue
 		}
 
-		logging.DebugContext(ctx, "responses API: calling %s args=%s", call.Name, truncateString(call.Arguments, 200))
+		logging.DebugContext(ctx, "responses API: calling %s args=%s", call.Name, tools.TruncateString(call.Arguments, 200))
 		toolStart := time.Now()
-		result, err := handler.call(ctx, []byte(call.Arguments))
+		result, err := handler.Call(ctx, []byte(call.Arguments))
 		toolDuration := time.Since(toolStart)
 
 		var output string
@@ -289,17 +285,4 @@ func executeAndBuildOutputs(ctx context.Context, calls []responseFunctionCall, h
 		})
 	}
 	return outputs
-}
-
-// resolveResponsesAPIKey determines the API key for the Responses API path,
-// checking CLI flag, config, and environment in order.
-func resolveResponsesAPIKey(cfgToken string) (string, error) {
-	key := pickString(runAPIKey, cfgToken)
-	if key == "" {
-		key = os.Getenv("OPENAI_API_KEY")
-	}
-	if key == "" {
-		return "", fmt.Errorf("API key required for OpenAI Responses API: use --api-key, config provider.token, or OPENAI_API_KEY env var")
-	}
-	return key, nil
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -591,9 +591,9 @@ func grepSearchPath(workingDir, resolved string, re *regexp.Regexp) ([]string, e
 }
 
 func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) filepath.WalkFunc {
-	return func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
+	return func(path string, info os.FileInfo, walkErr error) (retErr error) {
+		if walkErr != nil {
+			return walkErr
 		}
 		if info.IsDir() {
 			return nil
@@ -602,7 +602,11 @@ func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) file
 		if err != nil {
 			return nil
 		}
-		defer file.Close()
+		defer func() {
+			if cerr := file.Close(); cerr != nil && retErr == nil {
+				retErr = cerr
+			}
+		}()
 		rel, err := filepath.Rel(workingDir, path)
 		if err != nil {
 			rel = path

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-package main
+package tools
 
 import (
 	"bufio"
@@ -18,13 +18,14 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-const maxToolIterations = 100
+const MaxToolIterations = 100
 const maxToolOutput = 64 * 1024
 const maxSameToolRepeat = 10
+const maxMutatingToolRepeat = 50
 
-// mutatingTools are tools that legitimately chain in long sequences
-// (e.g. a judge applying many edits). The repetition guard uses a
-// higher threshold for these to avoid breaking valid workflows.
+var editsUsed bool
+
+// mutatingTools are tools that legitimately chain in long sequences.
 var mutatingTools = map[string]bool{
 	"Edit":  true,
 	"Write": true,
@@ -36,48 +37,67 @@ var highRepeatTools = map[string]bool{
 	"Grep": true,
 }
 
-const maxMutatingToolRepeat = 50
-
-type toolHandler struct {
-	def  llms.Tool
-	call func(ctx context.Context, rawArgs []byte) (string, error)
+// ResetEditsApplied resets the edit tracking state.
+func ResetEditsApplied() {
+	editsUsed = false
 }
 
-// toolRepeatTracker detects when the model is stuck calling the same
-// tool repeatedly (e.g. Bash in a loop). Mutating tools like Edit and
-// Write get a higher threshold since sequential edits are expected
-// behavior for agents applying fixes.
-type toolRepeatTracker struct {
-	lastName string
-	count    int
+// MarkEditsApplied marks that tool-based edits were made.
+func MarkEditsApplied() {
+	editsUsed = true
 }
 
-func (t *toolRepeatTracker) update(calls []llms.ToolCall) {
+// EditsApplied returns whether tool-based edits were made.
+func EditsApplied() bool {
+	return editsUsed
+}
+
+// Handler wraps a tool definition and its implementation function.
+type Handler struct {
+	Def  llms.Tool
+	Call func(ctx context.Context, rawArgs []byte) (string, error)
+}
+
+// RepeatTracker detects when the model is stuck calling the same
+// tool repeatedly. Mutating tools get a higher threshold.
+type RepeatTracker struct {
+	lastSignature string
+	LastName      string
+	Count         int
+}
+
+// Update records a new set of tool calls for repetition tracking.
+func (t *RepeatTracker) Update(calls []llms.ToolCall) {
+	signature := ""
 	name := ""
 	if len(calls) == 1 && calls[0].FunctionCall != nil {
 		name = calls[0].FunctionCall.Name
+		signature = name + ":" + calls[0].FunctionCall.Arguments
 	}
-	if name != "" && name == t.lastName {
-		t.count++
+	if signature != "" && signature == t.lastSignature {
+		t.Count++
 	} else {
-		t.count = 1
-		t.lastName = name
+		t.Count = 1
+		t.lastSignature = signature
+		t.LastName = name
 	}
 }
 
-func (t *toolRepeatTracker) exceeded() bool {
+// Exceeded returns true if the repetition limit has been hit.
+func (t *RepeatTracker) Exceeded() bool {
 	limit := maxSameToolRepeat
-	if highRepeatTools[t.lastName] {
-		limit = maxToolIterations
+	if highRepeatTools[t.LastName] {
+		limit = MaxToolIterations
 	}
-	if mutatingTools[t.lastName] {
+	if mutatingTools[t.LastName] {
 		limit = maxMutatingToolRepeat
 	}
-	return t.count >= limit
+	return t.Count >= limit
 }
 
-func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
-	handlers, toolDefs := buildToolHandlers(workingDir)
+// RunWithTools drives a tool-calling loop for LangChainGo-based models.
+func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, callOpts ...llms.CallOption) (string, error) {
+	handlers, toolDefs := BuildHandlers(workingDir)
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
@@ -92,11 +112,11 @@ func runWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	return finishToolLoop(ctx, llm, messages, lastContent, callOpts)
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]toolHandler, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
 	var lastContent string
-	var repeat toolRepeatTracker
-	for i := 0; i < maxToolIterations; i++ {
-		logging.InfoContext(ctx, "model iteration %d/%d", i+1, maxToolIterations)
+	var repeat RepeatTracker
+	for i := 0; i < MaxToolIterations; i++ {
+		logging.InfoContext(ctx, "model iteration %d/%d", i+1, MaxToolIterations)
 		iterStart := time.Now()
 		response, err := llm.GenerateContent(ctx, messages, callOpts...)
 		iterDuration := time.Since(iterStart)
@@ -122,9 +142,9 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		}
 		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
 
-		repeat.update(choice.ToolCalls)
-		if repeat.exceeded() {
-			logging.InfoContext(ctx, "model called %s %d times in a row, breaking tool loop", repeat.lastName, repeat.count)
+		repeat.Update(choice.ToolCalls)
+		if repeat.Exceeded() {
+			logging.InfoContext(ctx, "model called %s %d times in a row, breaking tool loop", repeat.LastName, repeat.Count)
 			break
 		}
 
@@ -135,8 +155,6 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 }
 
 func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, callOpts []llms.CallOption) (string, error) {
-	// Hit the iteration or repetition limit. Make one final call with
-	// tool_choice="none" to force the model to produce a text summary.
 	logging.InfoContext(ctx, "tool loop ended, requesting final response with tool_choice=none")
 	finalOpts := make([]llms.CallOption, len(callOpts), len(callOpts)+1)
 	copy(finalOpts, callOpts)
@@ -148,13 +166,12 @@ func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.Message
 		return response.Choices[0].Content, nil
 	}
 
-	// Fall back to any text content accumulated during the loop.
 	if lastContent != "" {
 		logging.InfoContext(ctx, "returning last partial content (%d bytes)", len(lastContent))
 		return lastContent, nil
 	}
 
-	return "", fmt.Errorf("tool loop ended after %d iterations with no usable response", maxToolIterations)
+	return "", fmt.Errorf("tool loop ended after %d iterations with no usable response", MaxToolIterations)
 }
 
 func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent {
@@ -194,7 +211,7 @@ func appendToolCallMessage(messages []llms.MessageContent, toolCalls []llms.Tool
 	})
 }
 
-func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]toolHandler) []llms.MessageContent {
+func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]Handler) []llms.MessageContent {
 	for _, toolCall := range toolCalls {
 		toolResponse := executeToolCall(ctx, toolCall, handlers)
 		messages = append(messages, llms.MessageContent{
@@ -205,7 +222,7 @@ func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolC
 	return messages
 }
 
-func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[string]toolHandler) llms.ToolCallResponse {
+func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[string]Handler) llms.ToolCallResponse {
 	toolResponse := llms.ToolCallResponse{
 		ToolCallID: toolCall.ID,
 	}
@@ -222,9 +239,9 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 	}
 
 	toolResponse.Name = toolCall.FunctionCall.Name
-	logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, truncateString(toolCall.FunctionCall.Arguments, 200))
+	logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, TruncateString(toolCall.FunctionCall.Arguments, 200))
 	toolStart := time.Now()
-	output, err := handler.call(ctx, []byte(toolCall.FunctionCall.Arguments))
+	output, err := handler.Call(ctx, []byte(toolCall.FunctionCall.Arguments))
 	toolDuration := time.Since(toolStart)
 	if err != nil {
 		toolResponse.Content = fmt.Sprintf("error: %v", err)
@@ -236,24 +253,25 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 	return toolResponse
 }
 
-func buildToolHandlers(workingDir string) (map[string]toolHandler, []llms.Tool) {
-	handlers := map[string]toolHandler{}
+// BuildHandlers creates all tool handlers and their definitions.
+func BuildHandlers(workingDir string) (map[string]Handler, []llms.Tool) {
+	handlers := map[string]Handler{}
 
-	add := func(handler toolHandler) {
-		name := handler.def.Function.Name
+	add := func(handler Handler) {
+		name := handler.Def.Function.Name
 		handlers[name] = handler
 	}
 
-	add(toolHandler{def: toolDefinitionRead(), call: readTool(workingDir)})
-	add(toolHandler{def: toolDefinitionWrite(), call: writeTool(workingDir)})
-	add(toolHandler{def: toolDefinitionEdit(), call: editTool(workingDir)})
-	add(toolHandler{def: toolDefinitionGlob(), call: globTool(workingDir)})
-	add(toolHandler{def: toolDefinitionGrep(), call: grepTool(workingDir)})
-	add(toolHandler{def: toolDefinitionBash(), call: bashTool(workingDir)})
+	add(Handler{Def: definitionRead(), Call: readTool(workingDir)})
+	add(Handler{Def: definitionWrite(), Call: trackEdits(writeTool(workingDir))})
+	add(Handler{Def: definitionEdit(), Call: trackEdits(editTool(workingDir))})
+	add(Handler{Def: definitionGlob(), Call: globTool(workingDir)})
+	add(Handler{Def: definitionGrep(), Call: grepTool(workingDir)})
+	add(Handler{Def: definitionBash(), Call: bashTool(workingDir)})
 
 	toolDefs := make([]llms.Tool, 0, len(handlers))
 	for _, handler := range handlers {
-		toolDefs = append(toolDefs, handler.def)
+		toolDefs = append(toolDefs, handler.Def)
 	}
 	sort.Slice(toolDefs, func(i, j int) bool {
 		return toolDefs[i].Function.Name < toolDefs[j].Function.Name
@@ -262,7 +280,19 @@ func buildToolHandlers(workingDir string) (map[string]toolHandler, []llms.Tool) 
 	return handlers, toolDefs
 }
 
-func toolDefinitionRead() llms.Tool {
+func trackEdits(call func(ctx context.Context, rawArgs []byte) (string, error)) func(ctx context.Context, rawArgs []byte) (string, error) {
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		result, err := call(ctx, rawArgs)
+		if err == nil {
+			MarkEditsApplied()
+		}
+		return result, err
+	}
+}
+
+// --- Tool definitions ---
+
+func definitionRead() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -279,7 +309,7 @@ func toolDefinitionRead() llms.Tool {
 	}
 }
 
-func toolDefinitionWrite() llms.Tool {
+func definitionWrite() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -297,7 +327,7 @@ func toolDefinitionWrite() llms.Tool {
 	}
 }
 
-func toolDefinitionEdit() llms.Tool {
+func definitionEdit() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -317,7 +347,7 @@ func toolDefinitionEdit() llms.Tool {
 	}
 }
 
-func toolDefinitionGlob() llms.Tool {
+func definitionGlob() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -334,7 +364,7 @@ func toolDefinitionGlob() llms.Tool {
 	}
 }
 
-func toolDefinitionGrep() llms.Tool {
+func definitionGrep() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -352,7 +382,7 @@ func toolDefinitionGrep() llms.Tool {
 	}
 }
 
-func toolDefinitionBash() llms.Tool {
+func definitionBash() llms.Tool {
 	return llms.Tool{
 		Type: "function",
 		Function: &llms.FunctionDefinition{
@@ -369,6 +399,8 @@ func toolDefinitionBash() llms.Tool {
 	}
 }
 
+// --- Tool implementations ---
+
 func readTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
 	type args struct {
 		Path string `json:"path"`
@@ -378,7 +410,7 @@ func readTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		if err := json.Unmarshal(rawArgs, &payload); err != nil {
 			return "", fmt.Errorf("invalid args: %w", err)
 		}
-		path, err := resolvePath(workingDir, payload.Path)
+		path, err := ResolvePath(workingDir, payload.Path)
 		if err != nil {
 			return "", err
 		}
@@ -400,7 +432,7 @@ func writeTool(workingDir string) func(ctx context.Context, rawArgs []byte) (str
 		if err := json.Unmarshal(rawArgs, &payload); err != nil {
 			return "", fmt.Errorf("invalid args: %w", err)
 		}
-		path, err := resolvePath(workingDir, payload.Path)
+		path, err := ResolvePath(workingDir, payload.Path)
 		if err != nil {
 			return "", err
 		}
@@ -419,14 +451,14 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		Path       string   `json:"path"`
 		Old        string   `json:"old"`
 		New        string   `json:"new"`
-		ReplaceAll flexBool `json:"replace_all"`
+		ReplaceAll FlexBool `json:"replace_all"`
 	}
 	return func(_ context.Context, rawArgs []byte) (string, error) {
 		var payload args
 		if err := json.Unmarshal(rawArgs, &payload); err != nil {
 			return "", fmt.Errorf("invalid args: %w", err)
 		}
-		path, err := resolvePath(workingDir, payload.Path)
+		path, err := ResolvePath(workingDir, payload.Path)
 		if err != nil {
 			return "", err
 		}
@@ -521,7 +553,7 @@ func grepTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		if strings.TrimSpace(searchPath) == "" {
 			searchPath = "."
 		}
-		resolved, err := resolvePath(workingDir, searchPath)
+		resolved, err := ResolvePath(workingDir, searchPath)
 		if err != nil {
 			return "", err
 		}
@@ -576,6 +608,7 @@ func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) file
 			rel = path
 		}
 		scanner := bufio.NewScanner(file)
+		scanner.Buffer(make([]byte, 64*1024), maxToolOutput)
 		lineNum := 1
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -583,6 +616,9 @@ func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) file
 				*matches = append(*matches, fmt.Sprintf("%s:%d:%s", filepath.ToSlash(rel), lineNum, line))
 			}
 			lineNum++
+		}
+		if err := scanner.Err(); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -614,18 +650,18 @@ func bashTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 	}
 }
 
-// flexBool unmarshals both JSON booleans and string representations
-// ("true"/"false") that LLMs sometimes produce for boolean fields.
-type flexBool bool
+// --- Utilities ---
 
-func (b *flexBool) UnmarshalJSON(data []byte) error {
-	// Try bool first.
+// FlexBool unmarshals both JSON booleans and string representations
+// ("true"/"false") that LLMs sometimes produce for boolean fields.
+type FlexBool bool
+
+func (b *FlexBool) UnmarshalJSON(data []byte) error {
 	var v bool
 	if err := json.Unmarshal(data, &v); err == nil {
-		*b = flexBool(v)
+		*b = FlexBool(v)
 		return nil
 	}
-	// Fall back to string.
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return fmt.Errorf("replace_all must be bool or string, got %s", string(data))
@@ -639,7 +675,8 @@ func (b *flexBool) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func resolvePath(workingDir, input string) (string, error) {
+// ResolvePath resolves a path relative to the working directory and validates it's within bounds.
+func ResolvePath(workingDir, input string) (string, error) {
 	if strings.TrimSpace(input) == "" {
 		return "", fmt.Errorf("path is required")
 	}
@@ -720,7 +757,8 @@ func globToRegex(pattern string) (string, error) {
 	return buf.String(), nil
 }
 
-func truncateString(s string, maxLen int) string {
+// TruncateString truncates a string to the given max length.
+func TruncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}


### PR DESCRIPTION

**Key Changes:**

- Implemented native Ollama LLM client using the /api/chat endpoint with full tool-call and context support
- Added OpenAI Responses API integration for GPT-5 and openai-responses providers with tool-call loop
- Introduced agent bundle system for assembling agent prompts, wrappers, and references with agent modes (e.g., readonly)
- Refactored agent CLI run logic for provider/model abstraction, tool loop, and apply diff functionality

**Added:**

- Native Ollama LLM implementation (`ollama/ollama.go`) supporting /api/chat, num_ctx, and tool-calling for improved agent context and tool execution
- OpenAI Responses API integration (`openairesponses/responses.go`) including function call extraction, tool execution loop, and support for GPT-5 models
- Agent bundle builder (`agent/bundle.go`) that assembles agent manifest, system prompt, wrapper, references, and supports agent modes (e.g., readonly)
- Flexible tool framework (`tools/tools.go`) providing tool definitions (Read, Write, Edit, Glob, Grep, Bash), handler registration, tool execution, repetition detection, and safe file operations
- Readonly agent mode support and new agent manifests for go-cobra, go-review, and go-review-judge (with multi-mode, readonly mode, and judge agent references)
- New agents: `go-doc-comments` and `python-doc-comments` (metadata, prompts, and comprehensive documentation knowledge bases)
- Comprehensive tests for agent bundle assembly and OpenAI Responses API logic (`cmd/squad/run_test.go`, `cmd/squad/openai_responses_test.go`)

**Changed:**

- Major refactor of `cmd/squad/run.go` to support provider abstraction, agent bundle usage, tool-call loop, and native diff application via `--apply`
- Enhanced `cmd/squad/root.go` to bind Viper config to CLI flags and support agent run configuration precedence (env/config/flags)
- Updated `config/config.go` to unmarshal provider token for consistent API key handling and fixed config loading bug
- Improved logging error handling to treat error values as plain strings, not format strings
- Added agent mode support in agent manifests (YAML) and enabled mode-specific entrypoint/wrapper/reference overrides
- Expanded Taskfile.yaml for judge pipeline, parallel agent workers, and codebase-wide review workflows
- Added aliases and argument validation to CLI commands (`config`, `version`)
- Updated and normalized all agent documentation, references, and system prompts to 2026 standards and clarified output instructions and review categories

**Removed:**

- Deprecated static agent prompt assembly in `cmd/squad/run.go` (replaced by agent bundle builder)
- Redundant/unused config force flag variable in `cmd/squad/config.go`
- Manual tool application logic in favor of the new dynamic tool handler system