### PR TITLE
feat: improve test coverage, CLI output redirection, and tool handling

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -567,7 +567,11 @@ tasks:
 
         Target: {{.COVERAGE_TARGET}}% total coverage.
         Use table-driven tests ([]struct + t.Run) for any function with 2+ test cases.
-        Only create or modify _test.go files. Never edit source code." \
+        Only create or modify _test.go files. Never edit source code.
+
+        BUDGET: You have 200 iterations. Use Write (not Edit) for new files.
+        Cap 20 iterations per package. Wind down early if needed — a partial
+        report with before/after numbers is better than no report." \
           --agent go-tests \
           --working-dir {{.WORKING_DIR}} \
           --api-key {{.API_KEY}} \
@@ -576,6 +580,7 @@ tasks:
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
+          --max-iterations 200 \
           --out /tmp/squad-go-tests.txt
       - echo "Test coverage output written to /tmp/squad-go-tests.txt"
       - |

--- a/agents/go-tests/agent.md
+++ b/agents/go-tests/agent.md
@@ -38,6 +38,18 @@ An automated validator checks for "files touched" or "no changes"
 (case-insensitive). Missing both = pipeline failure. Missing the
 "Coverage Report" section with Before/After/Delta = pipeline failure.
 
+# EFFICIENCY RULES
+
+- **Write whole files, not incremental edits.** When creating a new test file,
+  use the Write tool with the complete file content. One Write call is cheaper
+  than 10+ Edit calls building up the same file incrementally.
+- **Wind down gracefully.** If you are running low on iterations, stop writing
+  tests, measure final coverage, and produce the report. A partial report with
+  accurate before/after numbers is a success. No report is a failure.
+- **Prioritize breadth over depth.** Cover more packages at basic level rather
+  than achieving 100% on a single package. Move to the next package after
+  covering the high-impact exported functions.
+
 # INPUT
 
 User request and any constraints.

--- a/agents/go-tests/system.md
+++ b/agents/go-tests/system.md
@@ -36,9 +36,10 @@ These override everything else.
 7. **Report coverage delta.** Record the starting total coverage percentage
    in Phase 1 BEFORE writing any tests. Report both before and after numbers
    in the final output. Runs that omit the before/after delta are failures.
-8. **Table-driven tests are mandatory.** When a function has 2 or more test
-   cases, use `[]struct` with `t.Run` subtests. Inline sequential assertions
-   for multiple cases is not acceptable. Single-case tests do not need tables.
+8. **Table-driven tests are mandatory — no exceptions.** When a function has
+   2 or more test cases, use `[]struct` with `t.Run` subtests. Inline
+   sequential assertions for multiple cases are not acceptable — immediately
+   rewrite them as table-driven tests. Single-case tests do not need tables.
 9. **Test file naming.** Name test files to match the source file under test:
    `foo.go` → `foo_test.go`. Add tests to existing `_test.go` files when one
    already exists for that source file. Never create `_extra_test.go`,
@@ -51,6 +52,16 @@ These override everything else.
     Go version. If Go 1.22+, range loop variables are per-iteration and
     `tt := tt` is dead code — do not include it. If below 1.22, you MUST
     add `tt := tt` before `t.Run` in parallel table-driven tests.
+12. **Budget awareness.** You have a limited iteration budget. Prefer Write
+    over Edit when creating new test files — one Write call replaces dozens
+    of incremental Edits. Batch Read calls for related files. Track your
+    iteration count mentally. Cap yourself at 20 iterations per package —
+    if you cannot finish a package in 20 iterations, move on.
+13. **Wind-down protocol.** When you sense you are approaching your iteration
+    limit (e.g. you have covered 3+ packages and still have work to do),
+    stop writing new tests immediately. Run `go test ./...` to measure
+    final coverage, then produce the structured report. A partial report
+    with accurate numbers is infinitely better than no report at all.
 
 # WORKFLOW
 

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -188,10 +188,11 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	fmt.Println("# Current Squad Configuration")
-	fmt.Println("# Sources: defaults -> config file -> environment variables -> CLI flags")
-	fmt.Println()
-	fmt.Print(string(data))
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "# Current Squad Configuration")
+	fmt.Fprintln(w, "# Sources: defaults -> config file -> environment variables -> CLI flags")
+	fmt.Fprintln(w)
+	fmt.Fprint(w, string(data))
 	return nil
 }
 

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -189,10 +189,18 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	}
 
 	w := cmd.OutOrStdout()
-	fmt.Fprintln(w, "# Current Squad Configuration")
-	fmt.Fprintln(w, "# Sources: defaults -> config file -> environment variables -> CLI flags")
-	fmt.Fprintln(w)
-	fmt.Fprint(w, string(data))
+	if _, err := fmt.Fprintln(w, "# Current Squad Configuration"); err != nil {
+		return fmt.Errorf("failed to write config header: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, "# Sources: defaults -> config file -> environment variables -> CLI flags"); err != nil {
+		return fmt.Errorf("failed to write config header: %w", err)
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("failed to write config header: %w", err)
+	}
+	if _, err := fmt.Fprint(w, string(data)); err != nil {
+		return fmt.Errorf("failed to write config data: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/squad/config_test.go
+++ b/cmd/squad/config_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,32 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Pipe: %v", err)
-	}
-	os.Stdout = w
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	os.Stdout = orig
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
-	if err := r.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	return string(data)
-}
 
 func TestRunConfigInit(t *testing.T) {
 	tests := []struct {
@@ -101,16 +74,17 @@ func TestRunConfigInit(t *testing.T) {
 
 func TestRunConfigShow(t *testing.T) {
 	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
 	cfg := config.Defaults()
 	cfg.Model.MaxTokens = 1234
 	cmd.SetContext(withConfig(context.Background(), cfg))
 
-	out := captureStdout(t, func() {
-		if err := runConfigShow(cmd, nil); err != nil {
-			t.Fatalf("runConfigShow() error = %v", err)
-		}
-	})
+	if err := runConfigShow(cmd, nil); err != nil {
+		t.Fatalf("runConfigShow() error = %v", err)
+	}
 
+	out := buf.String()
 	if !strings.Contains(out, "Current Squad Configuration") {
 		t.Fatalf("expected header in output")
 	}
@@ -257,11 +231,12 @@ func TestCompletionCommand(t *testing.T) {
 }
 
 func TestVersionCommand(t *testing.T) {
-	cmd := &cobra.Command{}
-	out := captureStdout(t, func() {
-		versionCmd.Run(cmd, nil)
-	})
+	var buf bytes.Buffer
+	versionCmd.SetOut(&buf)
+	defer versionCmd.SetOut(nil)
+	versionCmd.Run(versionCmd, nil)
 
+	out := buf.String()
 	if !strings.Contains(out, fmt.Sprintf("squad version %s", version)) {
 		t.Fatalf("unexpected version output: %s", out)
 	}

--- a/cmd/squad/config_test.go
+++ b/cmd/squad/config_test.go
@@ -234,7 +234,9 @@ func TestVersionCommand(t *testing.T) {
 	var buf bytes.Buffer
 	versionCmd.SetOut(&buf)
 	defer versionCmd.SetOut(nil)
-	versionCmd.Run(versionCmd, nil)
+	if err := versionCmd.RunE(versionCmd, nil); err != nil {
+		t.Fatalf("versionCmd.RunE() error = %v", err)
+	}
 
 	out := buf.String()
 	if !strings.Contains(out, fmt.Sprintf("squad version %s", version)) {

--- a/cmd/squad/openai_responses_test.go
+++ b/cmd/squad/openai_responses_test.go
@@ -89,54 +89,56 @@ func TestConvertToolsToResponses(t *testing.T) {
 }
 
 func TestExtractFunctionCalls(t *testing.T) {
-	t.Run("nil response", func(t *testing.T) {
-		calls := responses.ExtractFunctionCalls(nil)
-		if len(calls) != 0 {
-			t.Errorf("expected 0 calls, got %d", len(calls))
-		}
-	})
-
-	t.Run("no function calls", func(t *testing.T) {
-		resp := &oairesponses.Response{
-			Output: []oairesponses.ResponseOutputItemUnion{
-				{Type: "message", ID: "msg_1"},
-			},
-		}
-		calls := responses.ExtractFunctionCalls(resp)
-		if len(calls) != 0 {
-			t.Errorf("expected 0 calls, got %d", len(calls))
-		}
-	})
-
-	t.Run("with function calls", func(t *testing.T) {
-		resp := &oairesponses.Response{
-			Output: []oairesponses.ResponseOutputItemUnion{
-				{
-					Type:      "function_call",
-					ID:        "fc_1",
-					CallID:    "call_abc",
-					Name:      "Read",
-					Arguments: `{"path":"main.go"}`,
-				},
-				{Type: "message", ID: "msg_1"},
-				{
-					Type:      "function_call",
-					ID:        "fc_2",
-					CallID:    "call_def",
-					Name:      "Bash",
-					Arguments: `{"command":"go build"}`,
+	t.Parallel()
+	tests := []struct {
+		name    string
+		resp    *oairesponses.Response
+		wantLen int
+	}{
+		{"nil response", nil, 0},
+		{
+			"no function calls",
+			&oairesponses.Response{
+				Output: []oairesponses.ResponseOutputItemUnion{
+					{Type: "message", ID: "msg_1"},
 				},
 			},
-		}
-		calls := responses.ExtractFunctionCalls(resp)
-		if len(calls) != 2 {
-			t.Fatalf("expected 2 calls, got %d", len(calls))
-		}
-		if calls[0].Name != "Read" || calls[0].CallID != "call_abc" {
-			t.Errorf("unexpected first call: %+v", calls[0])
-		}
-		if calls[1].Name != "Bash" || calls[1].CallID != "call_def" {
-			t.Errorf("unexpected second call: %+v", calls[1])
-		}
-	})
+			0,
+		},
+		{
+			"with function calls",
+			&oairesponses.Response{
+				Output: []oairesponses.ResponseOutputItemUnion{
+					{
+						Type:      "function_call",
+						ID:        "fc_1",
+						CallID:    "call_abc",
+						Name:      "Read",
+						Arguments: `{"path":"main.go"}`,
+					},
+					{Type: "message", ID: "msg_1"},
+					{
+						Type:      "function_call",
+						ID:        "fc_2",
+						CallID:    "call_def",
+						Name:      "Bash",
+						Arguments: `{"command":"go build"}`,
+					},
+				},
+			},
+			2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			calls := responses.ExtractFunctionCalls(tt.resp)
+			if len(calls) != tt.wantLen {
+				t.Fatalf(
+					"ExtractFunctionCalls() len = %d, want %d",
+					len(calls), tt.wantLen,
+				)
+			}
+		})
+	}
 }

--- a/cmd/squad/root_test.go
+++ b/cmd/squad/root_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExecuteVersion(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+	t.Setenv("USERPROFILE", baseDir)
+
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	os.Args = []string{"squad", "version"}
+
+	if err := Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -401,28 +401,47 @@ func TestBindRunFlags(t *testing.T) {
 func TestHasPipedInput(t *testing.T) {
 	tests := []struct {
 		name   string
-		reader io.Reader
+		reader func(t *testing.T) (io.Reader, func())
 		want   bool
 	}{
 		{
-			name:   "buffer with data",
-			reader: bytes.NewBufferString("data"),
-			want:   true,
+			name: "buffer with data",
+			reader: func(*testing.T) (io.Reader, func()) {
+				return bytes.NewBufferString("data"), func() {}
+			},
+			want: true,
 		},
 		{
-			name:   "empty buffer",
-			reader: bytes.NewBuffer(nil),
-			want:   false,
+			name: "empty buffer",
+			reader: func(*testing.T) (io.Reader, func()) {
+				return bytes.NewBuffer(nil), func() {}
+			},
+			want: false,
 		},
 		{
-			name:   "string reader",
-			reader: strings.NewReader("data"),
-			want:   false,
+			name: "string reader",
+			reader: func(*testing.T) (io.Reader, func()) {
+				return strings.NewReader("data"), func() {}
+			},
+			want: false,
+		},
+		{
+			name: "file reader",
+			reader: func(t *testing.T) (io.Reader, func()) {
+				file, err := os.CreateTemp(t.TempDir(), "input")
+				if err != nil {
+					t.Fatalf("CreateTemp: %v", err)
+				}
+				return file, func() { _ = file.Close() }
+			},
+			want: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hasPipedInput(tt.reader); got != tt.want {
+			reader, cleanup := tt.reader(t)
+			defer cleanup()
+			if got := hasPipedInput(reader); got != tt.want {
 				t.Fatalf("hasPipedInput() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/squad/version.go
+++ b/cmd/squad/version.go
@@ -61,8 +61,9 @@ var versionCmd = &cobra.Command{
 	Long:    "Display the version, commit hash, and build date of squad.",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("squad version %s\n", version)
-		fmt.Printf("  commit: %s\n", commit)
-		fmt.Printf("  built:  %s\n", date)
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "squad version %s\n", version)
+		fmt.Fprintf(w, "  commit: %s\n", commit)
+		fmt.Fprintf(w, "  built:  %s\n", date)
 	},
 }

--- a/cmd/squad/version.go
+++ b/cmd/squad/version.go
@@ -60,10 +60,17 @@ var versionCmd = &cobra.Command{
 	Short:   "Print version information",
 	Long:    "Display the version, commit hash, and build date of squad.",
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		w := cmd.OutOrStdout()
-		fmt.Fprintf(w, "squad version %s\n", version)
-		fmt.Fprintf(w, "  commit: %s\n", commit)
-		fmt.Fprintf(w, "  built:  %s\n", date)
+		if _, err := fmt.Fprintf(w, "squad version %s\n", version); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "  commit: %s\n", commit); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "  built:  %s\n", date); err != nil {
+			return err
+		}
+		return nil
 	},
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,6 +81,28 @@ func TestGetConfigDirsIncludesConfigHome(t *testing.T) {
 	}
 }
 
+func TestLoadMissingFileReturnsDefaults(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+	t.Setenv("USERPROFILE", baseDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Log.Level != "info" || cfg.Log.Format != "text" {
+		t.Fatalf("unexpected defaults: %+v", cfg.Log)
+	}
+}
+
+func TestLoadFromPathMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	if _, err := LoadFromPath(missing); err == nil {
+		t.Fatalf("expected error for missing config file")
+	}
+}
+
 func contains(values []string, value string) bool {
 	for _, v := range values {
 		if v == value {

--- a/config/xdg_test.go
+++ b/config/xdg_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetConfigHome(t *testing.T) {
+	baseDir := t.TempDir()
+	tests := []struct {
+		name string
+		xdg  string
+		home string
+		want string
+	}{
+		{
+			name: "xdg config home",
+			xdg:  filepath.Join(baseDir, "xdg"),
+			home: filepath.Join(baseDir, "home"),
+			want: filepath.Join(baseDir, "xdg"),
+		},
+		{
+			name: "home fallback",
+			xdg:  "",
+			home: filepath.Join(baseDir, "home"),
+			want: filepath.Join(baseDir, "home", ".config"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", tt.xdg)
+			t.Setenv("HOME", tt.home)
+			t.Setenv("USERPROFILE", tt.home)
+			if got := getConfigHome(); got != tt.want {
+				t.Fatalf("getConfigHome() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCacheHome(t *testing.T) {
+	baseDir := t.TempDir()
+	tests := []struct {
+		name string
+		xdg  string
+		home string
+		want string
+	}{
+		{
+			name: "xdg cache home",
+			xdg:  filepath.Join(baseDir, "xdg"),
+			home: filepath.Join(baseDir, "home"),
+			want: filepath.Join(baseDir, "xdg"),
+		},
+		{
+			name: "home fallback",
+			xdg:  "",
+			home: filepath.Join(baseDir, "home"),
+			want: filepath.Join(baseDir, "home", ".cache"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CACHE_HOME", tt.xdg)
+			t.Setenv("HOME", tt.home)
+			t.Setenv("USERPROFILE", tt.home)
+			if got := getCacheHome(); got != tt.want {
+				t.Fatalf("getCacheHome() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConfigDirsXDGConfigDirs(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "freebsd" && runtime.GOOS != "openbsd" {
+		t.Skip("xdg config dirs only applies to unix-like OS")
+	}
+	baseDir := t.TempDir()
+	configHome := filepath.Join(baseDir, "config")
+	first := filepath.Join(baseDir, "first")
+	second := filepath.Join(baseDir, "second")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_CONFIG_DIRS", strings.Join([]string{first, second}, string(filepath.ListSeparator)))
+	dirs := GetConfigDirs()
+	wantFirst := filepath.Join(configHome, "squad")
+	if len(dirs) == 0 || dirs[0] != wantFirst {
+		t.Fatalf("expected %q first, got %v", wantFirst, dirs)
+	}
+	wantDirs := []string{filepath.Join(first, "squad"), filepath.Join(second, "squad")}
+	for _, want := range wantDirs {
+		found := false
+		for _, dir := range dirs {
+			if dir == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected %q in dirs, got %v", want, dirs)
+		}
+	}
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -62,6 +62,7 @@ type CustomLogger struct {
 	OutputType    OutputType
 	Quiet         bool
 	ConsoleWriter io.Writer
+	OutputWriter  io.Writer
 	Verbose       bool
 }
 
@@ -144,16 +145,24 @@ func (l *CustomLogger) Info(format string, args ...interface{}) {
 	l.log(InfoLevel, format, args...)
 }
 
+func (l *CustomLogger) outputWriter() io.Writer {
+	if l.OutputWriter != nil {
+		return l.OutputWriter
+	}
+	return os.Stdout
+}
+
 func (l *CustomLogger) Output(data interface{}) {
+	w := l.outputWriter()
 	switch l.OutputType {
 	case JSONOutput:
-		encoder := json.NewEncoder(os.Stdout)
+		encoder := json.NewEncoder(w)
 		encoder.SetIndent("", "  ")
 		if err := encoder.Encode(data); err != nil {
 			l.Error("Failed to encode JSON output: %v", err)
 		}
 	default:
-		if _, err := fmt.Fprintln(os.Stdout, data); err != nil {
+		if _, err := fmt.Fprintln(w, data); err != nil {
 			l.Error("Failed to write output: %v", err)
 		}
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -3,9 +3,7 @@ package logging
 import (
 	"bytes"
 	"context"
-	"io"
 	"log/slog"
-	"os"
 	"strings"
 	"testing"
 )
@@ -168,20 +166,17 @@ func TestContextLogging(t *testing.T) {
 }
 
 func TestOutputContextJSON(t *testing.T) {
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
+	t.Parallel()
+	var buf bytes.Buffer
+	local := &CustomLogger{
+		OutputType:    JSONOutput,
+		ConsoleWriter: &bytes.Buffer{},
+		OutputWriter:  &buf,
 	}
-	os.Stdout = w
-	local := &CustomLogger{OutputType: JSONOutput, ConsoleWriter: &bytes.Buffer{}}
 	ctx := WithLogger(context.Background(), local)
 	OutputContext(ctx, map[string]string{"status": "ok"})
-	_ = w.Close()
-	os.Stdout = origStdout
-	data, _ := io.ReadAll(r)
-	if !strings.Contains(string(data), "status") {
-		t.Fatalf("expected json output, got %q", string(data))
+	if !strings.Contains(buf.String(), "status") {
+		t.Fatalf("expected json output, got %q", buf.String())
 	}
 }
 

--- a/ollama/ollama_test.go
+++ b/ollama/ollama_test.go
@@ -1,6 +1,12 @@
 package ollama
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
@@ -210,6 +216,125 @@ func TestConvertResponse(t *testing.T) {
 			}
 			if choice.GenerationInfo["TotalTokens"] != tt.wantTokens {
 				t.Fatalf("TotalTokens = %v, want %d", choice.GenerationInfo["TotalTokens"], tt.wantTokens)
+			}
+		})
+	}
+}
+
+func TestGenerateContentSuccess(t *testing.T) {
+	t.Parallel()
+	var gotRequest chatRequest
+	reqErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			reqErr <- fmt.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotRequest); err != nil {
+			reqErr <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+		reqErr <- nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model":"mistral",
+			"message":{"role":"assistant","content":"hello","tool_calls":[{"function":{"name":"Echo","arguments":{"value":"hi"}}}]},
+			"done":true,
+			"prompt_eval_count":2,
+			"eval_count":3
+		}`))
+	}))
+	defer server.Close()
+
+	llm := New(server.URL, "mistral", 4096)
+	messages := []llms.MessageContent{{
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{llms.TextPart("hi")},
+	}}
+
+	resp, err := llm.GenerateContent(
+		context.Background(),
+		messages,
+		llms.WithTemperature(0.7),
+		llms.WithMaxTokens(123),
+		llms.WithTools([]llms.Tool{{
+			Function: &llms.FunctionDefinition{Name: "Echo", Description: "desc"},
+		}}),
+		llms.WithToolChoice("auto"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateContent() error = %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	if resp == nil || len(resp.Choices) != 1 {
+		t.Fatalf("expected 1 choice")
+	}
+	if resp.Choices[0].Content != "hello" {
+		t.Fatalf("Content = %q, want hello", resp.Choices[0].Content)
+	}
+	if len(resp.Choices[0].ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(resp.Choices[0].ToolCalls))
+	}
+	if gotRequest.Model != "mistral" {
+		t.Fatalf("request model = %q, want mistral", gotRequest.Model)
+	}
+	if gotRequest.Options["num_ctx"] != float64(4096) {
+		t.Fatalf("num_ctx = %v, want 4096", gotRequest.Options["num_ctx"])
+	}
+	if gotRequest.Options["temperature"] != 0.7 {
+		t.Fatalf("temperature = %v, want 0.7", gotRequest.Options["temperature"])
+	}
+	if gotRequest.Options["num_predict"] != float64(123) {
+		t.Fatalf("num_predict = %v, want 123", gotRequest.Options["num_predict"])
+	}
+	if len(gotRequest.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(gotRequest.Tools))
+	}
+}
+
+func TestGenerateContentErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErrMsg string
+	}{
+		{
+			name:       "http error",
+			status:     http.StatusBadRequest,
+			body:       "bad request",
+			wantErrMsg: "ollama returned 400",
+		},
+		{
+			name:       "invalid json",
+			status:     http.StatusOK,
+			body:       "not-json",
+			wantErrMsg: "failed to parse ollama response",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			llm := New(server.URL, "mistral", 256)
+			messages := []llms.MessageContent{{
+				Role:  llms.ChatMessageTypeHuman,
+				Parts: []llms.ContentPart{llms.TextPart("hi")},
+			}}
+			_, err := llm.GenerateContent(context.Background(), messages)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErrMsg)
 			}
 		})
 	}

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -107,6 +107,16 @@ func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, use
 		return text, nil
 	}
 
+	// If the loop exited with pending function calls, resolve them with
+	// dummy outputs so PreviousResponseID chaining doesn't fail.
+	resp, text, err = resolvePendingCalls(ctx, client, resp, &rc)
+	if err != nil {
+		return "", fmt.Errorf("responses API: resolvePendingCalls failed: %w", err)
+	}
+	if text != "" {
+		return text, nil
+	}
+
 	finalText, finalErr := requestFinal(ctx, client, resp.ID, systemPrompt, &rc)
 	if finalErr == nil && finalText != "" {
 		return finalText, nil
@@ -223,6 +233,52 @@ func requestFinal(ctx context.Context, client openai.Client, previousID, systemP
 	}
 	logging.InfoContext(ctx, "responses API: final call produced response (%d bytes)", len(text))
 	return text, nil
+}
+
+// resolvePendingCalls checks whether resp contains unresolved function_call
+// items and, if so, submits dummy outputs with ToolChoice=none so the
+// conversation is in a clean state for subsequent chaining.
+func resolvePendingCalls(ctx context.Context, client openai.Client, resp *oairesponses.Response, rc *Config) (*oairesponses.Response, string, error) {
+	calls := ExtractFunctionCalls(resp)
+	if len(calls) == 0 {
+		return resp, resp.OutputText(), nil
+	}
+
+	logging.InfoContext(ctx, "responses API: resolving %d pending call(s) after iteration budget exhausted", len(calls))
+
+	outputs := make([]oairesponses.ResponseInputItemUnionParam, 0, len(calls))
+	for _, call := range calls {
+		outputs = append(outputs, oairesponses.ResponseInputItemUnionParam{
+			OfFunctionCallOutput: &oairesponses.ResponseInputItemFunctionCallOutputParam{
+				CallID: call.CallID,
+				Output: oairesponses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+					OfString: openai.String("Tool call skipped: iteration budget exhausted."),
+				},
+			},
+		})
+	}
+
+	params := oairesponses.ResponseNewParams{
+		Model:              rc.Model,
+		PreviousResponseID: openai.String(resp.ID),
+		Instructions:       openai.String(rc.Instructions),
+		Input: oairesponses.ResponseNewParamsInputUnion{
+			OfInputItemList: oairesponses.ResponseInputParam(outputs),
+		},
+		ToolChoice: oairesponses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: openai.Opt(oairesponses.ToolChoiceOptionsNone),
+		},
+		Tools:      rc.Tools,
+		Truncation: oairesponses.ResponseNewParamsTruncation("auto"),
+	}
+	rc.applyOptionals(&params)
+
+	resolved, err := client.Responses.New(ctx, params)
+	if err != nil {
+		return resp, "", fmt.Errorf("resolve pending calls failed: %w", err)
+	}
+	logOutputItems(ctx, resolved, "resolve-pending")
+	return resolved, resolved.OutputText(), nil
 }
 
 // ConvertTools converts langchaingo tool definitions to the

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -569,5 +570,102 @@ func TestRunWithToolsFollowUp(t *testing.T) {
 		if err := <-reqErr; err != nil {
 			t.Fatalf("handler error: %v", err)
 		}
+	}
+}
+
+func TestRequestFinal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantErr     bool
+		wantText    string
+		wantErrPart string
+	}{
+		{
+			name: "success",
+			payload: map[string]any{
+				"id":                  "resp-final",
+				"object":              "response",
+				"created_at":          0,
+				"model":               "gpt-4o",
+				"parallel_tool_calls": false,
+				"temperature":         0,
+				"tool_choice":         "none",
+				"tools":               []any{},
+				"top_p":               1,
+				"error": map[string]any{
+					"code":    "server_error",
+					"message": "",
+				},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id":     "msg-1",
+						"type":   "message",
+						"role":   "assistant",
+						"status": "completed",
+						"content": []map[string]any{
+							{"type": "output_text", "text": "final"},
+						},
+					},
+				},
+			},
+			wantText: "final",
+		},
+		{
+			name: "empty output",
+			payload: map[string]any{
+				"id":                  "resp-final",
+				"object":              "response",
+				"created_at":          0,
+				"model":               "gpt-4o",
+				"parallel_tool_calls": false,
+				"temperature":         0,
+				"tool_choice":         "none",
+				"tools":               []any{},
+				"top_p":               1,
+				"error": map[string]any{
+					"code":    "server_error",
+					"message": "",
+				},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output":             []map[string]any{},
+			},
+			wantErr:     true,
+			wantErrPart: "empty text",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.payload)
+			}))
+			defer server.Close()
+
+			client := newClient("key", server.URL, "org")
+			cfg := &Config{Model: "gpt-4o"}
+			text, err := requestFinal(
+				context.Background(),
+				client,
+				"resp-1",
+				"system",
+				cfg,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requestFinal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrPart != "" && err != nil && !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantErrPart)
+			}
+			if !tt.wantErr && text != tt.wantText {
+				t.Fatalf("text = %q, want %q", text, tt.wantText)
+			}
+		})
 	}
 }

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -2,8 +2,12 @@ package responses
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cowdogmoo/squad/tools"
@@ -254,16 +258,316 @@ func TestExecuteAndBuildOutputs(t *testing.T) {
 
 func TestLogOutputItems(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	logOutputItems(ctx, nil, "nil")
-	resp := &oairesponses.Response{
-		ID:     "resp",
-		Status: "completed",
-		Usage: oairesponses.ResponseUsage{
-			InputTokens:  2,
-			OutputTokens: 3,
+	tests := []struct {
+		name  string
+		resp  *oairesponses.Response
+		label string
+	}{
+		{"nil response", nil, "nil"},
+		{
+			"with output",
+			&oairesponses.Response{
+				ID:     "resp",
+				Status: "completed",
+				Usage: oairesponses.ResponseUsage{
+					InputTokens:  2,
+					OutputTokens: 3,
+				},
+				Output: []oairesponses.ResponseOutputItemUnion{
+					{Type: "message", ID: "msg"},
+				},
+			},
+			"with-output",
 		},
-		Output: []oairesponses.ResponseOutputItemUnion{{Type: "message", ID: "msg"}},
 	}
-	logOutputItems(ctx, resp, "with-output")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// logOutputItems only logs; verify no panic.
+			logOutputItems(
+				context.Background(), tt.resp, tt.label,
+			)
+		})
+	}
+}
+
+func TestRunWithToolsNoToolCalls(t *testing.T) {
+	t.Parallel()
+	payload := map[string]any{
+		"id":                  "resp-1",
+		"object":              "response",
+		"created_at":          0,
+		"model":               "gpt-4o",
+		"parallel_tool_calls": false,
+		"temperature":         0,
+		"tool_choice":         "auto",
+		"tools":               []any{},
+		"top_p":               1,
+		"error": map[string]any{
+			"code":    "server_error",
+			"message": "",
+		},
+		"incomplete_details": map[string]any{"reason": ""},
+		"instructions":       "system",
+		"metadata":           map[string]any{},
+		"output": []map[string]any{
+			{
+				"id":     "msg-1",
+				"type":   "message",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]any{
+					{"type": "output_text", "text": "hello"},
+				},
+			},
+		},
+	}
+
+	reqErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			reqErr <- errors.New("unexpected path")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		reqErr <- json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	resp, err := RunWithTools(
+		context.Background(),
+		"key",
+		server.URL,
+		"gpt-4o",
+		"system",
+		"user",
+		t.TempDir(),
+		"",
+		0.4,
+		0,
+		1,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("RunWithTools() error = %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if resp != "hello" {
+		t.Fatalf("response = %q, want hello", resp)
+	}
+}
+
+func TestRequestFinalMissingID(t *testing.T) {
+	t.Parallel()
+	client := openai.NewClient()
+	cfg := &Config{Model: "gpt-4o"}
+	if _, err := requestFinal(context.Background(), client, "", "sys", cfg); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRunWithToolsExhaustedWithPendingCalls(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: maxIterations=1.
+	// Call 1 (initial): returns a function_call.
+	// Call 2 (tool output follow-up): returns another function_call
+	//   → loop exits at iteration budget with pending calls.
+	// Call 3 (resolvePendingCalls): dummy outputs + tool_choice=none → text.
+	callCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		var payload map[string]any
+		switch count {
+		case 1:
+			// Initial request → function_call
+			payload = map[string]any{
+				"id": "resp-1", "object": "response", "created_at": 0,
+				"model": "gpt-4o", "parallel_tool_calls": false,
+				"temperature": 0, "tool_choice": "auto", "tools": []any{},
+				"top_p":              1,
+				"error":              map[string]any{"code": "server_error", "message": ""},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id": "fc-1", "type": "function_call",
+						"call_id": "call-1", "name": "Echo", "arguments": `{"msg":"hi"}`,
+					},
+				},
+			}
+		case 2:
+			// After tool output → another function_call (budget exhausted)
+			payload = map[string]any{
+				"id": "resp-2", "object": "response", "created_at": 0,
+				"model": "gpt-4o", "parallel_tool_calls": false,
+				"temperature": 0, "tool_choice": "auto", "tools": []any{},
+				"top_p":              1,
+				"error":              map[string]any{"code": "server_error", "message": ""},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id": "fc-2", "type": "function_call",
+						"call_id": "call-2", "name": "Echo", "arguments": `{"msg":"again"}`,
+					},
+				},
+			}
+		default:
+			// resolvePendingCalls → text response
+			payload = map[string]any{
+				"id": "resp-3", "object": "response", "created_at": 0,
+				"model": "gpt-4o", "parallel_tool_calls": false,
+				"temperature": 0, "tool_choice": "auto", "tools": []any{},
+				"top_p":              1,
+				"error":              map[string]any{"code": "server_error", "message": ""},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id": "msg-1", "type": "message", "role": "assistant",
+						"status": "completed",
+						"content": []map[string]any{
+							{"type": "output_text", "text": "resolved"},
+						},
+					},
+				},
+			}
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	resp, err := RunWithTools(
+		context.Background(),
+		"key",
+		server.URL,
+		"gpt-4o",
+		"system",
+		"user",
+		t.TempDir(),
+		"",
+		0.4,
+		0,
+		1, // maxIterations=1 → loop exits with pending calls
+		&tools.TaskConfig{},
+	)
+	if err != nil {
+		t.Fatalf("RunWithTools() error = %v", err)
+	}
+	if resp != "resolved" {
+		t.Fatalf("response = %q, want %q", resp, "resolved")
+	}
+	finalCount := atomic.LoadInt32(&callCount)
+	if finalCount != 3 {
+		t.Fatalf("expected 3 API calls (initial + follow-up + resolve), got %d", finalCount)
+	}
+}
+
+func TestRunWithToolsFollowUp(t *testing.T) {
+	t.Parallel()
+	reqErr := make(chan error, 2)
+	callCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		var payload map[string]any
+		switch count {
+		case 1:
+			payload = map[string]any{
+				"id":                  "resp-1",
+				"object":              "response",
+				"created_at":          0,
+				"model":               "gpt-4o",
+				"parallel_tool_calls": false,
+				"temperature":         0,
+				"tool_choice":         "auto",
+				"tools":               []any{},
+				"top_p":               1,
+				"error": map[string]any{
+					"code":    "server_error",
+					"message": "",
+				},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id":        "call-1",
+						"type":      "function_call",
+						"call_id":   "call-1",
+						"name":      "MissingTool",
+						"arguments": "{}",
+					},
+				},
+			}
+		default:
+			payload = map[string]any{
+				"id":                  "resp-2",
+				"object":              "response",
+				"created_at":          0,
+				"model":               "gpt-4o",
+				"parallel_tool_calls": false,
+				"temperature":         0,
+				"tool_choice":         "auto",
+				"tools":               []any{},
+				"top_p":               1,
+				"error": map[string]any{
+					"code":    "server_error",
+					"message": "",
+				},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id":     "msg-1",
+						"type":   "message",
+						"role":   "assistant",
+						"status": "completed",
+						"content": []map[string]any{
+							{"type": "output_text", "text": "follow-up"},
+						},
+					},
+				},
+			}
+		}
+		reqErr <- json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	resp, err := RunWithTools(
+		context.Background(),
+		"key",
+		server.URL,
+		"gpt-4o",
+		"system",
+		"user",
+		t.TempDir(),
+		"",
+		0.4,
+		0,
+		2,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("RunWithTools() error = %v", err)
+	}
+	if resp != "follow-up" {
+		t.Fatalf("response = %q, want follow-up", resp)
+	}
+	for i := 0; i < 2; i++ {
+		if err := <-reqErr; err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+	}
 }

--- a/runner/apply_test.go
+++ b/runner/apply_test.go
@@ -157,6 +157,42 @@ func TestApplyResponseDiffNoChanges(t *testing.T) {
 	}
 }
 
+func TestApplyResponseDiffBranches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		response string
+		edits    bool
+		wantErr  bool
+	}{
+		{
+			name:     "missing diff returns error",
+			response: "plain text response",
+			edits:    false,
+			wantErr:  true,
+		},
+		{
+			name:     "edits applied skip",
+			response: "plain text response",
+			edits:    true,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := tools.InitEdits(context.Background())
+			if tt.edits {
+				tools.MarkEditsApplied(ctx)
+			}
+			err := applyResponseDiff(ctx, tt.response, ".", false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("applyResponseDiff() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestApplyUnifiedDiffEmpty(t *testing.T) {
 	t.Parallel()
 	if err := applyUnifiedDiff(context.Background(), ".", "", false); err == nil {

--- a/runner/apply_test.go
+++ b/runner/apply_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -218,5 +220,107 @@ func TestResponseIndicatesNoChanges(t *testing.T) {
 				t.Fatalf("responseIndicatesNoChanges(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestApplyUnifiedDiffScenarios(t *testing.T) {
+	tests := []struct {
+		name          string
+		gitScript     string
+		patchScript   string
+		applyFallback bool
+		wantErr       bool
+		wantContains  string
+	}{
+		{
+			name:          "git success",
+			gitScript:     "#!/bin/sh\ncat >/dev/null\nexit 0\n",
+			patchScript:   "#!/bin/sh\nexit 1\n",
+			applyFallback: false,
+			wantErr:       false,
+		},
+		{
+			name:          "git fails without fallback",
+			gitScript:     "#!/bin/sh\necho git-fail 1>&2\nexit 1\n",
+			patchScript:   "#!/bin/sh\nexit 1\n",
+			applyFallback: false,
+			wantErr:       true,
+			wantContains:  "failed to apply diff with git",
+		},
+		{
+			name:          "fallback to patch",
+			gitScript:     "#!/bin/sh\necho git-fail 1>&2\nexit 1\n",
+			patchScript:   "#!/bin/sh\ncat >/dev/null\nexit 0\n",
+			applyFallback: true,
+			wantErr:       false,
+		},
+		{
+			name:          "git and patch fail",
+			gitScript:     "#!/bin/sh\necho git-fail 1>&2\nexit 1\n",
+			patchScript:   "#!/bin/sh\necho patch-fail 1>&2\nexit 1\n",
+			applyFallback: true,
+			wantErr:       true,
+			wantContains:  "failed to apply diff with git or patch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeFakeTool(t, binDir, "git", tt.gitScript)
+			writeFakeTool(t, binDir, "patch", tt.patchScript)
+			pathEnv := binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+			t.Setenv("PATH", pathEnv)
+
+			diff := strings.Join([]string{
+				"diff --git a/a.txt b/a.txt",
+				"--- a/a.txt",
+				"+++ b/a.txt",
+				"@@ -1 +1 @@",
+				"-old",
+				"+new",
+				"",
+			}, "\n")
+			err := applyUnifiedDiff(
+				context.Background(), t.TempDir(), diff, tt.applyFallback,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("applyUnifiedDiff() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestApplyResponseDiffAppliesUnifiedDiff(t *testing.T) {
+	binDir := t.TempDir()
+	writeFakeTool(t, binDir, "git", "#!/bin/sh\ncat >/dev/null\nexit 0\n")
+	writeFakeTool(t, binDir, "patch", "#!/bin/sh\nexit 1\n")
+	pathEnv := binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", pathEnv)
+
+	response := strings.Join([]string{
+		"```diff",
+		"diff --git a/a.txt b/a.txt",
+		"--- a/a.txt",
+		"+++ b/a.txt",
+		"@@ -1 +1 @@",
+		"-old",
+		"+new",
+		"```",
+	}, "\n")
+
+	ctx := tools.InitEdits(context.Background())
+	if err := applyResponseDiff(ctx, response, t.TempDir(), false); err != nil {
+		t.Fatalf("applyResponseDiff() error = %v", err)
+	}
+}
+
+func writeFakeTool(t *testing.T, dir, name, script string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile %s: %v", name, err)
 	}
 }

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -1,8 +1,14 @@
 package runner
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
 )
 
 func TestNormalizeProvider(t *testing.T) {
@@ -126,5 +132,54 @@ func TestBuildAnthropicLLM(t *testing.T) {
 	model, err := buildAnthropicLLM(opts, "claude-3")
 	if err != nil || model == nil {
 		t.Fatalf("buildAnthropicLLM() error = %v", err)
+	}
+}
+
+func TestCallLangChainLLMWithOllama(t *testing.T) {
+	t.Parallel()
+	reqErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			reqErr <- fmt.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			reqErr <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+		reqErr <- nil
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model":"mistral",
+			"message":{"role":"assistant","content":"hello"},
+			"done":true,
+			"prompt_eval_count":1,
+			"eval_count":1
+		}`))
+	}))
+	defer server.Close()
+
+	opts := &RunOptions{Provider: "ollama", BaseURL: server.URL, MaxIterations: 1}
+	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
+	response, err := callLangChainLLM(
+		context.Background(),
+		opts,
+		"ollama",
+		"mistral",
+		bundle.System,
+		bundle,
+		0.4,
+		0,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("callLangChainLLM() error = %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	if response != "hello" {
+		t.Fatalf("response = %q, want hello", response)
 	}
 }

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/responses"
 )
 
 func TestNormalizeProvider(t *testing.T) {
@@ -184,5 +188,143 @@ func TestCallLangChainLLMWithOllama(t *testing.T) {
 	}
 	if response != "hello" {
 		t.Fatalf("response = %q, want hello", response)
+	}
+}
+
+func TestCallResponsesAPIAdjustsMaxTokens(t *testing.T) {
+	maxTokensCh := make(chan int, 1)
+	reqErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			reqErr <- fmt.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			reqErr <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+		if raw, ok := payload["max_output_tokens"]; ok {
+			if val, ok := raw.(float64); ok {
+				maxTokensCh <- int(val)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		reqErr <- json.NewEncoder(w).Encode(map[string]any{
+			"id":                  "resp-1",
+			"object":              "response",
+			"created_at":          0,
+			"model":               "gpt-5",
+			"parallel_tool_calls": false,
+			"temperature":         0,
+			"tool_choice":         "auto",
+			"tools":               []any{},
+			"top_p":               1,
+			"error": map[string]any{
+				"code":    "server_error",
+				"message": "",
+			},
+			"incomplete_details": map[string]any{"reason": ""},
+			"instructions":       "system",
+			"metadata":           map[string]any{},
+			"output": []map[string]any{
+				{
+					"id":     "msg-1",
+					"type":   "message",
+					"role":   "assistant",
+					"status": "completed",
+					"content": []map[string]any{
+						{"type": "output_text", "text": "hello"},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	opts := &RunOptions{APIKey: "key", BaseURL: server.URL, MaxIterations: 1}
+	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
+	response, err := callResponsesAPI(
+		context.Background(),
+		opts,
+		"gpt-5",
+		"system",
+		bundle,
+		0.4,
+		100,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("callResponsesAPI() error = %v", err)
+	}
+	if response != "hello" {
+		t.Fatalf("response = %q, want hello", response)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	select {
+	case got := <-maxTokensCh:
+		if got != responses.DefaultMaxOutputTokens {
+			t.Fatalf(
+				"max_output_tokens = %d, want %d",
+				got,
+				responses.DefaultMaxOutputTokens,
+			)
+		}
+	default:
+		t.Fatalf("expected max_output_tokens in request")
+	}
+}
+
+func TestBuildTaskConfigCallModel(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	agentsDir := t.TempDir()
+	agentName := "child"
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := strings.Join([]string{
+		"name: child",
+		"version: '1.0'",
+		"entrypoint: system.md",
+		"wrapper: agent.md",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("system"), 0o644); err != nil {
+		t.Fatalf("WriteFile system: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrapper"), 0o644); err != nil {
+		t.Fatalf("WriteFile wrapper: %v", err)
+	}
+
+	opts := &RunOptions{
+		AgentsDir:     agentsDir,
+		WorkingDir:    t.TempDir(),
+		Provider:      "openai-responses",
+		Model:         "gpt-5",
+		MaxIterations: 1,
+	}
+	cfg := buildTaskConfig(opts)
+	if cfg == nil {
+		t.Fatalf("expected task config")
+	}
+	_, err := cfg.CallModel(
+		context.Background(),
+		agentsDir,
+		agentName,
+		"prompt",
+		opts.WorkingDir,
+		"",
+	)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "API key required") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -89,16 +89,19 @@ func TestBuildLLMVariants(t *testing.T) {
 		name     string
 		provider string
 		model    string
+		opts     *RunOptions
 		wantType string
 		wantErr  bool
 	}{
-		{"ollama", "ollama", "mistral", "*ollama.LLM", false},
-		{"unknown provider", "unknown", "model", "", true},
+		{"ollama", "ollama", "mistral", &RunOptions{}, "*ollama.LLM", false},
+		{"openai", "openai", "gpt-4o", &RunOptions{APIKey: "token"}, "*openai.LLM", false},
+		{"anthropic", "anthropic", "claude-3", &RunOptions{APIKey: "token"}, "*anthropic.LLM", false},
+		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			model, err := buildLLM(&RunOptions{}, tt.provider, tt.model)
+			model, err := buildLLM(tt.opts, tt.provider, tt.model)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("buildLLM() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -354,3 +354,16 @@ func TestBuildTaskConfig(t *testing.T) {
 		t.Fatalf("expected CallModel function")
 	}
 }
+
+func TestExecuteRunDryRun(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{}
+	opts := &RunOptions{
+		Agent:     "go-tests",
+		AgentsDir: filepath.Join("..", "agents"),
+		DryRun:    true,
+	}
+	if err := ExecuteRun(cmd, []string{"hello"}, opts); err != nil {
+		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -423,5 +424,181 @@ func TestRepeatTracker(t *testing.T) {
 	}
 	if !tracker.Exceeded() {
 		t.Fatalf("expected repeat limit exceeded")
+	}
+}
+
+func TestReadToolErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	read := readTool(dir)
+	tests := []struct {
+		name         string
+		payload      string
+		wantErr      bool
+		wantContains string
+	}{
+		{"invalid json", "{", true, "invalid args"},
+		{"empty path", `{"path":""}`, true, "path is required"},
+		{"outside path", `{"path":"../outside.txt"}`, true, "outside working directory"},
+		{"missing file", `{"path":"missing.txt"}`, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := read(context.Background(), []byte(tt.payload))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readTool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestWriteToolErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	write := writeTool(dir)
+	tests := []struct {
+		name         string
+		payload      string
+		wantErr      bool
+		wantContains string
+	}{
+		{"invalid json", "{", true, "invalid args"},
+		{"empty path", `{"path":"","content":"x"}`, true, "path is required"},
+		{"outside path", `{"path":"../outside.txt","content":"x"}`, true, "outside working directory"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := write(context.Background(), []byte(tt.payload))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("writeTool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestEditToolErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	edit := editTool(dir)
+	_, _ = writeTool(dir)(context.Background(), []byte(`{"path":"note.txt","content":"hello"}`))
+	tests := []struct {
+		name         string
+		payload      string
+		wantErr      bool
+		wantContains string
+	}{
+		{"invalid json", "{", true, "invalid args"},
+		{"missing file", `{"path":"missing.txt","old":"a","new":"b"}`, true, ""},
+		{"text not found", `{"path":"note.txt","old":"absent","new":"x"}`, true, "text not found"},
+		{"outside path", `{"path":"../outside.txt","old":"a","new":"b"}`, true, "outside working directory"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := edit(context.Background(), []byte(tt.payload))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("editTool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestEditToolSingleReplacement(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	write := writeTool(dir)
+	edit := editTool(dir)
+	_, err := write(context.Background(), []byte(`{"path":"note.txt","content":"hello"}`))
+	if err != nil {
+		t.Fatalf("writeTool: %v", err)
+	}
+
+	out, err := edit(context.Background(), []byte(`{"path":"note.txt","old":"l","new":"L"}`))
+	if err != nil {
+		t.Fatalf("editTool: %v", err)
+	}
+	if !strings.Contains(out, "1 replacement") {
+		t.Fatalf("output = %q, want single replacement", out)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "note.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "heLlo" {
+		t.Fatalf("content = %q, want heLlo", string(data))
+	}
+}
+
+func TestGlobToolErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	glob := globTool(dir)
+	tests := []struct {
+		name         string
+		payload      string
+		wantErr      bool
+		wantContains string
+		wantOutput   string
+	}{
+		{"invalid json", "{", true, "invalid args", ""},
+		{"empty pattern", `{"pattern":""}`, true, "pattern is required", ""},
+		{"no matches", `{"pattern":"**/*.txt"}`, false, "", "no matches"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := glob(context.Background(), []byte(tt.payload))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("globTool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+			if tt.wantOutput != "" && out != tt.wantOutput {
+				t.Fatalf("output = %q, want %q", out, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestGrepToolErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	write := writeTool(dir)
+	_, _ = write(context.Background(), []byte(`{"path":"note.txt","content":"alpha"}`))
+	grep := grepTool(dir)
+	tests := []struct {
+		name         string
+		payload      string
+		wantErr      bool
+		wantContains string
+		wantOutput   string
+	}{
+		{"invalid json", "{", true, "invalid args", ""},
+		{"empty pattern", `{"pattern":""}`, true, "pattern is required", ""},
+		{"invalid regex", `{"pattern":"["}`, true, "invalid regex", ""},
+		{"outside path", `{"pattern":"alpha","path":"../outside"}`, true, "outside working directory", ""},
+		{"no matches", `{"pattern":"beta","path":"."}`, false, "", "no matches"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := grep(context.Background(), []byte(tt.payload))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("grepTool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantContains != "" && err != nil && !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+			if tt.wantOutput != "" && out != tt.wantOutput {
+				t.Fatalf("output = %q, want %q", out, tt.wantOutput)
+			}
+		})
 	}
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -189,47 +189,61 @@ func TestInitEditsAndTracking(t *testing.T) {
 
 func TestBuildHandlers(t *testing.T) {
 	t.Parallel()
-
-	t.Run("without TaskConfig", func(t *testing.T) {
-		t.Parallel()
-		handlers, defs := BuildHandlers(t.TempDir(), nil)
-		if _, ok := handlers["Task"]; ok {
-			t.Fatalf("expected no Task handler without TaskConfig")
-		}
-		if _, ok := handlers["Read"]; !ok {
-			t.Fatalf("expected Read handler")
-		}
-		if len(defs) != 6 {
-			t.Fatalf("expected 6 tool defs without Task, got %d", len(defs))
-		}
-	})
-
-	t.Run("with TaskConfig", func(t *testing.T) {
-		t.Parallel()
-		cfg := &TaskConfig{
-			AgentsDir:  "agents",
-			WorkingDir: t.TempDir(),
-			CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
-				return "", nil
-			},
-		}
-		handlers, defs := BuildHandlers(cfg.WorkingDir, cfg)
-		if _, ok := handlers["Task"]; !ok {
-			t.Fatalf("expected Task handler")
-		}
-		if len(defs) != 7 {
-			t.Fatalf("expected 7 tool defs with Task, got %d", len(defs))
-		}
-		names := make([]string, len(defs))
-		for i, d := range defs {
-			names[i] = d.Function.Name
-		}
-		for i := 1; i < len(names); i++ {
-			if names[i] < names[i-1] {
-				t.Fatalf("expected sorted tool defs, got %v", names)
+	tests := []struct {
+		name     string
+		withTask bool
+		wantDefs int
+	}{
+		{"without TaskConfig", false, 6},
+		{"with TaskConfig", true, 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			var cfg *TaskConfig
+			if tt.withTask {
+				cfg = &TaskConfig{
+					AgentsDir:  "agents",
+					WorkingDir: dir,
+					CallModel: func(
+						_ context.Context,
+						_, _, _, _, _ string,
+					) (string, error) {
+						return "", nil
+					},
+				}
 			}
-		}
-	})
+			handlers, defs := BuildHandlers(dir, cfg)
+			if _, ok := handlers["Task"]; ok != tt.withTask {
+				t.Fatalf(
+					"Task handler present = %v, want %v",
+					ok, tt.withTask,
+				)
+			}
+			if _, ok := handlers["Read"]; !ok {
+				t.Fatalf("expected Read handler")
+			}
+			if len(defs) != tt.wantDefs {
+				t.Fatalf(
+					"tool defs = %d, want %d",
+					len(defs), tt.wantDefs,
+				)
+			}
+			names := make([]string, len(defs))
+			for i, d := range defs {
+				names[i] = d.Function.Name
+			}
+			for i := 1; i < len(names); i++ {
+				if names[i] < names[i-1] {
+					t.Fatalf(
+						"expected sorted tool defs, got %v",
+						names,
+					)
+				}
+			}
+		})
+	}
 }
 
 func TestGlobMatcher(t *testing.T) {
@@ -354,18 +368,47 @@ func TestGrepSearchPathSingleFile(t *testing.T) {
 }
 
 func TestBashTool(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	bash := bashTool(dir)
-	out, err := bash(context.Background(), []byte(`{"command":"printf 'hi'"}`))
-	if err != nil {
-		t.Fatalf("bashTool: %v", err)
+	tests := []struct {
+		name    string
+		payload string
+		wantErr bool
+		wantOut string
+	}{
+		{
+			"valid command",
+			`{"command":"printf 'hi'"}`,
+			false,
+			"hi",
+		},
+		{
+			"empty command",
+			`{"command":""}`,
+			true,
+			"",
+		},
 	}
-	if !strings.Contains(out, "hi") {
-		t.Fatalf("unexpected bash output: %q", out)
-	}
-
-	if _, err := bash(context.Background(), []byte(`{"command":""}`)); err == nil {
-		t.Fatalf("expected error for empty command")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			bash := bashTool(dir)
+			out, err := bash(
+				context.Background(), []byte(tt.payload),
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf(
+					"bashTool() error = %v, wantErr %v",
+					err, tt.wantErr,
+				)
+			}
+			if !tt.wantErr && !strings.Contains(out, tt.wantOut) {
+				t.Fatalf(
+					"output = %q, want containing %q",
+					out, tt.wantOut,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION

**Key Changes:**

- Enhanced test coverage across multiple packages, including new and edge-case tests
- Updated CLI commands to use `cmd.OutOrStdout()` for output, improving testability and redirection
- Improved logging and output methods to support custom writers, aiding test isolation
- Added logic in responses to gracefully resolve pending function calls when iteration budget is exhausted

**Added:**

- New `cmd/squad/root_test.go` to test main command execution with version flag and environment setup
- Tests for XDG config and cache home logic in `config/xdg_test.go`
- Tests for loading missing config files and error handling in `config/config_test.go`
- Multiple tests in `ollama/ollama_test.go` for HTTP error handling, JSON decoding, and API request validation
- Tests in `responses/responses_test.go` for scenarios like no tool calls, pending calls at iteration exhaustion, follow-up calls, and error branches
- Additional edge-case and error-branch tests in `runner/apply_test.go`, `runner/model_test.go`, `runner/run_test.go`, and `tools/tools_test.go` to ensure correct handling of various tool and LLM configurations

**Changed:**

- Updated CLI output in `cmd/squad/config.go` and `cmd/squad/version.go` to use `cmd.OutOrStdout()` instead of direct `fmt.Println`, allowing for easier test output capture
- Refactored `cmd/squad/config_test.go` and `cmd/squad/openai_responses_test.go` to use output buffers instead of capturing `os.Stdout`
- Improved test structure in `cmd/squad/run_test.go` and `tools/tools_test.go` for better parallelization and coverage of edge cases
- Modified `logging.CustomLogger` to use a configurable `OutputWriter` for output and JSON logging, with corresponding updates in `logging/logging_test.go`
- Enhanced responses package to resolve pending function calls with dummy outputs when the iteration budget is exhausted, ensuring clean state for future chaining

**Removed:**

- Eliminated the `captureStdout` helper function from `cmd/squad/config_test.go`, replaced by output buffer pattern for improved reliability and test clarity