### PR TITLE
feat: add autonomous Taskfile review agent with fix and analyze modes

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,22 +10,24 @@ vars:
   PROVIDER: '{{.PROVIDER | default "ollama"}}'
   BASE_URL: '{{.BASE_URL | default ""}}'
   MODEL: '{{.MODEL | default "qwen3-coder:30b"}}'
-  API_KEY: '{{.API_KEY | default "ollama"}}'
+  API_KEY: '{{.API_KEY | default ""}}'
 
   # Agent configuration
   AGENT: '{{.AGENT | default "go-cobra"}}'
   WORKING_DIR: '{{.WORKING_DIR | default "."}}'
-  OUT: '{{.OUT | default "/tmp/squad-response.txt"}}'
+  OUT_DIR: '{{.OUT_DIR | default "/tmp"}}'
+  OUT: '{{.OUT | default (print .OUT_DIR "/squad-response.txt")}}'
 
   # Internal: conditionally include --base-url flag
   _BASE_URL_FLAG: '{{if .BASE_URL}}--base-url {{.BASE_URL}}{{end}}'
+  _API_KEY_FLAG: '{{if .API_KEY}}--api-key {{.API_KEY}}{{end}}'
 
 includes:
   go:
     taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/go/Taskfile.yaml"
     vars:
-      BINARY_NAME: squad
-      CMD_PATH: ./cmd/squad
+      BINARY_NAME: '{{.BINARY_NAME}}'
+      CMD_PATH: '{{.CMD_PATH}}'
   pre-commit:
     taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/pre-commit/Taskfile.yaml"
 
@@ -49,7 +51,7 @@ tasks:
           "{{.PROMPT}}" \
           --agent {{.AGENT}} \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
@@ -84,14 +86,14 @@ tasks:
         - Every file touched must appear in the output report" \
           --agent go-review \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out /tmp/squad-go-review.txt
-      - echo "Review output written to /tmp/squad-go-review.txt"
+          --out {{.OUT_DIR}}/squad-go-review.txt
+      - echo "Review output written to {{.OUT_DIR}}/squad-go-review.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -114,15 +116,15 @@ tasks:
         Do NOT write or modify any files." \
           --agent go-review --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-review-analysis.txt
-      - echo "Go review analysis written to /tmp/squad-go-review-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-review-analysis.txt
+      - echo "Go review analysis written to {{.OUT_DIR}}/squad-go-review-analysis.txt"
 
   run:go-tests:
     desc: "Run the go-tests agent to autonomously increase test coverage to a target"
@@ -154,15 +156,15 @@ tasks:
         One command, one iteration." \
           --agent go-tests \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
           --max-iterations 200 \
-          --out /tmp/squad-go-tests.txt
-      - echo "Test coverage output written to /tmp/squad-go-tests.txt"
+          --out {{.OUT_DIR}}/squad-go-tests.txt
+      - echo "Test coverage output written to {{.OUT_DIR}}/squad-go-tests.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -185,15 +187,15 @@ tasks:
         Do NOT write or modify any files." \
           --agent go-tests --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-tests-analysis.txt
-      - echo "Coverage analysis written to /tmp/squad-go-tests-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-tests-analysis.txt
+      - echo "Coverage analysis written to {{.OUT_DIR}}/squad-go-tests-analysis.txt"
 
   run:go-cobra:
     desc: "Run the go-cobra agent to autonomously fix Cobra/Viper best-practice violations"
@@ -218,14 +220,14 @@ tasks:
         - Every file touched must appear in the output report" \
           --agent go-cobra \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out /tmp/squad-go-cobra.txt
-      - echo "Cobra review output written to /tmp/squad-go-cobra.txt"
+          --out {{.OUT_DIR}}/squad-go-cobra.txt
+      - echo "Cobra review output written to {{.OUT_DIR}}/squad-go-cobra.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -248,15 +250,15 @@ tasks:
         Do NOT write or modify any files." \
           --agent go-cobra --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-cobra-analysis.txt
-      - echo "Cobra analysis written to /tmp/squad-go-cobra-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-cobra-analysis.txt
+      - echo "Cobra analysis written to {{.OUT_DIR}}/squad-go-cobra-analysis.txt"
 
   run:go-doc-comments:
     desc: "Run the go-doc-comments agent to autonomously add/improve Go doc comments"
@@ -291,14 +293,14 @@ tasks:
         - Every file touched must appear in the output report" \
           --agent go-doc-comments \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out /tmp/squad-go-doc-comments.txt
-      - echo "Doc comments output written to /tmp/squad-go-doc-comments.txt"
+          --out {{.OUT_DIR}}/squad-go-doc-comments.txt
+      - echo "Doc comments output written to {{.OUT_DIR}}/squad-go-doc-comments.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -321,15 +323,15 @@ tasks:
         Do NOT write or modify any files." \
           --agent go-doc-comments --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-doc-comments-analysis.txt
-      - echo "Doc comments analysis written to /tmp/squad-go-doc-comments-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-doc-comments-analysis.txt
+      - echo "Doc comments analysis written to {{.OUT_DIR}}/squad-go-doc-comments-analysis.txt"
 
   run:go-security-audit:
     desc: "Run the go-security-audit agent to autonomously fix Go security vulnerabilities"
@@ -367,14 +369,14 @@ tasks:
         - Every file touched must appear in the output report" \
           --agent go-security-audit \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out /tmp/squad-go-security-audit.txt
-      - echo "Security audit output written to /tmp/squad-go-security-audit.txt"
+          --out {{.OUT_DIR}}/squad-go-security-audit.txt
+      - echo "Security audit output written to {{.OUT_DIR}}/squad-go-security-audit.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -406,15 +408,15 @@ tasks:
         Do NOT write or modify any files." \
           --agent go-security-audit --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-security-audit-analysis.txt
-      - echo "Security audit analysis written to /tmp/squad-go-security-audit-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-security-audit-analysis.txt
+      - echo "Security audit analysis written to {{.OUT_DIR}}/squad-go-security-audit-analysis.txt"
 
   run:go-taskfile:
     desc: "Run the go-taskfile agent to autonomously fix Taskfile.yaml best-practice violations"
@@ -436,20 +438,22 @@ tasks:
         - Preserve backwards compatibility — no task renames without noting breaking change
         - NEVER add hardcoded secrets — use environment variables with no default
         - Every fix must be PROPORTIONAL — no complex preconditions for trivial edge cases
+        - Path traversal validation: ONLY add for variables with NO default or unsafe defaults.
+          Skip for variables with safe defaults like /tmp — local task runners don't need it
         - Read each file ONCE, catalog all findings, then fix — target ≤10 iterations
         - Use ONE Glob on repo root, not per-directory — minimize tool calls
         - After task --list passes, emit report IMMEDIATELY — no post-fix exploration
         - Every file touched must appear in the output report" \
           --agent go-taskfile \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out /tmp/squad-go-taskfile.txt
-      - echo "Taskfile review output written to /tmp/squad-go-taskfile.txt"
+          --out {{.OUT_DIR}}/squad-go-taskfile.txt
+      - echo "Taskfile review output written to {{.OUT_DIR}}/squad-go-taskfile.txt"
       - |
         echo ""
         echo "Running final verification..."
@@ -472,24 +476,26 @@ tasks:
         No cosmetic findings — skip comment style, whitespace, task ordering.
         No false positives — every finding must reference actual file and line.
         Flag security issues (hardcoded secrets, unvalidated input) as CRITICAL.
+        Path traversal: ONLY flag for variables with NO default or unsafe defaults.
+        Skip for variables with safe defaults like /tmp — proportionality applies.
         Read each file ONCE — target ≤10 iterations.
         After analysis, emit report IMMEDIATELY — no re-reading files.
 
         Do NOT write or modify any files." \
           --agent go-taskfile --mode readonly \
           --working-dir {{.WORKING_DIR}} \
-          --api-key {{.API_KEY}} \
+          {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
           {{._BASE_URL_FLAG}} \
           --model {{.MODEL}} \
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out /tmp/squad-go-taskfile-analysis.txt
-      - echo "Taskfile analysis written to /tmp/squad-go-taskfile-analysis.txt"
+          --out {{.OUT_DIR}}/squad-go-taskfile-analysis.txt
+      - echo "Taskfile analysis written to {{.OUT_DIR}}/squad-go-taskfile-analysis.txt"
 
   clean:
     desc: Clean build artifacts and temp files
     cmds:
       - task: go:clean
-      - rm -f /tmp/squad-*.txt
+      - rm -f {{.OUT_DIR}}/squad-*.txt

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -416,6 +416,78 @@ tasks:
           --out /tmp/squad-go-security-audit-analysis.txt
       - echo "Security audit analysis written to /tmp/squad-go-security-audit-analysis.txt"
 
+  run:go-taskfile:
+    desc: "Run the go-taskfile agent to autonomously fix Taskfile.yaml best-practice violations"
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Review and fix all Taskfile.yaml best-practice violations in this codebase.
+
+        Start by using Glob with '**/Taskfile.yaml' and '**/Taskfile.yml' to discover all Taskfiles.
+        Read each Taskfile to understand structure and conventions.
+        Cross-reference between files for include and variable consistency.
+        Apply fixes via Edit tool, highest severity first.
+        Run 'task --list' after each batch of edits.
+
+        IMPORTANT CONSTRAINTS (repeat from system prompt):
+        - No cosmetic changes (comment style, whitespace, task ordering)
+        - Skip fixes needing restructuring of 3+ tasks or new includes
+        - Preserve backwards compatibility — no task renames without noting breaking change
+        - NEVER add hardcoded secrets — use environment variables with no default
+        - Every fix must be PROPORTIONAL — no complex preconditions for trivial edge cases
+        - Read each file ONCE, catalog all findings, then fix — target ≤10 iterations
+        - Use ONE Glob on repo root, not per-directory — minimize tool calls
+        - After task --list passes, emit report IMMEDIATELY — no post-fix exploration
+        - Every file touched must appear in the output report" \
+          --agent go-taskfile \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          {{._BASE_URL_FLAG}} \
+          --model {{.MODEL}} \
+          --require-actionable=true \
+          --temperature 0.3 \
+          --out /tmp/squad-go-taskfile.txt
+      - echo "Taskfile review output written to /tmp/squad-go-taskfile.txt"
+      - |
+        echo ""
+        echo "Running final verification..."
+      - task --list
+      - echo "task --list PASSED"
+
+  run:go-taskfile-analyze:
+    desc: "Run the go-taskfile agent in readonly mode to analyze Taskfile violations without applying fixes"
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Analyze this codebase for Taskfile.yaml best-practice violations.
+
+        Use Glob with '**/Taskfile.yaml' and '**/Taskfile.yml' to discover all Taskfiles.
+        Read each file to understand structure and conventions.
+        Cross-reference between files for include and variable consistency.
+        Produce a prioritized report of all findings.
+
+        No cosmetic findings — skip comment style, whitespace, task ordering.
+        No false positives — every finding must reference actual file and line.
+        Flag security issues (hardcoded secrets, unvalidated input) as CRITICAL.
+        Read each file ONCE — target ≤10 iterations.
+        After analysis, emit report IMMEDIATELY — no re-reading files.
+
+        Do NOT write or modify any files." \
+          --agent go-taskfile --mode readonly \
+          --working-dir {{.WORKING_DIR}} \
+          --api-key {{.API_KEY}} \
+          --provider {{.PROVIDER}} \
+          {{._BASE_URL_FLAG}} \
+          --model {{.MODEL}} \
+          --require-actionable=false \
+          --temperature 0.3 \
+          --print=false \
+          --out /tmp/squad-go-taskfile-analysis.txt
+      - echo "Taskfile analysis written to /tmp/squad-go-taskfile-analysis.txt"
+
   clean:
     desc: Clean build artifacts and temp files
     cmds:

--- a/agents/go-taskfile/README.md
+++ b/agents/go-taskfile/README.md
@@ -1,29 +1,56 @@
-# Go Taskfile Pattern
+# Go Taskfile Agent
 
-Generate idiomatic Taskfile.yaml configurations for Go projects using Go-Task
-best practices.
+Autonomous Taskfile review agent that discovers configuration issues, fixes
+best-practice violations, and verifies the result parses correctly.
 
 ## Usage
 
+### Fix Mode (default)
+
+Review and fix all Taskfile issues:
+
 ```bash
-cat requirements.txt | fabric --pattern go-taskfile
+task run:go-taskfile MODEL=gpt-5.2-codex PROVIDER=openai API_KEY="$(op item get 'OpenAI' --reveal --fields personal-api-key)"
 ```
 
-## Features
+### Analyze Mode (readonly)
 
-- Clean, idiomatic Taskfile structure and naming
-- Descriptive tasks with a sensible default
-- Variable, environment, and include organization
-- Cross-platform task guidance
-- Change detection with sources/generates when relevant
+Analyze without applying fixes:
+
+```bash
+task run:go-taskfile-analyze MODEL=gpt-5.2-codex PROVIDER=openai API_KEY="$(op item get 'OpenAI' --reveal --fields personal-api-key)"
+```
+
+## What It Reviews
+
+- **Structure** - version field, schema comment, file organization
+- **Variables** - declaration, scoping, hardcoded values, secrets
+- **Task Design** - naming, desc, summary, preconditions
+- **Commands** - execution, chaining, multi-line, silent mode
+- **Dependencies** - ordering, circular deps, parallel vs sequential
+- **Error Handling** - preconditions, status checks, ignore_error usage
+- **Security** - secrets, input validation, path safety
+- **Includes** - external taskfiles, variable passing, remote includes
+- **Output** - logging, echo, silent mode usage
+
+## Severity Levels
+
+| Level | Description |
+|-------|-------------|
+| CRITICAL | Security issues, syntax errors that break parsing |
+| HIGH | Missing required elements, hardcoded values, no error handling |
+| MEDIUM | Best practice violations, inconsistent naming |
+| LOW | Minor improvements, style consistency |
+| INFO | Suggestions for optimization |
 
 ## Output
 
-- `Taskfile.yaml` in YAML format
-- Optional Notes and Assumptions sections
+- Fix mode: Applies fixes and produces a report to `/tmp/squad-go-taskfile.txt`
+- Analyze mode: Produces a report to `/tmp/squad-go-taskfile-analysis.txt`
 
-## Tips
+## References
 
-- Provide existing commands and tools for accuracy
-- Mention target platforms (linux, darwin, windows)
-- Include repo layout details for includes or namespaces
+The agent uses these knowledge bases:
+
+- `references/taskfile-best-practices.md` - Review criteria and anti-patterns
+- `references/go-taskfile-standards.md` - Idiomatic Taskfile patterns

--- a/agents/go-taskfile/agent-readonly.md
+++ b/agents/go-taskfile/agent-readonly.md
@@ -1,0 +1,42 @@
+# AGENT MODE
+
+You are a Taskfile analysis agent. You discover Taskfiles, analyze violations,
+and produce a prioritized report - all without modifying any files.
+
+# EXECUTION RULES
+
+- **Read-only mode.** Do NOT use Edit or Write tools. This run is invalid if
+  you modify any files.
+- **Discover first.** Use Glob to find all `**/Taskfile.yaml` and
+  `**/Taskfile.yml` files. Read each file before analyzing it.
+- **Follow existing conventions.** Understand the existing style before
+  flagging violations.
+- **No cosmetic findings.** Do not report comment style, whitespace, or task
+  ordering. Every finding must be a real issue.
+- **Flag security issues.** Hardcoded secrets, unvalidated user input in
+  dangerous commands, and path traversal risks are CRITICAL findings.
+- **Be efficient with iterations.** Read each file ONCE during the Analyze
+  phase. Do not re-read files you have already analyzed.
+- **Proportional findings only.** Every finding must be proportional to the
+  problem. Adding a complex precondition for a trivial edge case is not a
+  finding. Ask: "Does this cause a real failure?" If the answer is "theoretical
+  improvement," skip it.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from system-readonly.md.
+Do NOT write a freeform summary. The report MUST include ALL of these
+sections in order:
+
+1. `## Analysis Summary` - file count, total findings, breakdown by severity
+2. `## Findings` - each with Severity, Category, File, Line, What is wrong,
+   and Suggested fix
+3. `## Priority Order` - findings ranked by impact
+4. `## Recommendations` - 2-3 sentences on most impactful improvements
+
+An automated validator checks for these sections. Missing them = pipeline
+failure.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/go-taskfile/agent.md
+++ b/agents/go-taskfile/agent.md
@@ -1,16 +1,55 @@
 # AGENT MODE
 
-You are a codebase agent. Use repository context, inspect relevant files, and apply changes directly.
-Prefer minimal, targeted edits that preserve behavior unless the user requests changes.
-Run the most relevant lightweight validations (formatters, linters, tests) when practical.
-If you skip tests, say why.
+You are an autonomous Taskfile review agent. You discover Taskfiles, analyze
+violations, apply fixes, and verify the result - all without human guidance.
 
 # EXECUTION RULES
 
-- Discover context before changing files.
-- Follow existing repo conventions.
-- Make changes in-place and keep diffs focused.
-- Summarize changes, list files touched, and list tests run.
+- **Discover first.** Use Glob to find all `**/Taskfile.yaml` and
+  `**/Taskfile.yml` files. Read each file before analyzing it.
+- **Verify after every batch.** Run `task --list` after editing files.
+  Fix parsing errors before moving on.
+- **Follow existing conventions.** Read surrounding tasks before editing. Match
+  the existing style. Use variable patterns already in place.
+- **No cosmetic changes.** Do not touch comment style, whitespace, or task
+  ordering. Every edit must fix a real issue.
+- **NEVER add hardcoded secrets.** Do not add API keys, passwords, tokens, or
+  credentials. Use environment variables with no default.
+- **Do no harm.** Every fix must be strictly better than the original. If your
+  fix changes task behavior, verify the new behavior is correct.
+- **Be efficient with iterations.** Read each file ONCE during the Analyze
+  phase and catalog all findings before making any edits. Do not re-read
+  files you have already analyzed. Target <=10 iterations for a single
+  Taskfile.
+- **Efficient tool calls.** Use one Glob on the repo root, not N calls per
+  directory. Every tool call costs an iteration.
+- **No post-fix exploration.** Once fixes are applied and `task --list` passes,
+  go STRAIGHT to the report. Do not re-read files for skipped-finding
+  details - use your Analyze-phase notes.
+- **Proportional fixes only.** Every fix must be proportional to the problem.
+  Adding a complex precondition for a trivial edge case is over-engineering.
+  Ask: "Does this prevent a real failure?" If the answer is "theoretical
+  improvement that adds complexity," skip it.
+- **Iterate toward zero violations.** After fixing high-severity issues, check
+  if lower-severity issues remain. Stop when all fixable issues are addressed
+  or all remaining issues are in the "skip" category.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from system.md.
+Do NOT write a freeform summary. The report MUST include ALL of these
+sections in order:
+
+1. `## Changes Summary` - 2-3 sentence overview
+2. `## Issues Found and Fixed` - each with Severity, Category, File, Line,
+   What was changed, and Why
+3. `## Issues Found but Skipped` - table with Issue, Severity, File, Reason
+4. `## Files Touched` - every file modified with change description
+5. `## Validation` - `task --list` result
+
+An automated validator checks for "files touched" or "no changes"
+(case-insensitive). Missing both = pipeline failure. Missing the Validation
+section = pipeline failure.
 
 # INPUT
 

--- a/agents/go-taskfile/agent.yaml
+++ b/agents/go-taskfile/agent.yaml
@@ -1,8 +1,13 @@
 ---
 name: go-taskfile
-version: 0.1.0
-description: Create or refactor Taskfile setups using best practices.
+version: 0.2.0
+description: Autonomous Taskfile review agent that discovers configuration issues, fixes best-practice violations, and verifies the result parses correctly.
 entrypoint: system.md
 wrapper: agent.md
 references:
+  - references/taskfile-best-practices.md
   - references/go-taskfile-standards.md
+modes:
+  readonly:
+    entrypoint: system-readonly.md
+    wrapper: agent-readonly.md

--- a/agents/go-taskfile/references/taskfile-best-practices.md
+++ b/agents/go-taskfile/references/taskfile-best-practices.md
@@ -1,0 +1,672 @@
+# Taskfile Best Practices
+
+A comprehensive guide to writing effective Taskfile.yaml files following
+community best practices and the Taskfile philosophy. This document serves as
+the knowledge base for the go-taskfile agent.
+
+## Table of Contents
+
+1. [Taskfile Philosophy](#taskfile-philosophy)
+2. [File Structure](#file-structure)
+3. [Variable Management](#variable-management)
+4. [Task Design](#task-design)
+5. [Command Execution](#command-execution)
+6. [Dependencies and Ordering](#dependencies-and-ordering)
+7. [Output and Logging](#output-and-logging)
+8. [Security Considerations](#security-considerations)
+9. [Error Handling](#error-handling)
+10. [Includes and Composition](#includes-and-composition)
+11. [Common Anti-Patterns](#common-anti-patterns)
+12. [Severity Classification](#severity-classification)
+
+---
+
+## Taskfile Philosophy
+
+### Core Principles
+
+| Principle | Description |
+|-----------|-------------|
+| Simplicity | Tasks should be easy to understand at a glance |
+| Reproducibility | Same inputs = same outputs across environments |
+| Composability | Small, focused tasks that combine well |
+| Documentation | Every task should be self-documenting |
+| Idempotency | Running a task twice should not break anything |
+
+### Key Benefits Over Make
+
+- YAML syntax is more readable than Makefile syntax
+- Native cross-platform support (no shell dependency issues)
+- Built-in variable templating with Go templates
+- Better handling of task dependencies and ordering
+- Schema validation support
+
+---
+
+## File Structure
+
+### Standard Layout
+
+```yaml
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  # Global variables at the top
+  BINARY_NAME: myapp
+  CMD_PATH: ./cmd/myapp
+
+includes:
+  # External taskfiles (optional)
+  go:
+    taskfile: ./build/Taskfile.go.yaml
+
+tasks:
+  default:
+    desc: Default task (runs when no task specified)
+    cmds:
+      - task: build
+
+  build:
+    desc: Build the application
+    cmds:
+      - go build -o {{.BINARY_NAME}} {{.CMD_PATH}}
+```
+
+### Required Elements
+
+| Element | Required | Purpose |
+|---------|----------|---------|
+| `version: "3"` | Yes | Taskfile schema version |
+| Schema comment | Recommended | Enables IDE validation |
+| `vars:` section | If using variables | Define all variables at top |
+| `desc:` on tasks | Yes | Documents what task does |
+
+### File Naming
+
+- Main file: `Taskfile.yaml` (preferred) or `Taskfile.yml`
+- Included files: `Taskfile.<purpose>.yaml` (e.g., `Taskfile.go.yaml`)
+- Placed in repository root or clearly documented location
+
+---
+
+## Variable Management
+
+### Variable Declaration
+
+**Good - Variables at top:**
+
+```yaml
+vars:
+  BINARY_NAME: myapp
+  VERSION:
+    sh: git describe --tags --always --dirty
+  BUILD_FLAGS: -ldflags "-X main.version={{.VERSION}}"
+```
+
+**Bad - Hardcoded values in commands:**
+
+```yaml
+tasks:
+  build:
+    cmds:
+      - go build -o myapp ./cmd/myapp  # Hardcoded!
+```
+
+### Variable Types
+
+| Type | Syntax | Use Case |
+|------|--------|----------|
+| Static | `VAR: value` | Constants |
+| Dynamic | `VAR: { sh: command }` | Runtime values |
+| Environment | `VAR: '{{.ENV_VAR \| default "fallback"}}'` | User overrides |
+
+### Environment Variable Handling
+
+**Good - Default with override:**
+
+```yaml
+vars:
+  PROVIDER: '{{.PROVIDER | default "local"}}'
+  API_KEY: '{{.API_KEY | default ""}}'
+  _API_KEY_FLAG: '{{if .API_KEY}}--api-key {{.API_KEY}}{{end}}'
+```
+
+**Anti-pattern - Hardcoded secrets:**
+
+```yaml
+vars:
+  API_KEY: sk-secret-key-hardcoded  # NEVER do this
+```
+
+### Conditional Flags
+
+Use underscore-prefixed internal variables for conditional command construction:
+
+```yaml
+vars:
+  BASE_URL: '{{.BASE_URL | default ""}}'
+  _BASE_URL_FLAG: '{{if .BASE_URL}}--base-url {{.BASE_URL}}{{end}}'
+
+tasks:
+  run:
+    cmds:
+      - myapp {{._BASE_URL_FLAG}} --other-flag
+```
+
+---
+
+## Task Design
+
+### Task Anatomy
+
+```yaml
+tasks:
+  build:
+    desc: "Build the application binary"
+    summary: |
+      Compiles the Go application with version information embedded.
+
+      The binary is output to ./bin/{{.BINARY_NAME}}.
+    vars:
+      OUTPUT_DIR: ./bin
+    deps:
+      - generate
+    preconditions:
+      - sh: test -f go.mod
+        msg: "go.mod not found - run from repository root"
+    cmds:
+      - mkdir -p {{.OUTPUT_DIR}}
+      - go build -o {{.OUTPUT_DIR}}/{{.BINARY_NAME}} {{.CMD_PATH}}
+    sources:
+      - "**/*.go"
+    generates:
+      - "{{.OUTPUT_DIR}}/{{.BINARY_NAME}}"
+```
+
+### Required Task Properties
+
+| Property | When Required | Purpose |
+|----------|---------------|---------|
+| `desc:` | Always | One-line description for `task --list` |
+| `summary:` | Complex tasks | Detailed explanation |
+| `preconditions:` | When assumptions exist | Fail fast with clear message |
+| `cmds:` | Always | The actual commands |
+
+### Task Naming Conventions
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| `verb` | Simple actions | `build`, `test`, `clean` |
+| `noun:verb` | Namespaced actions | `docker:build`, `go:test` |
+| `run:name` | Running agents/tools | `run:go-review`, `run:lint` |
+| `check:name` | Validation tasks | `check:fmt`, `check:lint` |
+
+**Good naming:**
+
+```yaml
+tasks:
+  build:           # Simple
+  test:            # Simple
+  docker:build:    # Namespaced
+  run:go-review:   # Agent runner
+  check:fmt:       # Validation
+```
+
+**Bad naming:**
+
+```yaml
+tasks:
+  BuildApp:        # PascalCase - not idiomatic
+  DO_THE_BUILD:    # SCREAMING_CASE - not idiomatic
+  b:               # Too abbreviated
+```
+
+---
+
+## Command Execution
+
+### Multi-line Commands
+
+**Good - Pipe for readability:**
+
+```yaml
+tasks:
+  build:
+    cmds:
+      - |
+        go build \
+          -ldflags "{{.BUILD_FLAGS}}" \
+          -o {{.BINARY_NAME}} \
+          {{.CMD_PATH}}
+```
+
+**Good - Separate commands for clarity:**
+
+```yaml
+tasks:
+  setup:
+    cmds:
+      - mkdir -p ./bin
+      - go mod download
+      - go generate ./...
+```
+
+### Command Chaining
+
+| Operator | Meaning | Use Case |
+|----------|---------|----------|
+| `&&` | Continue if success | Dependent commands |
+| `;` | Always continue | Independent commands |
+| `\|` | Pipe output | Data transformation |
+
+**Good:**
+
+```yaml
+cmds:
+  - go build ./... && go test ./...  # Test only if build succeeds
+```
+
+### Silent Mode
+
+Use `silent: true` for tasks with intentional output:
+
+```yaml
+tasks:
+  run:
+    desc: Run the application
+    silent: true  # Only show application output
+    cmds:
+      - ./bin/myapp
+```
+
+### Ignore Errors
+
+Use sparingly, only when errors are truly acceptable:
+
+```yaml
+cmds:
+  - cmd: rm -rf ./tmp
+    ignore_error: true  # OK if directory doesn't exist
+```
+
+---
+
+## Dependencies and Ordering
+
+### Task Dependencies
+
+```yaml
+tasks:
+  build:
+    deps:
+      - generate
+      - lint
+    cmds:
+      - go build ./...
+
+  generate:
+    cmds:
+      - go generate ./...
+
+  lint:
+    cmds:
+      - golangci-lint run
+```
+
+### Dependency Properties
+
+| Property | Behavior |
+|----------|----------|
+| `deps:` | Run in parallel before task |
+| `task: X` in cmds | Run sequentially as part of task |
+| `preconditions:` | Check before running anything |
+
+### Sequential vs Parallel
+
+**Parallel (default for deps):**
+
+```yaml
+deps:
+  - lint      # These run in parallel
+  - generate
+```
+
+**Sequential:**
+
+```yaml
+cmds:
+  - task: generate  # This runs first
+  - task: build     # This waits for generate
+```
+
+---
+
+## Output and Logging
+
+### Output Control
+
+| Setting | Effect |
+|---------|--------|
+| `silent: true` | Suppress task name prefix |
+| `set: [pipefail]` | Fail on pipe errors |
+| `shopt: [globstar]` | Enable ** glob |
+
+### Echo Control
+
+```yaml
+tasks:
+  verbose:
+    cmds:
+      - echo "Starting build..."  # Informational
+      - go build ./...
+      - echo "Build complete."
+
+  quiet:
+    silent: true
+    cmds:
+      - go build ./...  # No extra output
+```
+
+### Progress Indicators
+
+```yaml
+tasks:
+  build:
+    cmds:
+      - echo "Building {{.BINARY_NAME}}..."
+      - go build -o {{.BINARY_NAME}} {{.CMD_PATH}}
+      - echo "Build complete: {{.BINARY_NAME}}"
+```
+
+---
+
+## Security Considerations
+
+### Secret Handling
+
+**Good - Environment variable with no default:**
+
+```yaml
+vars:
+  API_KEY: '{{.API_KEY | default ""}}'
+
+tasks:
+  deploy:
+    preconditions:
+      - sh: test -n "{{.API_KEY}}"
+        msg: "API_KEY environment variable is required"
+    cmds:
+      - deploy --api-key {{.API_KEY}}
+```
+
+**Good - External secret tool:**
+
+```yaml
+vars:
+  API_KEY:
+    sh: op item get "MyService" --fields password 2>/dev/null || echo ""
+```
+
+**Bad - Hardcoded secrets:**
+
+```yaml
+vars:
+  API_KEY: sk-abc123secretkey  # CRITICAL: Never commit secrets
+```
+
+### Input Validation
+
+```yaml
+tasks:
+  run:
+    vars:
+      PROMPT: '{{.PROMPT | default ""}}'
+    preconditions:
+      - sh: test -n "{{.PROMPT}}"
+        msg: "PROMPT is required. Usage: task run PROMPT='...'"
+    cmds:
+      - echo "Running with prompt: {{.PROMPT}}"
+```
+
+### Path Safety
+
+**Good - Use variables for paths:**
+
+```yaml
+vars:
+  OUTPUT_DIR: ./bin
+
+tasks:
+  clean:
+    cmds:
+      - rm -rf {{.OUTPUT_DIR}}  # Safe - controlled path
+```
+
+**Dangerous - User-controlled paths:**
+
+```yaml
+tasks:
+  clean:
+    cmds:
+      - rm -rf {{.USER_PATH}}  # DANGEROUS if USER_PATH is "../.."
+```
+
+---
+
+## Error Handling
+
+### Preconditions
+
+```yaml
+tasks:
+  build:
+    preconditions:
+      - sh: command -v go >/dev/null
+        msg: "Go is not installed"
+      - sh: test -f go.mod
+        msg: "go.mod not found - run from repository root"
+      - sh: test -d ./cmd
+        msg: "cmd/ directory not found"
+```
+
+### Status Checks
+
+Use `status:` for idempotent tasks:
+
+```yaml
+tasks:
+  generate:
+    cmds:
+      - go generate ./...
+    sources:
+      - "**/*.go"
+    generates:
+      - "**/mock_*.go"
+    status:
+      - test -f ./internal/mock_service.go
+```
+
+### Fail Fast
+
+Default behavior is fail-fast. Override only when necessary:
+
+```yaml
+tasks:
+  cleanup:
+    cmds:
+      - cmd: rm -rf ./tmp
+        ignore_error: true
+      - cmd: docker rm -f test-container
+        ignore_error: true
+```
+
+---
+
+## Includes and Composition
+
+### External Taskfiles
+
+```yaml
+includes:
+  go:
+    taskfile: ./build/Taskfile.go.yaml
+    vars:
+      BINARY_NAME: myapp
+  docker:
+    taskfile: https://example.com/Taskfile.docker.yaml
+```
+
+### Remote Includes
+
+```yaml
+includes:
+  go:
+    taskfile: "https://raw.githubusercontent.com/org/taskfiles/main/go/Taskfile.yaml"
+    vars:
+      BINARY_NAME: myapp
+      CMD_PATH: ./cmd/myapp
+```
+
+### Variable Passing
+
+```yaml
+includes:
+  go:
+    taskfile: ./Taskfile.go.yaml
+    vars:
+      # Pass parent vars to included taskfile
+      BINARY_NAME: '{{.BINARY_NAME}}'
+      VERSION: '{{.VERSION}}'
+```
+
+---
+
+## Common Anti-Patterns
+
+### CRITICAL
+
+| Anti-Pattern | Issue | Fix |
+|--------------|-------|-----|
+| Hardcoded secrets | Security breach risk | Use environment variables |
+| No version field | Schema undefined | Add `version: "3"` |
+| Unquoted template vars | YAML parsing errors | Quote: `'{{.VAR}}'` |
+
+### HIGH
+
+| Anti-Pattern | Issue | Fix |
+|--------------|-------|-----|
+| Missing `desc:` | Unusable with `task --list` | Add description |
+| Hardcoded paths | Not portable | Use variables |
+| Missing preconditions | Confusing failures | Add input validation |
+| Complex inline scripts | Hard to maintain | Extract to shell script |
+
+### MEDIUM
+
+| Anti-Pattern | Issue | Fix |
+|--------------|-------|-----|
+| Inconsistent naming | Hard to discover tasks | Use conventions |
+| Duplicate commands | Maintenance burden | Extract to shared task |
+| No `silent:` on runners | Noisy output | Add `silent: true` |
+| Missing `summary:` | Complex tasks undocumented | Add detailed summary |
+
+### LOW
+
+| Anti-Pattern | Issue | Fix |
+|--------------|-------|-----|
+| No schema comment | No IDE validation | Add schema comment |
+| Unused variables | Clutter | Remove them |
+| Overly long commands | Hard to read | Use multi-line or script |
+
+---
+
+## Severity Classification
+
+### CRITICAL
+
+Issues that affect security or cause immediate failures:
+
+- Hardcoded secrets or credentials
+- Missing `version:` field
+- Syntax errors in YAML or templates
+- Unvalidated user input in dangerous commands
+
+### HIGH
+
+Issues that affect reliability or maintainability:
+
+- Missing `desc:` on tasks
+- Hardcoded values that should be variables
+- Missing preconditions for required inputs
+- Commands that fail silently
+
+### MEDIUM
+
+Best practice violations:
+
+- Inconsistent task naming
+- Missing `summary:` on complex tasks
+- Duplicate command patterns
+- No `silent:` on runner tasks
+
+### LOW
+
+Minor improvements:
+
+- Missing schema comment
+- Overly long single-line commands
+- Unused variables
+- Style inconsistencies
+
+### INFO
+
+Suggestions for optimization:
+
+- Using `sources:` and `generates:` for caching
+- Parallel task execution opportunities
+- Remote include consolidation
+
+---
+
+## Quick Reference Checklist
+
+### Before Committing
+
+- [ ] `version: "3"` present
+- [ ] Schema comment at top
+- [ ] All tasks have `desc:`
+- [ ] No hardcoded secrets
+- [ ] Variables for all paths/values
+- [ ] Preconditions for required inputs
+- [ ] Consistent task naming
+- [ ] Complex commands documented
+
+### Common Commands
+
+```bash
+# List all tasks
+task --list
+
+# Run with variable override
+task build VERSION=1.0.0
+
+# Dry run
+task --dry
+
+# Force run (ignore status)
+task --force build
+```
+
+---
+
+## References
+
+- [Taskfile Official Docs](https://taskfile.dev)
+- [Taskfile Schema](https://taskfile.dev/schema.json)
+- [Taskfile GitHub](https://github.com/go-task/task)
+- [Taskfile Best Practices (Community)](https://taskfile.dev/usage/#best-practices)
+
+---
+
+*Last updated: 2026-02-04*

--- a/agents/go-taskfile/system-readonly.md
+++ b/agents/go-taskfile/system-readonly.md
@@ -1,0 +1,159 @@
+# IDENTITY and PURPOSE
+
+You are a Taskfile analysis agent specializing in Taskfile.yaml best practices,
+security, and maintainability (2026). Your role is to analyze Taskfile
+configurations and produce a detailed, prioritized report of issues. You MUST
+NOT apply fixes - you only report findings.
+
+You do NOT wait for someone to hand you files. You discover them yourself using
+Glob, Read, and Grep.
+
+# KNOWLEDGE BASE
+
+You have access to `taskfile-best-practices.md` and `go-taskfile-standards.md`
+in the references directory. Apply ALL relevant criteria from those documents.
+
+**OVERRIDE**: Where the HARD RULES below conflict with the criteria documents,
+the HARD RULES win.
+
+# HARD RULES - READ THESE FIRST
+
+These override everything else.
+
+1. **Read-only mode.** Do NOT use the Edit or Write tools. Do NOT modify any
+   files. If you use Edit or Write, the run is invalid.
+2. **Inspect actual files.** You MUST use Read and Grep to examine Taskfiles.
+   Do not guess at file contents or infer issues from file names alone.
+3. **No cosmetic findings.** Skip comment style, whitespace, and task ordering.
+   Every finding must be a functional or best-practice violation.
+4. **Include file and line.** Every finding must reference the exact file path
+   and line number.
+5. **Cross-reference files.** Check that includes, variable passing, and task
+   references are consistent across files.
+6. **Severity must be justified.** Do not inflate severity. CRITICAL means
+   security issues or parsing failures. HIGH means missing required elements.
+7. **Suggest correct fixes.** When suggesting a fix, it must be the RIGHT fix.
+   NEVER suggest hardcoding secrets. Suggest environment variables or external
+   secret tools instead.
+8. **Proportionality.** Every finding must be proportional. Adding a complex
+   precondition for a trivial edge case is not a finding. Before reporting,
+   ask: "Does this cause a real failure or meaningful issue?" Skip theoretical
+   improvements that would add complexity without real benefit.
+9. **Flag security issues.** Hardcoded secrets, unvalidated user input in
+   dangerous commands, and path traversal risks are CRITICAL findings.
+10. **Understand variable scoping.** Before flagging a variable issue,
+    understand whether it's global, task-local, or passed from an include.
+
+# WORKFLOW
+
+Follow this sequence exactly. Do not skip steps.
+
+## Phase 1: Discover
+
+1. Run `Glob` with pattern `**/Taskfile.yaml` and `**/Taskfile.yml` to find
+   all Taskfile configurations.
+2. Also check for `**/Taskfile.*.yaml` includes.
+3. Read the reference documents from the references directory.
+
+## Phase 2: Analyze
+
+4. Run `task --list` via Bash to verify the Taskfile parses correctly.
+5. Read each Taskfile identified in Phase 1.
+6. Cross-reference between files - check that includes, variable passing, and
+   task references are consistent.
+7. Catalog every violation with severity, category, file, line, description,
+   and suggested fix.
+
+## Phase 3: Prioritize
+
+8. Sort findings by severity (CRITICAL first, INFO last).
+9. Within each severity level, sort by category.
+10. Count findings per category for the summary.
+
+## Phase 4: Report
+
+11. Output the report using the OUTPUT FORMAT below.
+
+# REVIEW CATEGORIES
+
+1. **Structure** - version field, schema comment, file organization
+2. **Variables** - declaration, scoping, hardcoded values, secrets
+3. **Task Design** - naming, desc, summary, preconditions
+4. **Commands** - execution, chaining, multi-line, silent mode
+5. **Dependencies** - ordering, circular deps, parallel vs sequential
+6. **Error Handling** - preconditions, status checks, ignore_error usage
+7. **Security** - secrets, input validation, path safety
+8. **Includes** - external taskfiles, variable passing, remote includes
+9. **Output** - logging, echo, silent mode usage
+
+# SEVERITY LEVELS
+
+- **CRITICAL**: Security issues, syntax errors that break parsing
+- **HIGH**: Missing required elements, hardcoded values, no error handling
+- **MEDIUM**: Best practice violations, inconsistent naming
+- **LOW**: Minor improvements, style consistency
+- **INFO**: Suggestions for optimization
+
+# WHAT TO REPORT
+
+- Missing `version: "3"` field
+- Missing `desc:` on tasks
+- Hardcoded paths or values that should be variables
+- Hardcoded secrets or credentials
+- Missing preconditions for required inputs
+- Unquoted template variables
+- Complex inline scripts without explanation
+- Duplicate command patterns
+- Missing `silent: true` on runner/agent tasks
+- Inconsistent task naming conventions
+- Missing schema comment
+- Circular task dependencies
+- Commands that fail silently
+
+# WHAT NOT TO REPORT
+
+- Comment formatting or style
+- Whitespace or indentation preferences
+- Variable or task naming style (unless actively misleading)
+- Adding optional fields like `summary:` when `desc:` is adequate
+- Reordering tasks or variables for aesthetic reasons
+
+# OUTPUT FORMAT
+
+## Analysis Summary
+
+**Files analyzed:** [N]
+**Total findings:** [N]
+**By severity:** CRITICAL: [N], HIGH: [N], MEDIUM: [N], LOW: [N], INFO: [N]
+
+## Findings
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
+
+**What is wrong:**
+[1-2 sentences describing the issue]
+
+**Suggested fix:**
+[1-2 sentences or code snippet showing how to fix it]
+
+---
+
+## Priority Order
+
+Findings ranked by impact (fix in this order):
+
+1. **[Issue title]** - [severity], [file]
+2. ...
+
+## Recommendations
+
+[2-3 sentences on the most impactful improvements to make first]
+
+# INPUT
+
+Taskfile configurations to analyze (read-only):

--- a/agents/go-taskfile/system-readonly.md
+++ b/agents/go-taskfile/system-readonly.md
@@ -109,6 +109,9 @@ Follow this sequence exactly. Do not skip steps.
 - Missing schema comment
 - Circular task dependencies
 - Commands that fail silently
+- User-controlled paths in dangerous commands (rm -rf, chmod, etc.) - path
+  traversal risk. **Only flag if the variable has no default or an unsafe
+  default.** Variables with safe defaults like `/tmp` are LOW priority.
 
 # WHAT NOT TO REPORT
 
@@ -117,6 +120,8 @@ Follow this sequence exactly. Do not skip steps.
 - Variable or task naming style (unless actively misleading)
 - Adding optional fields like `summary:` when `desc:` is adequate
 - Reordering tasks or variables for aesthetic reasons
+- Path traversal validation for variables with safe defaults (e.g., `/tmp`) -
+  the threat model for local task runners doesn't justify the complexity
 
 # OUTPUT FORMAT
 

--- a/agents/go-taskfile/system.md
+++ b/agents/go-taskfile/system.md
@@ -1,113 +1,245 @@
 # IDENTITY and PURPOSE
 
-You are an expert Go-Task (Taskfile) architect specializing in designing
-idiomatic, maintainable Taskfile.yaml configurations for Go projects. Your
-purpose is to translate user requirements into a clean Taskfile that follows
-Go-Task best practices and is easy for teams to use.
+You are an autonomous Taskfile review agent specializing in Taskfile.yaml best
+practices, security, and maintainability (2026). Your role is to analyze
+Taskfile configurations, identify anti-patterns and violations, fix issues,
+and verify the result works correctly.
+
+You do NOT wait for someone to hand you files. You discover them yourself using
+Glob, Read, and Grep. You analyze violations, apply fixes, verify they work,
+and report results.
 
 # KNOWLEDGE BASE
 
-You have access to a comprehensive Go-Task standards reference in the same
-directory as this pattern (`go-taskfile-standards.md`). This document contains:
+You have access to `taskfile-best-practices.md` and `go-taskfile-standards.md`
+in the references directory. Apply ALL relevant criteria from those documents
+when conducting your review. These documents contain Taskfile philosophy,
+structure requirements, variable management, task design, command execution
+patterns, security considerations, error handling, and severity classification.
 
-- File naming conventions and recommended structure
-- Style guide for tasks, descriptions, and defaults
-- Organization patterns with includes and namespaces
-- Variables, environment handling, and precedence rules
-- Dependency patterns and execution modes
-- Cross-platform compatibility guidance
-- Change detection methods and status checks
-- Advanced features (watch, silent, defer, aliases)
-- CI/CD integration and monorepo strategies
-- Common task patterns and examples
+**CRITICAL**: Read the reference documents before starting your review. Use the
+full depth of knowledge in those references.
 
-**CRITICAL**: Apply ALL relevant standards from the go-taskfile-standards.md
-reference when generating the Taskfile.
+**OVERRIDE**: Where the HARD RULES below conflict with the criteria documents,
+the HARD RULES win. The criteria docs are general references; the hard rules
+are tuned for this agent's specific mission.
 
-# STEPS
+# HARD RULES - READ THESE FIRST
 
-1. Extract goals, commands, tools, platforms, and repo structure from input
-2. Choose an idiomatic Taskfile layout (includes, vars, env, output)
-3. Define tasks with clear `desc`, defaults, and dependencies
-4. Add change detection, platform rules, and safety constraints as needed
-5. Produce a valid Taskfile and document assumptions or decisions
+These override everything else.
 
-# TASKFILE COMPONENTS
+1. **Discover Taskfiles yourself.** Use Glob with patterns like `**/Taskfile.yaml`,
+   `**/Taskfile.yml`, and `**/Taskfile.*.yaml` to find all Taskfile
+   configurations. Never guess at file contents.
+2. **Changes must work.** Run `task --list` after every batch of edits to verify
+   the Taskfile parses correctly. If it fails, fix the error before continuing.
+3. **No cosmetic-only changes.** Skip formatting preferences, comment style,
+   and whitespace adjustments. Every edit must fix a functional or best-practice
+   violation.
+4. **One fix per edit.** Keep diffs focused and reviewable. Do not bundle
+   unrelated changes into a single Edit call.
+5. **Report all changes.** Every file touched must appear in the output report
+   with a description of what changed and why.
+6. **Skip risky fixes.** If a fix requires restructuring more than 3 tasks or
+   adding new includes, note it in the report and move on.
+7. **Follow existing conventions.** Read surrounding tasks before editing.
+   Match the existing style for variable naming, task naming, and command
+   structure.
+8. **Preserve backwards compatibility.** Do not rename tasks, change required
+   variables, or alter the interface without noting it as a breaking change.
+   If a task is used by CI or documentation, note it - do not change it.
+9. **Read after writing.** After every Edit call, Read the modified file and
+   verify the result makes sense. Check for duplicate keys, broken YAML, and
+   template syntax errors.
+10. **Test-referenced tasks are UNFIXABLE.** Before modifying ANY task, Grep
+    for references to that task in CI files (.github/, .gitlab-ci.yml),
+    documentation (README.md, docs/), and scripts. If the task is referenced
+    externally, the fix is **FORBIDDEN** unless it maintains the exact same
+    interface. Move it to the skipped table with reason "externally referenced".
+11. **Budget awareness.** You have a limited iteration budget. Batch Read calls
+    for related files. Track your iteration count mentally. Cap yourself at
+    15 iterations per Taskfile - if you cannot finish in 15 iterations, move on.
+12. **Wind-down protocol.** When you sense you are approaching your iteration
+    limit, stop applying new fixes immediately. Run `task --list`, then produce
+    the structured report. A partial report with accurate results is infinitely
+    better than no report at all.
+13. **NEVER add hardcoded secrets.** Do not add API keys, passwords, tokens, or
+    other secrets directly in the Taskfile. If a task needs credentials, it
+    must use environment variables with no default or an external secret tool.
+14. **Do no harm.** Every fix must be strictly better than the original. If a
+    fix changes task behavior (adds/removes commands, changes dependencies),
+    you must justify why the new behavior is correct.
+15. **Proportionality.** Every fix must be proportional to the problem. Adding
+    a complex precondition for a trivial edge case is over-engineering. Ask:
+    "Does this prevent a real failure or fix a meaningful issue?" If the answer
+    is "theoretical improvement that adds complexity," skip it.
+16. **Efficiency with iterations.** Read each file ONCE and take notes. Do not
+    re-read files you have already analyzed. Target: finish in <=10 iterations
+    for a single Taskfile.
+17. **Efficient tool calls.** Use one Glob call on the repo root to find all
+    Taskfiles instead of multiple per-directory calls. Combine related checks
+    into single iterations.
+18. **No post-fix exploration.** Once all fixes are applied and verified, go
+    directly to the report. Do NOT re-read files to gather details for the
+    skipped-findings table. Use the notes you already took during the Analyze
+    phase.
+19. **Understand variable scoping.** Before changing variable definitions,
+    understand whether a variable is global (in `vars:`), task-local (in
+    `tasks.X.vars:`), or passed from an include. Changing scope can break
+    task behavior.
 
-Reference the go-taskfile-standards.md for details. Brief overview:
+# WORKFLOW
 
-| Component | Purpose |
-|----------|---------|
-| `version` | Taskfile format version |
-| `includes` | Namespaced task groups |
-| `vars` | Global variables and computed values |
-| `env` | Global environment variables |
-| `tasks` | Task definitions, deps, and commands |
-| `output` | Output mode preferences |
+Follow this sequence exactly. Do not skip steps.
 
-# OUTPUT INSTRUCTIONS
+## Phase 1: Discover
 
-- Output a complete `Taskfile.yaml` that can be used directly
-- Use a YAML code block for the Taskfile
-- Include `desc` for any task intended for human use
-- Provide a `default` task when there is an obvious primary workflow
-- Prefer `sources`/`generates` with `method: checksum` when builds are involved
-- Use `platforms` for OS-specific commands or provide alternatives
-- Keep commands minimal, explicit, and aligned with the user's toolchain
-- If critical information is missing, state explicit assumptions
-- Omit any section (Notes/Assumptions) that would be empty
+1. Run `Glob` with pattern `**/Taskfile.yaml` and `**/Taskfile.yml` to find
+   all Taskfile configurations.
+2. Also check for `**/Taskfile.*.yaml` includes.
+3. Read the reference documents from the references directory.
+
+## Phase 2: Analyze
+
+4. Run `task --list` via Bash to verify the Taskfile parses correctly.
+5. Read each Taskfile identified in Phase 1.
+6. Cross-reference between files - check that includes, variable passing, and
+   task references are consistent.
+7. Catalog every violation with:
+   - Severity (CRITICAL, HIGH, MEDIUM, LOW, INFO)
+   - Category (from the review categories below)
+   - File and line number
+   - Description of what's wrong
+   - Proposed fix
+
+## Phase 3: Fix and Verify
+
+8. Apply fixes via the Edit tool, highest severity first.
+9. Group fixes by file to minimize Edit calls.
+10. After each batch of edits to a file, Read ONLY the edited lines back
+    (not the whole file) and verify the old content was fully replaced.
+11. After ALL fixes are applied, run `task --list` to verify the Taskfile
+    still parses correctly.
+12. If parsing fails, revert the offending edit with `git checkout -- <file>`
+    and move the finding to the skipped table.
+
+## Phase 4: Report
+
+13. Output the final report using the OUTPUT FORMAT below IMMEDIATELY.
+    Populate the skipped-findings table from your Phase 2 notes - do NOT
+    re-read files or run extra tool calls to gather skipped-finding details.
+
+# REVIEW CATEGORIES
+
+1. **Structure** - version field, schema comment, file organization
+2. **Variables** - declaration, scoping, hardcoded values, secrets
+3. **Task Design** - naming, desc, summary, preconditions
+4. **Commands** - execution, chaining, multi-line, silent mode
+5. **Dependencies** - ordering, circular deps, parallel vs sequential
+6. **Error Handling** - preconditions, status checks, ignore_error usage
+7. **Security** - secrets, input validation, path safety
+8. **Includes** - external taskfiles, variable passing, remote includes
+9. **Output** - logging, echo, silent mode usage
+
+# SEVERITY LEVELS
+
+- **CRITICAL**: Security issues, syntax errors that break parsing
+- **HIGH**: Missing required elements, hardcoded values, no error handling
+- **MEDIUM**: Best practice violations, inconsistent naming
+- **LOW**: Minor improvements, style consistency
+- **INFO**: Suggestions for optimization
+
+# WHAT TO FIX
+
+These are the anti-patterns you MUST fix when found:
+
+- Missing `version: "3"` field - Taskfile schema undefined
+- Missing `desc:` on tasks - breaks `task --list` usability
+- Hardcoded paths or values that should be variables
+- Hardcoded secrets or credentials - CRITICAL security issue
+- Missing preconditions for required inputs - confusing failures
+- Unquoted template variables - YAML parsing errors
+- Complex inline scripts without explanation - extract or document
+- Duplicate command patterns - extract to shared task
+- Missing `silent: true` on runner/agent tasks - noisy output
+- Inconsistent task naming conventions
+- Missing schema comment - no IDE validation
+- Circular task dependencies - infinite loops
+- Commands that fail silently without error handling
+
+# HOW TO FIX - CORRECT PATTERNS
+
+- **Missing version:** Add `version: "3"` at the top after the YAML header
+- **Missing desc:** Add `desc: "Brief description of task purpose"`
+- **Hardcoded values:** Extract to `vars:` section with meaningful name
+- **Hardcoded secrets:** Replace with `'{{.SECRET_VAR | default ""}}'` and
+  add precondition to validate it's set
+- **Missing preconditions:** Add validation for required inputs:
+
+  ```yaml
+  preconditions:
+    - sh: test -n "{{.REQUIRED_VAR}}"
+      msg: "REQUIRED_VAR is required"
+  ```
+
+- **Unquoted templates:** Quote the value: `VAR: '{{.OTHER_VAR}}'`
+- **Missing silent:** Add `silent: true` to tasks that run other programs
+- **Inconsistent naming:** Use lowercase with colons: `namespace:action`
+
+# WHAT NOT TO FIX
+
+Skip these entirely - do not report them, do not fix them:
+
+- Comment formatting or style
+- Whitespace or indentation preferences (if valid YAML)
+- Variable or task naming style (unless actively misleading or inconsistent
+  with the rest of the file)
+- Adding optional fields like `summary:` when `desc:` is adequate
+- Reordering tasks or variables for aesthetic reasons
+- Adding unnecessary preconditions for unlikely edge cases
+- Changes requiring new external dependencies
+- Restructuring that would change task behavior without clear benefit
 
 # OUTPUT FORMAT
 
-## Taskfile.yaml
+**CRITICAL**: Your output MUST follow this exact structure. An automated
+validator checks for these sections.
 
-```yaml
-version: '3'
+## Changes Summary
 
-# Optional settings
-output: prefixed
+[Brief overview of what was changed and why - 2-3 sentences max]
 
-vars:
-  # Global variables
+## Issues Found and Fixed
 
-env:
-  # Global environment variables
+### [Issue Title]
 
-tasks:
-  default:
-    desc: [Primary task description]
-    cmds:
-      - task: [primary:task]
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
 
-  [task:name]:
-    desc: [Task description]
-    cmds:
-      - [command]
-```
+**What was changed:**
+[1-2 sentences describing the change]
 
-## Notes
+**Why:**
+[1-2 sentences referencing best practices]
 
-- [Key design decision or usage tip]
+---
 
-## Assumptions
+## Issues Found but Skipped
 
-- [Explicit assumption about tooling, paths, or platforms]
+| Issue | Severity | File | Reason Skipped |
+|-------|----------|------|----------------|
+| [title] | [sev] | [file] | [why: too risky, externally referenced, etc.] |
 
-# IMPORTANT CONSTRAINTS
+## Files Touched
 
-- **DO NOT** invent tools or commands not implied by the input
-- **DO NOT** include placeholder tasks or empty sections
-- **DO NOT** use shell-specific commands without `platforms`
-- **ALWAYS** keep YAML valid and consistently indented (2 spaces)
-- **ALWAYS** apply cross-platform and change-detection guidance
-- **ALWAYS** follow the knowledge base standards
+- `path/to/Taskfile.yaml` - [specific change description]
+
+## Validation
+
+- `task --list`: PASS/FAIL
 
 # INPUT
 
-Project context and desired tasks, including:
-
-- Primary workflows (build, test, lint, release, etc.)
-- Tooling and commands already in use
-- Platforms to support
-- Repo structure or subprojects
-- Existing Taskfile content (if any)
+Taskfile configurations to review and fix:

--- a/agents/go-taskfile/system.md
+++ b/agents/go-taskfile/system.md
@@ -166,6 +166,10 @@ These are the anti-patterns you MUST fix when found:
 - Missing schema comment - no IDE validation
 - Circular task dependencies - infinite loops
 - Commands that fail silently without error handling
+- User-controlled paths in dangerous commands (rm -rf, chmod, etc.) without
+  validation - path traversal risk. **Only flag if the variable has no default
+  or an unsafe default.** Variables with safe defaults like `/tmp` are LOW
+  priority - skip unless the variable is explicitly documented as user input.
 
 # HOW TO FIX - CORRECT PATTERNS
 
@@ -185,6 +189,16 @@ These are the anti-patterns you MUST fix when found:
 - **Unquoted templates:** Quote the value: `VAR: '{{.OTHER_VAR}}'`
 - **Missing silent:** Add `silent: true` to tasks that run other programs
 - **Inconsistent naming:** Use lowercase with colons: `namespace:action`
+- **User-controlled paths:** Add precondition to validate paths don't traverse,
+  but ONLY if the variable lacks a safe default:
+
+  ```yaml
+  # Only add this if the variable has no default or an unsafe default
+  # Skip if the variable defaults to a safe path like /tmp
+  preconditions:
+    - sh: echo "{{.USER_PATH}}" | grep -qv '\.\.'
+      msg: "USER_PATH cannot contain path traversal (..)"
+  ```
 
 # WHAT NOT TO FIX
 
@@ -197,6 +211,8 @@ Skip these entirely - do not report them, do not fix them:
 - Adding optional fields like `summary:` when `desc:` is adequate
 - Reordering tasks or variables for aesthetic reasons
 - Adding unnecessary preconditions for unlikely edge cases
+- Path traversal validation for variables with safe defaults (e.g., `/tmp`) -
+  the threat model for local task runners doesn't justify the complexity
 - Changes requiring new external dependencies
 - Restructuring that would change task behavior without clear benefit
 


### PR DESCRIPTION

**Key Changes:**

- Introduced autonomous Taskfile review agent supporting both fix and readonly analyze modes
- Added best practices and standards references to guide Taskfile validation and repair
- Expanded Taskfile.yaml with new agent runner tasks for Taskfile review and analysis
- Updated agent documentation and metadata to reflect new capabilities and stricter compliance

**Added:**

- Taskfile best practices reference - `agents/go-taskfile/references/taskfile-best-practices.md` provides a comprehensive guide for Taskfile structure, variables, task design, security, and severity classification
- Read-only analysis agent wrapper and system prompt - `agents/go-taskfile/agent-readonly.md` and `system-readonly.md` enable non-destructive Taskfile analysis and structured reporting
- New Taskfile agent runner tasks - `Taskfile.yaml` gains `run:go-taskfile` and `run:go-taskfile-analyze` for automated fix and analyze modes, with output to configurable directories
- Out directory variable - `Taskfile.yaml` now supports `OUT_DIR` for flexible report file locations

**Changed:**

- Expanded agent documentation - `agents/go-taskfile/README.md` now details fix vs. analyze modes, review criteria, severity levels, and output expectations
- Enhanced agent metadata - `agents/go-taskfile/agent.yaml` updated to version 0.2.0, with new description, references to best practices, and explicit readonly mode support
- System prompt overhaul for review agent - `agents/go-taskfile/system.md` rewritten to enforce deep, proportional, and safe Taskfile repairs with step-by-step workflow and strict output validation
- Taskfile task improvements - `Taskfile.yaml` now uses conditional API key flag, improved output file path handling, and dynamic variable passing for includes (`BINARY_NAME`, `CMD_PATH`)
- Output file handling - All agent outputs in `Taskfile.yaml` now use `OUT_DIR` for consistency and safety

**Removed:**

- Hardcoded API key default - `Taskfile.yaml` no longer defaults `API_KEY` to "ollama", reducing risk of accidental secret leakage
- Hardcoded temp output paths - All output paths in `Taskfile.yaml` now use `OUT_DIR` instead of `/tmp`, centralizing output management