### PR TITLE
test: add comprehensive error handling and edge case tests across core packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,77 @@ Notes:
 - Ollama does not require an API key; if your client requires one, use any non-empty string (e.g., `--api-key ollama`).
 - For OpenAI-compatible endpoints, `max_tokens` is used for Ollama; OpenAI defaults to `max_completion_tokens` unless you set `--openai-compat-max-tokens`.
 
+## Taskfile Tasks
+
+The project uses [Task](https://taskfile.dev) for orchestration. All tasks
+accept `MODEL`, `PROVIDER`, `API_KEY`, and other overrides as environment
+variables.
+
+### Go Tests Agent
+
+Measure coverage, write tests, and iterate to a target percentage:
+
+```bash
+task run:go-tests \
+  MODEL=gpt-5.2-codex \
+  PROVIDER=openai \
+  API_KEY="$OPENAI_API_KEY" \
+  COVERAGE_TARGET=90
+```
+
+Analyze coverage gaps without writing tests (readonly):
+
+```bash
+task run:go-tests-analyze \
+  MODEL=gpt-5.2-codex \
+  PROVIDER=openai \
+  API_KEY="$OPENAI_API_KEY" \
+  COVERAGE_TARGET=90
+```
+
+### Go Cobra Agent
+
+Find and fix Cobra/Viper best-practice violations:
+
+```bash
+task run:go-cobra \
+  MODEL=gpt-5.2-codex \
+  PROVIDER=openai \
+  API_KEY="$OPENAI_API_KEY"
+```
+
+Analyze violations without applying fixes (readonly):
+
+```bash
+task run:go-cobra-analyze \
+  MODEL=gpt-5.2-codex \
+  PROVIDER=openai \
+  API_KEY="$OPENAI_API_KEY"
+```
+
+### Generic Agent Run
+
+Run any agent with a custom prompt:
+
+```bash
+task run \
+  AGENT=go-cobra \
+  PROMPT="add shell completions for all flags" \
+  MODEL=qwen3-coder:30b \
+  PROVIDER=ollama
+```
+
+### Common Overrides
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROVIDER` | `ollama` | LLM provider (`openai`, `ollama`, `anthropic`) |
+| `MODEL` | `qwen3-coder:30b` | Model name |
+| `API_KEY` | `ollama` | API key for the provider |
+| `BASE_URL` | *(provider default)* | Custom API endpoint |
+| `WORKING_DIR` | `.` | Target codebase directory |
+| `COVERAGE_TARGET` | `75` | Target coverage % (go-tests only) |
+
 ## Configuration
 
 Initialize a config file:

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -65,3 +65,108 @@ modes:
 		t.Fatalf("expected combined output to include user prompt")
 	}
 }
+
+func TestBuildBundleErrors(t *testing.T) {
+	baseManifest := `name: Demo
+version: v1
+entrypoint: system.txt
+wrapper: wrapper.txt
+references:
+  - ref.md
+`
+
+	setup := func(t *testing.T) (string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		agentDir := filepath.Join(dir, "demo")
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(baseManifest), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "system.txt"), []byte("system"), 0o644); err != nil {
+			t.Fatalf("write system: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "wrapper.txt"), []byte("wrapper"), 0o644); err != nil {
+			t.Fatalf("write wrapper: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "ref.md"), []byte("reference"), 0o644); err != nil {
+			t.Fatalf("write ref: %v", err)
+		}
+		return dir, agentDir
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(t *testing.T, dir, agentDir string)
+		wantPart string
+	}{
+		{
+			name: "missing manifest",
+			mutate: func(t *testing.T, _, agentDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(agentDir, "agent.yaml")); err != nil {
+					t.Fatalf("remove manifest: %v", err)
+				}
+			},
+			wantPart: "failed to read agent manifest",
+		},
+		{
+			name: "invalid manifest",
+			mutate: func(t *testing.T, _, agentDir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte("bad: ["), 0o644); err != nil {
+					t.Fatalf("write manifest: %v", err)
+				}
+			},
+			wantPart: "failed to parse agent manifest",
+		},
+		{
+			name: "missing system prompt",
+			mutate: func(t *testing.T, _, agentDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(agentDir, "system.txt")); err != nil {
+					t.Fatalf("remove system: %v", err)
+				}
+			},
+			wantPart: "failed to read system prompt",
+		},
+		{
+			name: "missing wrapper",
+			mutate: func(t *testing.T, _, agentDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(agentDir, "wrapper.txt")); err != nil {
+					t.Fatalf("remove wrapper: %v", err)
+				}
+			},
+			wantPart: "failed to read agent wrapper",
+		},
+		{
+			name: "missing reference",
+			mutate: func(t *testing.T, _, agentDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(agentDir, "ref.md")); err != nil {
+					t.Fatalf("remove ref: %v", err)
+				}
+			},
+			wantPart: "failed to read reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, agentDir := setup(t)
+			if tt.mutate != nil {
+				tt.mutate(t, dir, agentDir)
+			}
+			_, err := BuildBundle(dir, "demo", "prompt", "/work", "")
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantPart) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.wantPart)
+			}
+		})
+	}
+}

--- a/agents/go-tests/system.md
+++ b/agents/go-tests/system.md
@@ -52,7 +52,17 @@ These override everything else.
     Go version. If Go 1.22+, range loop variables are per-iteration and
     `tt := tt` is dead code — do not include it. If below 1.22, you MUST
     add `tt := tt` before `t.Run` in parallel table-driven tests.
-12. **Budget awareness.** You have a limited iteration budget. Prefer Write
+12. **Never close over the outer `t` in table-driven setup functions.** When
+    a test table has a `setup` or `mutate` callback, it MUST accept `t
+    *testing.T` as a parameter and use that — not the `t` from the outer
+    test function. Closing over the outer `t` breaks if subtests run in
+    parallel and makes failures report against the wrong subtest.
+13. **Test helper types must be goroutine-safe.** If you create a struct
+    that implements `io.Writer`, `io.Reader`, or similar interfaces for
+    use in tests, use `sync/atomic` or `sync.Mutex` for any mutable
+    fields (counters, flags). Tests may run concurrently even if not
+    explicitly parallel today.
+14. **Budget awareness.** You have a limited iteration budget. Prefer Write
     over Edit when creating new test files — one Write call replaces dozens
     of incremental Edits. Batch Read calls for related files. Track your
     iteration count mentally. Cap yourself at 20 iterations per package —

--- a/cmd/squad/config_test.go
+++ b/cmd/squad/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cowdogmoo/squad/config"
@@ -241,5 +242,203 @@ func TestVersionCommand(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, fmt.Sprintf("squad version %s", version)) {
 		t.Fatalf("unexpected version output: %s", out)
+	}
+}
+
+func TestRunConfigInitForceOverwrite(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("force", true, "")
+	cmd.SetContext(withConfig(context.Background(), config.Defaults()))
+
+	configPath, err := config.ConfigFile("config.yaml")
+	if err != nil {
+		t.Fatalf("ConfigFile: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := runConfigInit(cmd, nil); err != nil {
+		t.Fatalf("runConfigInit() error = %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.TrimSpace(string(data)) == "existing" {
+		t.Fatalf("expected config file to be overwritten")
+	}
+}
+
+func TestRunConfigInitMissingConfig(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("force", false, "")
+	cmd.SetContext(context.Background())
+
+	if err := runConfigInit(cmd, nil); err == nil {
+		t.Fatalf("expected error for missing config")
+	}
+}
+
+func TestRunConfigInitMissingForceFlag(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(withConfig(context.Background(), config.Defaults()))
+
+	configPath, err := config.ConfigFile("config.yaml")
+	if err != nil {
+		t.Fatalf("ConfigFile: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := runConfigInit(cmd, nil); err == nil {
+		t.Fatalf("expected error for missing force flag")
+	}
+}
+
+func TestRunConfigShowMissingConfig(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runConfigShow(cmd, nil); err == nil {
+		t.Fatalf("expected error for missing config")
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write(p []byte) (int, error) {
+	return 0, fmt.Errorf("write failed")
+}
+
+type failAfterWriter struct {
+	failAfter int32
+	writes    atomic.Int32
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if w.writes.Add(1) > w.failAfter {
+		return 0, fmt.Errorf("write failed")
+	}
+	return len(p), nil
+}
+
+func TestRunConfigShowWriteError(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(errWriter{})
+	cmd.SetContext(withConfig(context.Background(), config.Defaults()))
+
+	if err := runConfigShow(cmd, nil); err == nil {
+		t.Fatalf("expected write error")
+	}
+}
+
+func TestRunConfigShowWriteFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		failAfter int32
+	}{
+		{"fail after header", 1},
+		{"fail after description", 2},
+		{"fail after spacer", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &failAfterWriter{failAfter: tt.failAfter}
+			cmd := &cobra.Command{}
+			cmd.SetOut(writer)
+			cmd.SetContext(withConfig(context.Background(), config.Defaults()))
+			if err := runConfigShow(cmd, nil); err == nil {
+				t.Fatalf("expected write error")
+			}
+		})
+	}
+}
+
+func TestRunConfigPathWriteError(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(errWriter{})
+
+	if err := runConfigPath(cmd, nil); err == nil {
+		t.Fatalf("expected write error")
+	}
+}
+
+func TestRunConfigSetErrors(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+
+	cfg := config.Defaults()
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	configPath, err := config.ConfigFile("config.yaml")
+	if err != nil {
+		t.Fatalf("ConfigFile: %v", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name  string
+		args  []string
+		setup func(t *testing.T)
+	}{
+		{
+			name: "missing file",
+			args: []string{"model.max_tokens", "42"},
+			setup: func(t *testing.T) {
+				t.Helper()
+				_ = os.Remove(configPath)
+			},
+		},
+		{
+			name: "invalid value",
+			args: []string{"model.max_tokens", ":["},
+			setup: func(t *testing.T) {
+				t.Helper()
+				if err := os.WriteFile(configPath, data, 0o644); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+			err := runConfigSet(cmd, tt.args)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestRunConfigGetMissingConfig(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runConfigGet(cmd, []string{"model.max_tokens"}); err == nil {
+		t.Fatalf("expected error for missing config")
 	}
 }

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cowdogmoo/squad/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // setupTestAgent creates a temporary agent directory with the given manifest
@@ -398,6 +399,14 @@ func TestBindRunFlags(t *testing.T) {
 	}
 }
 
+func TestBindRunFlagsMissingFlag(t *testing.T) {
+	cmd := &cobra.Command{}
+	v := viper.New()
+	if err := bindRunFlags(cmd, v); err == nil {
+		t.Fatalf("expected bindRunFlags error")
+	}
+}
+
 func TestHasPipedInput(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -520,6 +529,154 @@ func TestFindRunCmd(t *testing.T) {
 			cmd := findRunCmd(tt.root)
 			if (cmd == nil) != tt.wantNil {
 				t.Fatalf("findRunCmd() nil = %v, want %v", cmd == nil, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestNewRunCmdArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		input   io.Reader
+		wantErr bool
+	}{
+		{
+			name:    "args provided",
+			args:    []string{"prompt"},
+			input:   bytes.NewBuffer(nil),
+			wantErr: false,
+		},
+		{
+			name:    "piped input",
+			args:    nil,
+			input:   bytes.NewBufferString("hello"),
+			wantErr: false,
+		},
+		{
+			name:    "missing prompt",
+			args:    nil,
+			input:   bytes.NewBuffer(nil),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRunCmd()
+			cmd.SetIn(tt.input)
+			err := cmd.Args(cmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Args() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitConfigWithConfigPath(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+
+	cfg := config.Defaults()
+	cfg.Log.Level = "debug"
+	path := filepath.Join(baseDir, "config.yaml")
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	root := NewRootCmd()
+	root.SetContext(context.Background())
+	if err := root.PersistentFlags().Set("config", path); err != nil {
+		t.Fatalf("Set config: %v", err)
+	}
+
+	if err := initConfig(root, nil); err != nil {
+		t.Fatalf("initConfig() error = %v", err)
+	}
+	loaded := configFromContext(root)
+	if loaded == nil {
+		t.Fatalf("expected config in context")
+	}
+	if loaded.Log.Level != "debug" {
+		t.Fatalf("Log.Level = %q, want %q", loaded.Log.Level, "debug")
+	}
+}
+
+func TestInitConfigMissingConfigFile(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+
+	missingPath := filepath.Join(baseDir, "missing.yaml")
+	root := NewRootCmd()
+	root.SetContext(context.Background())
+	if err := root.PersistentFlags().Set("config", missingPath); err != nil {
+		t.Fatalf("Set config: %v", err)
+	}
+
+	if err := initConfig(root, nil); err != nil {
+		t.Fatalf("initConfig() error = %v", err)
+	}
+	loaded := configFromContext(root)
+	if loaded == nil {
+		t.Fatalf("expected config in context")
+	}
+	defaults := config.Defaults()
+	if loaded.Log.Level != defaults.Log.Level {
+		t.Fatalf("Log.Level = %q, want %q", loaded.Log.Level, defaults.Log.Level)
+	}
+}
+
+func TestInitConfigMissingRunCommand(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+
+	root := NewRootCmd()
+	root.SetContext(context.Background())
+	if runCmd := findRunCmd(root); runCmd != nil {
+		root.RemoveCommand(runCmd)
+	}
+
+	if err := initConfig(root, nil); err == nil {
+		t.Fatalf("expected error for missing run command")
+	}
+}
+
+func TestConfigFromContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     *cobra.Command
+		wantNil bool
+	}{
+		{
+			name: "missing config",
+			cmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.SetContext(context.Background())
+				return cmd
+			}(),
+			wantNil: true,
+		},
+		{
+			name: "config present",
+			cmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.SetContext(withConfig(context.Background(), config.Defaults()))
+				return cmd
+			}(),
+			wantNil: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := configFromContext(tt.cmd)
+			if (cfg == nil) != tt.wantNil {
+				t.Fatalf("configFromContext() nil = %v, want %v", cfg == nil, tt.wantNil)
 			}
 		})
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -3,7 +3,9 @@ package logging
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 )
@@ -189,5 +191,90 @@ func TestFallbackLogging(t *testing.T) {
 	InfoContext(context.TODO(), "fallback")
 	if !strings.Contains(buf.String(), "fallback") {
 		t.Fatalf("expected fallback output")
+	}
+}
+
+func TestNewCustomLoggerAndOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewCustomLogger(slog.LevelWarn)
+	if logger.LogLevel != slog.LevelWarn {
+		t.Fatalf("LogLevel = %v, want %v", logger.LogLevel, slog.LevelWarn)
+	}
+	if logger.OutputType != PlainOutput {
+		t.Fatalf("OutputType = %v, want %v", logger.OutputType, PlainOutput)
+	}
+	if logger.ConsoleWriter == nil {
+		t.Fatalf("expected ConsoleWriter to be set")
+	}
+
+	logger.OutputWriter = buf
+	logger.Output("hello")
+	if !strings.Contains(buf.String(), "hello") {
+		t.Fatalf("expected output to contain hello")
+	}
+}
+
+func TestCustomLoggerFormatMessageColor(t *testing.T) {
+	logger := &CustomLogger{OutputType: ColorOutput}
+	colored := logger.formatMessage(InfoLevel, "hi %s", "squad")
+	if !strings.Contains(colored, "hi squad") {
+		t.Fatalf("expected colored output to contain message")
+	}
+	logger.OutputType = PlainOutput
+	plain := logger.formatMessage(InfoLevel, "hi")
+	if plain != "hi" {
+		t.Fatalf("plain output = %q, want %q", plain, "hi")
+	}
+}
+
+func TestCustomLoggerOutputJSONError(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	logger := &CustomLogger{
+		OutputType:    JSONOutput,
+		OutputWriter:  &out,
+		ConsoleWriter: &errOut,
+		LogLevel:      slog.LevelInfo,
+	}
+	logger.Output(make(chan int))
+	if !strings.Contains(errOut.String(), "Failed to encode JSON output") {
+		t.Fatalf("expected json error output, got %q", errOut.String())
+	}
+}
+
+func TestCustomLoggerErrorFormatsError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := &CustomLogger{ConsoleWriter: buf, LogLevel: slog.LevelDebug}
+	logger.Error(fmt.Errorf("boom"), "extra")
+	logger.Error(123)
+	out := buf.String()
+	if !strings.Contains(out, "boom extra") {
+		t.Fatalf("expected formatted error, got %q", out)
+	}
+	if !strings.Contains(out, "123") {
+		t.Fatalf("expected numeric error, got %q", out)
+	}
+}
+
+func TestGlobalOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	loggerMu.Lock()
+	logger = &CustomLogger{
+		OutputType:    PlainOutput,
+		OutputWriter:  buf,
+		ConsoleWriter: &bytes.Buffer{},
+	}
+	loggerMu.Unlock()
+
+	Output("global")
+	if !strings.Contains(buf.String(), "global") {
+		t.Fatalf("expected global output to be written")
+	}
+}
+
+func TestOutputWriterDefaultsToStdout(t *testing.T) {
+	logger := &CustomLogger{}
+	if logger.outputWriter() != os.Stdout {
+		t.Fatalf("expected outputWriter to default to stdout")
 	}
 }

--- a/ollama/ollama_test.go
+++ b/ollama/ollama_test.go
@@ -199,6 +199,27 @@ func TestConvertResponse(t *testing.T) {
 			0,
 			3,
 		},
+		{
+			"tool call args marshal error",
+			chatResponse{
+				Message: &ollamaMessage{
+					Content: "hello",
+					ToolCalls: []ollamaToolCall{{
+						Function: ollamaFunctionCall{
+							Name: "Bad",
+							Arguments: map[string]any{
+								"bad": func() {},
+							},
+						},
+					}},
+				},
+				PromptEvalCount: 1,
+				EvalCount:       1,
+			},
+			"hello",
+			0,
+			2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -337,5 +358,25 @@ func TestGenerateContentErrors(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tt.wantErrMsg)
 			}
 		})
+	}
+}
+
+func TestCallUsesGenerateFromSinglePrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"mistral","message":{"role":"assistant","content":"hello"},"done":true}`))
+	}))
+	defer server.Close()
+
+	llm := New(server.URL, "mistral", 256)
+	resp, err := llm.Call(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if resp != "hello" {
+		t.Fatalf("response = %q, want %q", resp, "hello")
 	}
 }

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -665,6 +666,87 @@ func TestRequestFinal(t *testing.T) {
 			}
 			if !tt.wantErr && text != tt.wantText {
 				t.Fatalf("text = %q, want %q", text, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestRunWithToolsErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) *httptest.Server
+	}{
+		{
+			name: "initial request error",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte("boom"))
+				}))
+			},
+		},
+		{
+			name: "resolve pending error",
+			setup: func(t *testing.T) *httptest.Server {
+				callCount := int32(0)
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					count := atomic.AddInt32(&callCount, 1)
+					if count == 3 {
+						w.WriteHeader(http.StatusInternalServerError)
+						_, _ = w.Write([]byte("boom"))
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					payload := map[string]any{
+						"id":                  fmt.Sprintf("resp-%d", count),
+						"object":              "response",
+						"created_at":          0,
+						"model":               "gpt-4o",
+						"parallel_tool_calls": false,
+						"temperature":         0,
+						"tool_choice":         "auto",
+						"tools":               []any{},
+						"top_p":               1,
+						"error":               map[string]any{"code": "server_error", "message": ""},
+						"incomplete_details":  map[string]any{"reason": ""},
+						"instructions":        "system",
+						"metadata":            map[string]any{},
+						"output": []map[string]any{
+							{
+								"id":        "fc-1",
+								"type":      "function_call",
+								"call_id":   "call-1",
+								"name":      "Missing",
+								"arguments": "{}",
+							},
+						},
+					}
+					_ = json.NewEncoder(w).Encode(payload)
+				}))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setup(t)
+			defer server.Close()
+
+			_, err := RunWithTools(
+				context.Background(),
+				"key",
+				server.URL,
+				"gpt-4o",
+				"system",
+				"user",
+				t.TempDir(),
+				"",
+				0.2,
+				0,
+				1,
+				&tools.TaskConfig{},
+			)
+			if err == nil {
+				t.Fatalf("expected error")
 			}
 		})
 	}

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -191,7 +191,7 @@ func TestCallLangChainLLMWithOllama(t *testing.T) {
 	}
 }
 
-func TestCallResponsesAPIAdjustsMaxTokens(t *testing.T) {
+func TestCallResponsesAPIRoundTrip(t *testing.T) {
 	maxTokensCh := make(chan int, 1)
 	reqErr := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -326,5 +326,121 @@ func TestBuildTaskConfigCallModel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "API key required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallModelRoutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		setup    func(t *testing.T) *httptest.Server
+		want     string
+	}{
+		{
+			name:     "ollama",
+			provider: "ollama",
+			model:    "mistral",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/api/chat" {
+						t.Fatalf("unexpected path: %s", r.URL.Path)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"model":"mistral","message":{"role":"assistant","content":"ok"},"done":true}`))
+				}))
+			},
+			want: "ok",
+		},
+		{
+			name:     "responses api",
+			provider: "openai-responses",
+			model:    "gpt-4o",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/responses" {
+						t.Fatalf("unexpected path: %s", r.URL.Path)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"id":                  "resp-1",
+						"object":              "response",
+						"created_at":          0,
+						"model":               "gpt-4o",
+						"parallel_tool_calls": false,
+						"temperature":         0,
+						"tool_choice":         "auto",
+						"tools":               []any{},
+						"top_p":               1,
+						"error":               map[string]any{"code": "server_error", "message": ""},
+						"incomplete_details":  map[string]any{"reason": ""},
+						"instructions":        "system",
+						"metadata":            map[string]any{},
+						"output": []map[string]any{
+							{
+								"id":     "msg-1",
+								"type":   "message",
+								"role":   "assistant",
+								"status": "completed",
+								"content": []map[string]any{
+									{"type": "output_text", "text": "ok"},
+								},
+							},
+						},
+					})
+				}))
+			},
+			want: "ok",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setup(t)
+			defer server.Close()
+
+			opts := &RunOptions{APIKey: "key", BaseURL: server.URL, MaxIterations: 1}
+			if tt.provider == "ollama" {
+				opts.Provider = "ollama"
+				opts.APIKey = ""
+			}
+
+			bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
+			got, err := callModel(
+				context.Background(),
+				opts,
+				tt.provider,
+				tt.model,
+				bundle.System,
+				bundle,
+				0.4,
+				0,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("callModel() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("response = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCallLangChainLLMUnknownProvider(t *testing.T) {
+	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
+	opts := &RunOptions{Provider: "unknown"}
+	_, err := callLangChainLLM(
+		context.Background(),
+		opts,
+		"unknown",
+		"model",
+		bundle.System,
+		bundle,
+		0.2,
+		0,
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -365,5 +367,62 @@ func TestExecuteRunDryRun(t *testing.T) {
 	}
 	if err := ExecuteRun(cmd, []string{"hello"}, opts); err != nil {
 		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+}
+
+func TestExecuteRunPromptError(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(""))
+	opts := &RunOptions{Agent: "go-tests", AgentsDir: filepath.Join("..", "agents")}
+	if err := ExecuteRun(cmd, nil, opts); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestExecuteRunInvokeModelError(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	opts := &RunOptions{
+		Agent:           "go-tests",
+		AgentsDir:       filepath.Join("..", "agents"),
+		Provider:        "openai-responses",
+		Model:           "gpt-5",
+		MaxIterations:   1,
+		ConfigAvailable: true,
+	}
+	if err := ExecuteRun(cmd, []string{"hello"}, opts); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestExecuteRunSuccessOllama(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"mistral","message":{"role":"assistant","content":"ok"},"done":true}`))
+	}))
+	defer server.Close()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	opts := &RunOptions{
+		Agent:           "go-tests",
+		AgentsDir:       filepath.Join("..", "agents"),
+		Provider:        "ollama",
+		Model:           "mistral",
+		BaseURL:         server.URL,
+		MaxIterations:   1,
+		ConfigAvailable: true,
+	}
+	if err := ExecuteRun(cmd, []string{"hello"}, opts); err != nil {
+		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "ok") {
+		t.Fatalf("expected response output, got %q", buf.String())
 	}
 }

--- a/tools/toolloop_test.go
+++ b/tools/toolloop_test.go
@@ -15,6 +15,11 @@ type fakeLLM struct {
 	calls     int
 }
 
+type stubLLM struct {
+	resp *llms.ContentResponse
+	err  error
+}
+
 func (f *fakeLLM) GenerateContent(_ context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
 	if f.calls >= len(f.responses) {
 		return nil, errors.New("no response")
@@ -25,6 +30,14 @@ func (f *fakeLLM) GenerateContent(_ context.Context, _ []llms.MessageContent, _ 
 }
 
 func (f *fakeLLM) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+func (s *stubLLM) GenerateContent(_ context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	return s.resp, s.err
+}
+
+func (s *stubLLM) Call(context.Context, string, ...llms.CallOption) (string, error) {
 	return "", nil
 }
 
@@ -206,5 +219,54 @@ func TestFinishToolLoopFallback(t *testing.T) {
 	}
 	if out != "partial" {
 		t.Fatalf("output = %q, want %q", out, "partial")
+	}
+}
+
+func TestRunWithToolsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		llm  llms.Model
+	}{
+		{
+			name: "generate error",
+			llm:  &stubLLM{err: errors.New("boom")},
+		},
+		{
+			name: "nil response",
+			llm:  &stubLLM{resp: nil},
+		},
+		{
+			name: "empty choices",
+			llm:  &stubLLM{resp: &llms.ContentResponse{Choices: nil}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RunWithTools(context.Background(), tt.llm, "", "user", t.TempDir(), 1, nil)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestFinishToolLoopFinalContent(t *testing.T) {
+	llm := &stubLLM{
+		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final"}}},
+	}
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil)
+	if err != nil {
+		t.Fatalf("finishToolLoop() error = %v", err)
+	}
+	if out != "final" {
+		t.Fatalf("output = %q, want %q", out, "final")
+	}
+}
+
+func TestFinishToolLoopErrorNoContent(t *testing.T) {
+	llm := &stubLLM{err: errors.New("boom")}
+	_, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil)
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION

**Key Changes:**

- Added extensive negative and edge case tests for error handling in core commands, runners, agent bundling, and tool execution
- Improved coverage of config initialization, show, set, and get commands, including writer failures and config file absence
- Tested multiple model/provider routes and error cases in runner and agent logic
- Validated logging and output behavior, including color, JSON, and fallback modes

**Added:**

- Error handling and negative case tests for `runConfigInit`, `runConfigShow`, `runConfigPath`, `runConfigSet`, and `runConfigGet` in `cmd/squad/config_test.go`, covering missing configs, force flags, writer errors, and invalid values
- Tests for missing and error scenarios in `bindRunFlags`, `newRunCmd` argument validation, and `initConfig` with various config file states in `cmd/squad/run_test.go`
- Edge case tests for agent bundle building with missing/invalid manifest and references in `agent/bundle_test.go`
- Additional error and edge case tests for model routing and provider selection in `runner/model_test.go`, including unknown providers and response structure handling
- Tests for error propagation in tool loop execution and tool response handling, including LLM errors and response validation in `tools/toolloop_test.go`
- Expanded logging output and formatting tests, including color, JSON error handling, and output writer defaults in `logging/logging_test.go`
- Validation of error handling for Ollama tool call marshaling and prompt logic in `ollama/ollama_test.go`
- Negative tests for API error responses, tool call resolution, and request failures in `responses/responses_test.go`
- Tests for runner execution error conditions, such as prompt errors, model invocation failures, and Ollama integration in `runner/run_test.go`
- Goroutine-safety and closure best-practice documentation for test helpers and table-driven tests in `agents/go-tests/system.md`

**Changed:**

- Updated Go testing best-practices documentation in `agents/go-tests/system.md` to explicitly require goroutine-safe helper types and avoidance of closing over outer `t` in setup/mutate callbacks

**Removed:**

- No content removed