### PR TITLE
feat: add autonomous python docstring agent with task automation and documentation

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: 1.25.6
+  GO_VERSION: 1.25.7
 
 jobs:
   goreleaser:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.6
+  GO_VERSION: 1.25.7
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,7 +34,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.25.6
+  GO_VERSION: 1.25.7
   PYTHON_VERSION: 3.13.3
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.25.6
+  GO_VERSION: 1.25.7
 
 permissions:
   actions: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-shebang-scripts-are-executable
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         entry: yamllint --strict -c .hooks/linters/yamllint.yaml
@@ -60,7 +60,7 @@ repos:
 
   # Github actions
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.9
+    rev: v1.7.10
     hooks:
       - id: actionlint
         name: Check Github Actions

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 - Update docs
 - Document process to create new agents - make sure it's relavtively easy and painless
 - Make agents as easy as warpgate templates
+- Show time elapsed for running an agent at end and number of tokens + cost analysis based on model used

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -761,6 +761,131 @@ tasks:
           --out {{.OUT_DIR}}/squad-python-tests-analysis.txt
       - echo "Python coverage analysis written to {{.OUT_DIR}}/squad-python-tests-analysis.txt"
 
+  run:python-doc-comments:
+    desc: "Run the python-doc-comments agent to autonomously add/improve Python docstrings"
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Add or improve docstrings on all public Python declarations in this codebase.
+
+        Start by using Glob with '**/*.py' to discover all Python source files.
+        Batch Read calls: read 4-6 files per iteration. Do NOT read one file per iteration.
+        Catalog every public declaration that is missing a docstring or has a deficient one.
+        Apply fixes via Edit tool, highest priority first.
+        Run 'python -m py_compile <files>' after each batch of edits.
+
+        IMPORTANT CONSTRAINTS (repeat from system prompt):
+        - ONLY modify docstrings — never change code logic, signatures, or imports
+        - Triple double quotes — always use \"\"\" for docstrings, never '''
+        - Start with summary line in imperative mood ('Return X' not 'Returns X')
+        - No blank line before docstring — docstring immediately follows def/class
+        - Complete sentences with proper punctuation
+        - Focus on WHAT, not HOW — no implementation details
+        - No redundant docstrings ('Process processes the data' = skip)
+        - SKIP trivial functions: close, get_value, simple wrappers — they need NO docstring
+        - Key test: 'Does this docstring tell the reader something the name does not?' If no → skip
+        - Proportional: one-line getter = one-line docstring, complex = multi-paragraph
+        - Public declarations only — skip private names (_foo)
+        - Match existing style (NumPy/Sphinx if present, else Google style)
+        - NEVER add -> None — it's always inferable
+
+        ITERATION BUDGET — scales with codebase size (count after Glob):
+        - Small (≤20 files): 12 iterations max
+        - Medium (21-50 files): 20 iterations max
+        - Large (50+ files): 25 iterations max
+
+        Phase allocation:
+        - Phase 1 (1 iter): Glob + Read reference in parallel, COUNT source files
+        - Phase 2 (varies): Read files with 4-6 parallel Reads per iteration
+        - Phase 3 (2-4 iter): ALL Edit calls batched (10 fixes = 10 Edit calls in ONE response)
+        - Phase 4 (1 iter): Verify + report in SAME response
+
+        Do NOT hardcode directory names like app/, src/, lib/ — use Glob output.
+        COVERAGE IS MANDATORY for small/medium. For large codebases, document sampling.
+
+        HARD REQUIREMENTS:
+        - Do NOT read one file per iteration — batch 4-6 Read calls per iteration
+        - Do NOT edit-wait-edit-wait — batch ALL edits into ONE iteration
+        - Do NOT re-read files after editing — trust Edit output
+        - STOP after verification — emit report in SAME response, NO more iterations
+        - If ruff not installed, proceed with py_compile only
+        - Every file touched must appear in the output report" \
+          --agent python-doc-comments \
+          --working-dir {{.WORKING_DIR}} \
+          {{._API_KEY_FLAG}} \
+          --provider {{.PROVIDER}} \
+          {{._BASE_URL_FLAG}} \
+          --model {{.MODEL}} \
+          --require-actionable=true \
+          --temperature 0.3 \
+          --out {{.OUT_DIR}}/squad-python-doc-comments.txt
+      - echo "Python doc comments output written to {{.OUT_DIR}}/squad-python-doc-comments.txt"
+      - |
+        echo ""
+        echo "Running final verification..."
+      - cd {{.WORKING_DIR}} && python -m py_compile $(find . -name "*.py" -not -path "*/__pycache__/*" -not -path "*/.venv/*" -not -path "*/venv/*" -not -name "test_*.py" 2>/dev/null | head -20) 2>/dev/null || true
+      - echo "Verification complete"
+
+  run:python-doc-comments-analyze:
+    desc: "Run the python-doc-comments agent in readonly mode to analyze docstring gaps without applying fixes"
+    silent: true
+    cmds:
+      - |
+        go run ./cmd/squad run -v \
+          "Analyze this codebase for missing or deficient Python docstrings.
+
+        Use Glob with '**/*.py' to discover all Python source files.
+        Batch Read calls: read 4-6 files per iteration. Do NOT read one file per iteration.
+        Catalog every public declaration that needs a docstring.
+        Produce a prioritized report of all findings.
+
+        ANALYSIS CHECKLIST (check each file for these):
+        - Public functions/methods — do they have docstrings? (HIGH if missing on complex)
+        - Public classes — do they have docstrings with Attributes section? (HIGH if missing)
+        - Modules — do they have module docstrings? (MEDIUM if missing)
+        - Existing docstrings — are they complete sentences? (MEDIUM if fragments)
+        - Existing docstrings — do they use imperative mood? (LOW if not)
+        - Complex functions — do they have Args/Returns/Raises? (LOW if missing)
+
+        SEVERITY GUIDE:
+        - HIGH: missing docstring on complex public function/class
+        - MEDIUM: missing docstring on simpler exports, format violations
+        - LOW: improvement opportunities (missing Args/Returns, could use examples)
+
+        WHAT TO SKIP:
+        - Private names (_foo) — don't need docstrings
+        - Trivial functions (close, get_value, wrappers) — name is the doc
+        - -> None return annotations — always inferable, NEVER report as missing
+
+        No cosmetic findings — skip import ordering, naming style.
+        No false positives — every finding must reference actual file and line.
+
+        ITERATION BUDGET — scales with codebase size (count after Glob):
+        - Small (≤20 files): 12 iterations max
+        - Medium (21-50 files): 20 iterations max
+        - Large (50+ files): 25 iterations max
+
+        EFFICIENCY (must follow):
+        - Batch reads: 4-6 files per iteration, not one file per iteration
+        - Do NOT hardcode directory names like app/, src/ — use Glob output
+        - Small/medium: read ALL files. Large: prioritize entry points + core modules
+        - Use ONE Grep/Glob on repo root — do NOT run per-directory searches
+        - After analysis is complete, emit report IMMEDIATELY — no re-reading files
+
+        Do NOT write or modify any files." \
+          --agent python-doc-comments --mode readonly \
+          --working-dir {{.WORKING_DIR}} \
+          {{._API_KEY_FLAG}} \
+          --provider {{.PROVIDER}} \
+          {{._BASE_URL_FLAG}} \
+          --model {{.MODEL}} \
+          --require-actionable=false \
+          --temperature 0.3 \
+          --print=false \
+          --out {{.OUT_DIR}}/squad-python-doc-comments-analysis.txt
+      - echo "Python doc comments analysis written to {{.OUT_DIR}}/squad-python-doc-comments-analysis.txt"
+
   clean:
     desc: Clean build artifacts and temp files
     cmds:

--- a/agents/python-doc-comments/README.md
+++ b/agents/python-doc-comments/README.md
@@ -1,0 +1,141 @@
+# python-doc-comments
+
+Autonomous Python documentation agent that discovers public declarations, adds
+or improves docstrings following PEP 257 and Google Style conventions, and
+verifies linting passes.
+
+## Overview
+
+This agent specializes in creating high-quality Python documentation that
+follows:
+
+- [PEP 257](https://peps.python.org/pep-0257/) — Docstring Conventions
+- [PEP 8](https://peps.python.org/pep-0008/) — Style Guide for Python Code
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+- [PEP 484](https://peps.python.org/pep-0484/) — Type Hints
+
+## Modes
+
+### Normal (edit) mode
+
+Discovers all Python source files, catalogs missing or deficient docstrings on
+public declarations, applies fixes, verifies linting, and reports results.
+
+```bash
+task run:python-doc-comments WORKING_DIR=/path/to/repo
+task run:python-doc-comments WORKING_DIR=/path/to/repo MODEL=gpt-4o PROVIDER=openai
+```
+
+### Readonly (analysis) mode
+
+Produces a prioritized report of docstring gaps without modifying any files.
+
+```bash
+task run:python-doc-comments-analyze WORKING_DIR=/path/to/repo
+task run:python-doc-comments-analyze WORKING_DIR=/path/to/repo MODEL=gpt-4o PROVIDER=openai
+```
+
+## What Gets Documented
+
+The agent documents all public (non-underscore) declarations:
+
+- **Modules** — First statement describing module purpose
+- **Classes** — What instances represent, Attributes section
+- **Functions/Methods** — Summary, Args, Returns, Raises sections
+- **Properties** — What the property represents
+- **Constants** — Purpose and valid values
+
+## What Gets Skipped
+
+- Private (leading underscore) functions/methods/classes
+- Code logic, signatures, or behavior (only docstrings are modified)
+- Test files (`test_*.py`, `*_test.py`) and virtual environments
+- Trivial functions where a docstring would just restate the name
+- `-> None` return annotations (always inferable)
+- `__pycache__` directories
+
+## Hard Rules
+
+Key constraints that prevent common failure modes:
+
+1. **Only modify docstrings** — never change code logic
+2. **Triple double quotes** — always use `"""`, never `'''`
+3. **Start with summary line** — imperative mood for functions
+4. **No blank line before docstring** — immediately follows def/class
+5. **Complete sentences** — fragments are not docstrings
+6. **No redundant docstrings** — "Process processes the data" = skip
+7. **Proportional** — match docstring length to function complexity
+8. **Focus on WHAT, not HOW** — no implementation details
+9. **Match existing style** — NumPy/Sphinx if present, else Google
+10. **NEVER add `-> None`** — it's always inferable
+
+## Output Format
+
+### Normal mode
+
+- Changes Summary
+- Docstrings Added (with file, line, category, docstring, reason)
+- Docstrings Improved (with before/after)
+- Declarations Skipped (table with reasons)
+- Files Touched
+- Validation (`python -m py_compile`, `ruff check`)
+
+### Readonly mode
+
+- Analysis Summary (files analyzed, finding counts by severity)
+- Findings (with severity, category, file, line, suggested docstring)
+- Priority Order (ranked by impact)
+- Recommendations
+
+## Docstring Styles
+
+### Google Style (Default)
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Args:
+        arg1: Description of arg1.
+        arg2: Description of arg2.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ValueError: When validation fails.
+    """
+    pass
+```
+
+### NumPy Style
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of arg1.
+    arg2 : str
+        Description of arg2.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+    """
+    pass
+```
+
+## Reference
+
+See [references/python-documentation-standards.md](references/python-documentation-standards.md)
+for the complete knowledge base covering PEP 257, docstring styles, comment
+rules, type hints, codetags, linter directives, and quality checklist.
+
+## Related Agents
+
+- **python-review** — review Python code for best practices
+- **python-tests** — generate Python tests

--- a/agents/python-doc-comments/agent-readonly.md
+++ b/agents/python-doc-comments/agent-readonly.md
@@ -1,0 +1,37 @@
+# AGENT MODE — READONLY
+
+You are a Python documentation analysis agent. You discover code, analyze
+docstring gaps, and produce a prioritized report — all without human guidance.
+You MUST NOT modify any files.
+
+# EXECUTION RULES
+
+- **Read-only.** Do NOT use Edit or Write tools. This is an analysis run only.
+- **Discover first.** Use Glob to find all `**/*.py` files, filter out
+  `__pycache__/`, `.venv/`, `test_*.py`, then Read each source file.
+- **Batch reads.** Read 4-6 files per iteration.
+- **Public declarations only.** Only report on public (no leading underscore)
+  functions, classes, and methods.
+- **No redundant findings.** If a declaration has a good docstring, skip it.
+- **Skip trivial.** If a meaningful docstring would just restate the signature
+  (e.g., `close`, `get_value`), note as trivial and skip.
+- **Include file and line.** Every finding needs exact location.
+- **Match existing style.** If codebase uses NumPy or Sphinx style, note that
+  suggested docstrings should match.
+- **NEVER report `-> None` as missing.** It's always inferable.
+- **Efficient iterations.** Target ≤12 iterations for small codebases.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from system-readonly.md.
+The report MUST include ALL of these sections:
+
+1. `## Analysis Summary` — Files analyzed, total findings, by severity
+2. `## Findings` — each with Severity, Category, File, Line, What is wrong,
+   Suggested docstring
+3. `## Priority Order` — ranked list for fixing
+4. `## Recommendations` — 2-3 sentences on most impactful improvements
+
+# INPUT
+
+User request and any constraints.

--- a/agents/python-doc-comments/agent.md
+++ b/agents/python-doc-comments/agent.md
@@ -1,0 +1,67 @@
+# AGENT MODE
+
+You are an autonomous Python documentation agent. You discover code, analyze
+docstring gaps, add or improve docstrings, and verify the result passes linting
+— all without human guidance.
+
+# EXECUTION RULES
+
+- **Discover first.** Use Glob to find all `**/*.py` files, filter out
+  `__pycache__/`, `.venv/`, `test_*.py`, then Read each source file. Never
+  guess at file contents.
+- **Batch reads.** Read 4-6 files per iteration. Do NOT read one file per
+  iteration — that wastes your iteration budget.
+- **Only modify docstrings.** Never change code logic, function signatures,
+  variable values, or import statements. Every edit must be a docstring
+  addition or improvement. If you accidentally change code, revert with
+  `git checkout -- <file>`.
+- **Verify after every batch.** Run `python -m py_compile <files>` and
+  `ruff check <files>` after editing files. If ruff is NOT installed, proceed
+  with py_compile only — do NOT retry ruff.
+- **Triple double quotes.** Always use `"""` for docstrings, never `'''`.
+- **Start with summary line.** Imperative mood for functions ("Return X" not
+  "Returns X"), descriptive for classes.
+- **No blank line before docstring.** Docstring immediately follows `def`/`class`.
+- **Complete sentences.** Fragments are not docstrings.
+- **Focus on WHAT, not HOW.** Explain what a function does, not its
+  internal implementation.
+- **No redundant docstrings.** "Process processes the data" adds zero value.
+  Skip and note it if you cannot add meaningful information. Trivial functions
+  (close, get_value, simple wrappers) are almost always skip candidates.
+- **Proportional docstrings.** One-line getter = one-line docstring. Complex
+  function with options = multi-paragraph docstring with Args/Returns/Raises.
+- **Public declarations only.** Skip private names (`_foo`) entirely.
+- **Match existing style.** If codebase uses NumPy or Sphinx style, match it.
+  Otherwise use Google style.
+- **NEVER add `-> None`.** It's always inferable. Only add return type hints
+  for non-obvious types.
+- **Be efficient with iterations.** Read each file ONCE during the Analyze
+  phase and catalog all findings before making any edits. Do not re-read files
+  you have already analyzed. Target ≤12 iterations for a small codebase
+  (≤20 files).
+- **Efficient tool calls.** Use one Grep/Glob on the repo root, not N calls
+  per-directory. Every tool call costs an iteration.
+- **No post-fix exploration.** Once fixes are applied and verification passes,
+  go STRAIGHT to the report. Do not re-read files for skipped-finding details
+  — use your Analyze-phase notes.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from system.md. Do NOT
+write a freeform summary. The report MUST include ALL of these sections in
+order:
+
+1. `## Changes Summary` — 2-3 sentence overview
+2. `## Docstrings Added` — each with File, Line, Category, Docstring, Why
+3. `## Docstrings Improved` — each with File, Line, Before, After, Why
+4. `## Declarations Skipped` — table with Declaration, File, Reason
+5. `## Files Touched` — every file modified with change description
+6. `## Validation` — py_compile and ruff results
+
+An automated validator checks for "files touched" or "no changes"
+(case-insensitive). Missing both = pipeline failure. Missing the Validation
+section = pipeline failure.
+
+# INPUT
+
+User request and any constraints.

--- a/agents/python-doc-comments/agent.yaml
+++ b/agents/python-doc-comments/agent.yaml
@@ -1,0 +1,12 @@
+---
+name: python-doc-comments
+version: 0.2.0
+description: Autonomous Python documentation agent that discovers public declarations, adds or improves docstrings following PEP 257 and Google Style, and verifies linting passes.
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - references/python-documentation-standards.md
+modes:
+  readonly:
+    entrypoint: system-readonly.md
+    wrapper: agent-readonly.md

--- a/agents/python-doc-comments/references/python-documentation-standards.md
+++ b/agents/python-doc-comments/references/python-documentation-standards.md
@@ -1,0 +1,739 @@
+# Python Documentation Standards
+
+A comprehensive guide to Python documentation following PEP 8, PEP 257, and modern best practices. This document serves as the knowledge base for the python-doc-comments pattern.
+
+## Table of Contents
+
+1. [Core Principles](#core-principles)
+2. [Docstrings (PEP 257)](#docstrings-pep-257)
+3. [Comments (PEP 8)](#comments-pep-8)
+4. [Type Hints](#type-hints)
+5. [Codetags](#codetags)
+6. [Magic Comments](#magic-comments)
+7. [Linter Directives](#linter-directives)
+8. [Common Mistakes](#common-mistakes)
+9. [Quality Checklist](#quality-checklist)
+
+---
+
+## Core Principles
+
+### The Golden Rules
+
+| Principle            | Description                               |
+| -------------------- | ----------------------------------------- |
+| Triple double quotes | Always use `"""` for docstrings           |
+| Complete sentences   | Proper capitalization and punctuation     |
+| Explain "why"        | Code shows "what", comments explain "why" |
+| User focus           | Document for users, not implementation    |
+| Synchronize          | Outdated comments are worse than none     |
+| Use sparingly        | Prefer clear code over excessive comments |
+
+### Philosophy
+
+- **Self-documenting code** is the first priority
+- Comments should add value, not state the obvious
+- Type hints complement docstrings, not replace them
+- Professional tone in all documentation
+
+---
+
+## Docstrings (PEP 257)
+
+Docstrings become the `__doc__` attribute of modules, functions, classes, and methods.
+
+### One-Line Docstrings
+
+For simple, obvious cases:
+
+```python
+def kos_root():
+    """Return the pathname of the KOS root directory."""
+    global _kos_root
+    return _kos_root
+```
+
+**Rules:**
+
+- Closing quotes on the **same line**
+- **Imperative mood**: "Return X" not "Returns X"
+- End with a **period**
+- No blank lines before or after
+
+### Multi-Line Docstrings
+
+For complex documentation:
+
+```python
+def complex(real=0.0, imag=0.0):
+    """Form a complex number.
+
+    Keyword arguments:
+    real -- the real part (default 0.0)
+    imag -- the imaginary part (default 0.0)
+    """
+    if imag == 0.0 and real == 0.0:
+        return complex_zero
+```
+
+**Structure:**
+
+1. Summary line (fits on one line)
+2. Blank line
+3. Detailed description
+4. Closing quotes on **separate line**
+
+### Module Docstrings
+
+```python
+"""A one-line summary of the module, terminated by a period.
+
+Leave a blank line. The rest of this docstring should contain an
+overall description of the module. Optionally, it may also contain
+a brief description of exported classes and functions.
+
+Typical usage example:
+
+    foo = ClassFoo()
+    bar = foo.function_bar()
+"""
+
+import os
+import sys
+```
+
+**Placement:**
+
+- Must be the **first statement** in the module
+- Comes **after** magic comments (shebang, encoding)
+- Comes **before** imports
+
+### Function/Method Docstrings (Google Style)
+
+```python
+def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
+    """Fetch rows from a Bigtable.
+
+    Retrieve rows pertaining to the given keys from the Table instance
+    represented by big_table.
+
+    Args:
+        big_table: An open Bigtable Table instance.
+        keys: A sequence of strings representing the key of each table
+            row to fetch.
+        other_silly_variable: Another optional variable, that has a much
+            longer name than the other args.
+
+    Returns:
+        A dict mapping keys to the corresponding table row data fetched.
+        Each row is represented as a tuple of strings. For example:
+
+        {'Serak': ('Rigel VII', 'Preparer'),
+         'Zim': ('Irk', 'Invader')}
+
+    Raises:
+        IOError: An error occurred accessing the bigtable.Table object.
+    """
+    pass
+```
+
+**Sections:**
+
+| Section | Purpose                                |
+| ------- | -------------------------------------- |
+| Args    | List each parameter with description   |
+| Returns | Describe the return value and its type |
+| Yields  | For generators                         |
+| Raises  | Document exceptions that may be raised |
+
+### Class Docstrings
+
+```python
+class SampleClass:
+    """Summary of class here.
+
+    Longer class information and detailed description.
+
+    Attributes:
+        likes_spam: A boolean indicating if we like SPAM or not.
+        eggs: An integer count of the eggs we have laid.
+    """
+
+    def __init__(self, likes_spam=False):
+        """Initialize the instance based on spam preference.
+
+        Args:
+            likes_spam: Defines if instance exhibits this preference.
+        """
+        self.likes_spam = likes_spam
+        self.eggs = 0
+```
+
+**Key Points:**
+
+- Summarize what instances represent
+- List public attributes in **Attributes** section
+- Document `__init__` separately
+
+### Docstring Styles Comparison
+
+**Google Style** (recommended):
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Args:
+        arg1: Description of arg1.
+        arg2: Description of arg2.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ValueError: When validation fails.
+    """
+    pass
+```
+
+**NumPy Style** (scientific computing):
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of arg1.
+    arg2 : str
+        Description of arg2.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+
+    Raises
+    ------
+    ValueError
+        When validation fails.
+    """
+    pass
+```
+
+**Sphinx/reStructuredText Style**:
+
+```python
+def function(arg1: int, arg2: str) -> bool:
+    """Summary line.
+
+    :param arg1: Description of arg1
+    :type arg1: int
+    :param arg2: Description of arg2
+    :type arg2: str
+    :return: Description of return value
+    :rtype: bool
+    :raises ValueError: When validation fails
+    """
+    pass
+```
+
+---
+
+## Comments (PEP 8)
+
+### Block Comments
+
+Block comments apply to code that follows them.
+
+```python
+# Filter out inactive users and sort by registration date.
+# This is necessary because the database query doesn't
+# guarantee ordering for performance reasons.
+active_users = [u for u in users if u.is_active]
+return sorted(active_users, key=lambda u: u.registered_at)
+```
+
+**Rules:**
+
+- Start with `#` followed by a single space
+- Indent to the same level as the code
+- Separate paragraphs with a line containing only `#`
+
+### Inline Comments
+
+Inline comments appear on the same line as code. Use sparingly.
+
+```python
+# Good: Explains non-obvious reasoning
+x = x + 1  # Compensate for border offset in rendering
+
+# Good: Clarifies business logic
+discount = 0.9  # 10% discount for premium members
+
+# Bad: States the obvious
+x = x + 1  # Increment x
+```
+
+**Rules:**
+
+- Separate from code by **at least 2 spaces**
+- Start with `#` and a single space
+- Maximum **72 characters** recommended
+- Use sparingly - only when adding real value
+
+### When Comments Add Value
+
+```python
+# Explains business logic
+discount = 0.25 if user.is_grandfathered else 0.20
+
+# Warns about gotchas
+# Note: This modifies the list in-place
+items.sort()
+
+# Documents performance implications
+# Using dict lookup O(1) instead of list search O(n)
+user_map = {user.id: user for user in users}
+
+# Explains non-obvious algorithms
+# Boyer-Moore voting algorithm - O(n) time, O(1) space
+candidate = None
+```
+
+---
+
+## Type Hints
+
+Type hints complement docstrings by providing static type information.
+
+### Basic Types
+
+```python
+def greeting(name: str) -> str:
+    """Return a greeting message."""
+    return f'Hello {name}'
+```
+
+### Complex Types
+
+```python
+from typing import List, Dict, Optional, Union
+
+def process_items(
+    items: List[str],
+    config: Optional[Dict[str, Union[str, int]]] = None
+) -> List[Dict[str, str]]:
+    """Process items with optional configuration.
+
+    Args:
+        items: List of item names to process.
+        config: Optional configuration dictionary.
+
+    Returns:
+        List of processed item dictionaries.
+    """
+    pass
+```
+
+### Modern Python (3.10+)
+
+```python
+def process(items: list[str], config: dict[str, str | int] | None = None) -> list[dict[str, str]]:
+    """Process items with optional configuration."""
+    pass
+```
+
+### Key Points
+
+| Aspect          | Description                         |
+| --------------- | ----------------------------------- |
+| Static analysis | Used by mypy, pyright, IDEs         |
+| Documentation   | Human-readable, stays in code       |
+| Runtime         | Type hints don't enforce at runtime |
+| Combination     | Use both type hints AND docstrings  |
+
+---
+
+## Codetags
+
+Standardized annotations that flag code requiring attention.
+
+### Common Tags
+
+| Tag     | Purpose                  | Example                           |
+| ------- | ------------------------ | --------------------------------- |
+| `TODO`  | Pending tasks            | `# TODO: Add input validation`    |
+| `FIXME` | Code needing fixes       | `# FIXME: Memory leak in loop`    |
+| `XXX`   | Synonym for FIXME        | `# XXX: This breaks with unicode` |
+| `BUG`   | Known defects            | `# BUG: Tracked as JIRA-456`      |
+| `HACK`  | Temporary workarounds    | `# HACK: Works around API bug`    |
+| `NOTE`  | Important clarifications | `# NOTE: Requires Python 3.8+`    |
+
+### Format with Metadata
+
+```python
+# TODO: Refactor this function. <JD d:2026-01-15 p:2>
+def legacy_code():
+    pass
+
+# FIXME: Memory leak in loop. <AS t:JIRA-789 p:1>
+def leaky_function():
+    pass
+```
+
+**Metadata Fields:**
+
+- `<initials>` - Owner/author
+- `d:date` - Due date (ISO 8601)
+- `p:0-3` - Priority (0=highest)
+- `t:id` - Tracker reference
+
+### Best Practices
+
+1. Include ownership (initials or name)
+2. Add context (ticket numbers, due dates)
+3. Be specific about the problem
+4. For serious issues, create tickets in issue tracker
+5. Keep TODOs temporary - fix or move to tracker
+
+---
+
+## Magic Comments
+
+Special comments that provide instructions to the interpreter.
+
+### Shebang Line
+
+```python
+#!/usr/bin/env python3
+```
+
+**Rules:**
+
+- Must be the **first line**
+- `#!/usr/bin/env python3` is portable (uses PATH)
+- Only needed for executable scripts
+
+### Encoding Declaration (PEP 263)
+
+```python
+# -*- coding: utf-8 -*-
+```
+
+**Rules:**
+
+- Must be on first or second line
+- Usually **unnecessary** (UTF-8 is default in Python 3)
+- Required only for non-UTF-8 encodings
+
+### Complete File Header
+
+```python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Module docstring comes after magic comments.
+
+This is the proper order for file headers in Python.
+"""
+
+import os
+import sys
+```
+
+---
+
+## Linter Directives
+
+Special comments to control static analysis tools.
+
+### Type Checking (mypy, pyright)
+
+```python
+# type: ignore
+result = some_untyped_function()  # type: ignore
+
+# Specific error
+value = process(wrong_type)  # type: ignore[arg-type]
+```
+
+### Style Checking (flake8)
+
+```python
+# noqa
+long_line = "Very long line"  # noqa
+
+# Specific rule
+another_long_line = "Long line"  # noqa: E501
+
+# Unused import
+from module import unused  # noqa: F401
+```
+
+### Linting (pylint)
+
+```python
+# pylint: disable=line-too-long
+very_long_line = "Intentionally long"
+
+# pylint: disable=broad-except
+try:
+    risky()
+except Exception:  # pylint: disable=broad-except
+    handle()
+```
+
+### Code Coverage
+
+```python
+def debug_function():  # pragma: no cover
+    """Only used during development."""
+    print("Debug")
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+```
+
+### Formatting (black)
+
+```python
+# fmt: off
+matrix = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+]
+# fmt: on
+```
+
+### Best Practices for Directives
+
+1. Be specific - use exact error codes
+2. Add explanations - why ignoring?
+3. Minimize scope - apply to smallest section
+4. Review regularly - suppressed warnings may hide issues
+
+---
+
+## Common Mistakes
+
+### Redundant Comments
+
+**Bad:**
+
+```python
+x = x + 1  # Increment x
+name = "John"  # Set name to John
+```
+
+**Good:**
+
+```python
+x = x + 1  # Compensate for zero-based indexing
+```
+
+### Redundant Docstrings
+
+**Bad:**
+
+```python
+def add(a, b):
+    """Add two numbers.
+
+    This function takes two numbers and adds them together.
+    It returns the sum of a and b.
+    """
+    return a + b
+```
+
+**Good:**
+
+```python
+def add(a, b):
+    """Return the sum of a and b."""
+    return a + b
+```
+
+### Commented-Out Code
+
+**Bad:**
+
+```python
+def current():
+    # old_way()
+    # previous_version()
+    return new_way()
+```
+
+**Good:**
+
+```python
+def current():
+    return new_way()
+```
+
+### Lying Comments
+
+**Bad:**
+
+```python
+# Return the user's full name
+def get_username(user):
+    return user.email  # Actually returns email!
+```
+
+### Over-Commenting
+
+**Bad:**
+
+```python
+def process_order(order):
+    # Validate the order
+    if not order.is_valid():
+        # Raise exception if invalid
+        raise ValueError("Invalid order")
+
+    # Calculate the total
+    total = order.calculate_total()
+
+    # Return the final total
+    return total
+```
+
+**Good:**
+
+```python
+def process_order(order):
+    if not order.is_valid():
+        raise ValueError("Invalid order")
+    return order.calculate_total()
+```
+
+### Missing Type Context
+
+**Old way (duplicates type info):**
+
+```python
+def process_user(user):
+    """Process a user.
+
+    Args:
+        user (dict): User dictionary with 'id', 'name', 'email'
+
+    Returns:
+        bool: True if successful
+    """
+    pass
+```
+
+**Modern way (types in signature):**
+
+```python
+from typing import TypedDict
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: str
+
+def process_user(user: User) -> bool:
+    """Process a user and update the database."""
+    pass
+```
+
+---
+
+## Tools and Automation
+
+### Recommended Tools
+
+| Tool                                              | Purpose            |
+| ------------------------------------------------- | ------------------ |
+| [black](https://github.com/psf/black)             | Code formatting    |
+| [isort](https://github.com/PyCQA/isort)           | Import sorting     |
+| [mypy](https://github.com/python/mypy)            | Type checking      |
+| [pylint](https://github.com/pylint-dev/pylint)    | Linting            |
+| [flake8](https://github.com/PyCQA/flake8)         | Style checking     |
+| [pydocstyle](https://github.com/PyCQA/pydocstyle) | Docstring checking |
+
+### pyproject.toml Configuration
+
+```toml
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+strict = true
+
+[tool.pylint.messages_control]
+max-line-length = 88
+
+[tool.pydocstyle]
+convention = "google"
+```
+
+### Documentation Generators
+
+| Tool                                  | Description              |
+| ------------------------------------- | ------------------------ |
+| [Sphinx](https://www.sphinx-doc.org/en/master/) | Full documentation suite |
+| [MkDocs](https://www.mkdocs.org/)     | Markdown-based docs      |
+| [pdoc](https://pdoc.dev/)             | Auto-generated API docs  |
+
+---
+
+## Quality Checklist
+
+### Docstrings
+
+- [ ] Triple double quotes (`"""`)
+- [ ] All public modules, classes, and functions documented
+- [ ] One-line format for simple cases
+- [ ] Multi-line format with summary, blank line, details
+- [ ] Args, Returns, Raises sections for functions
+- [ ] Attributes section for classes
+- [ ] Imperative mood for one-liners
+
+### Comments
+
+- [ ] Block comments indented with code
+- [ ] Inline comments used sparingly (2+ spaces)
+- [ ] Explain "why" not "what"
+- [ ] No obvious or redundant comments
+- [ ] Complete sentences with proper grammar
+- [ ] Updated when code changes
+
+### Type Hints
+
+- [ ] Used for function parameters and returns
+- [ ] Complex types imported from `typing`
+- [ ] Complement docstrings, not replace them
+
+### Tool Integration
+
+- [ ] Linter directives used sparingly
+- [ ] Specific error codes when possible
+- [ ] Code formatted consistently
+
+### Code Quality
+
+- [ ] Code is self-documenting with clear names
+- [ ] No commented-out code
+- [ ] TODOs include context and ownership
+- [ ] Professional and respectful tone
+
+---
+
+## References
+
+- [PEP 8 - Style Guide for Python Code](https://peps.python.org/pep-0008/)
+- [PEP 257 - Docstring Conventions](https://peps.python.org/pep-0257/)
+- [PEP 263 - Source Code Encodings](https://peps.python.org/pep-0263/)
+- [PEP 350 - Codetags](https://peps.python.org/pep-0350/)
+- [PEP 484 - Type Hints](https://peps.python.org/pep-0484/)
+- [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+
+---
+
+_Last updated: 2026-01-11_

--- a/agents/python-doc-comments/system-readonly.md
+++ b/agents/python-doc-comments/system-readonly.md
@@ -1,0 +1,153 @@
+# IDENTITY and PURPOSE
+
+You are a Python documentation analysis agent specializing in docstring quality
+and correctness (2026). Your role is to analyze a Python codebase and produce a
+detailed, prioritized report of missing or deficient documentation (docstrings,
+type hints). You MUST NOT apply fixes — you only report findings.
+
+You do NOT wait for someone to hand you code. You discover it yourself using
+Glob, Read, and Grep.
+
+# KNOWLEDGE BASE
+
+You have access to `python-documentation-standards.md` in the references
+directory. Apply ALL relevant standards from that document.
+
+# HARD RULES — READ THESE FIRST
+
+These override everything else.
+
+1. **Read-only mode.** Do NOT use the Edit or Write tools. Do NOT modify any
+   files. If you use Edit or Write, the run is invalid.
+2. **Inspect actual code.** You MUST use Read and Grep to examine source files.
+   Do not guess at file contents or infer issues from file names alone.
+3. **Public declarations only.** Only report on public (no leading underscore)
+   functions, classes, and methods. Private names do not need docstrings.
+4. **No redundant findings.** If a declaration has a correct, well-formed
+   docstring, do not report it. Only report missing, incomplete, or incorrect
+   docstrings.
+5. **Include file and line.** Every finding must reference the exact file path
+   and line number.
+6. **Severity must be justified.** HIGH means complex public functions with no
+   docstring. MEDIUM means simpler exports or format violations. LOW means
+   improvement opportunities.
+7. **Skip trivial declarations.** If a meaningful docstring would just restate
+   the signature, note it as trivial and skip.
+
+# WORKFLOW
+
+Follow this sequence exactly. Do not skip steps.
+
+## Phase 1: Discover
+
+1. Run `Glob` with pattern `**/*.py` to find all Python source files.
+2. Filter out `__pycache__/`, `.venv/`, `venv/`, `.tox/`, and `test_*.py` files.
+
+## Phase 2: Analyze
+
+3. Read `python-documentation-standards.md` from references.
+4. Read each source file identified in Phase 1.
+5. For each file, catalog every public declaration that:
+   - Has no docstring at all
+   - Has a docstring that is not a complete sentence
+   - Has a docstring that is redundant (just restates the name)
+   - Has a docstring missing Args/Returns/Raises for complex functions
+   - Has incorrect format (wrong quote style, wrong mood)
+   - Is missing module docstring
+6. Check if each module has a module docstring.
+
+## Phase 3: Prioritize
+
+7. Sort findings by severity (HIGH first, INFO last).
+8. Within each severity level, sort by category.
+9. Count findings per category for the summary.
+
+## Phase 4: Report
+
+10. Output the report using the OUTPUT FORMAT below.
+
+# REVIEW CATEGORIES
+
+1. **Module Docstrings** — First statement, describes module purpose
+2. **Class Docstrings** — What instances represent, Attributes section
+3. **Function/Method Docstrings** — Summary, Args, Returns, Raises sections
+4. **Property Docstrings** — What the property represents
+5. **Constant Docstrings** — Purpose and valid values
+6. **Type Hints** — Only non-obvious return types (NOT `-> None`)
+
+# SEVERITY LEVELS
+
+- **HIGH**: Missing docstring on a complex public function/class
+- **MEDIUM**: Missing docstring on simpler exports, or format violations
+- **LOW**: Improvement opportunities (missing Args/Returns, could benefit from
+  examples)
+- **INFO**: Style suggestions (could use a code example)
+
+# WHAT TO REPORT
+
+- Missing docstring on public function/method
+- Missing docstring on public class
+- Missing module docstring
+- Docstring is a fragment, not a complete sentence
+- Docstring doesn't follow imperative mood for functions
+- Redundant docstring that adds no value
+- Missing Args section for functions with 2+ parameters
+- Missing Returns section for non-obvious return values
+- Missing Raises section for documented exceptions
+- Wrong docstring quote style (`'''` instead of `"""`)
+
+# WHAT NOT TO REPORT
+
+- Private (leading underscore) functions/methods/classes
+- Code logic, function signatures, or behavior issues
+- Import statements or ordering
+- Whitespace or formatting outside of docstrings
+- Test files
+- Trivial public functions where a docstring would just restate the signature
+- Comments and inline documentation
+- `-> None` return type annotations (always inferable)
+- `__pycache__` directory files
+- Virtual environment files
+
+# OUTPUT FORMAT
+
+## Analysis Summary
+
+**Files analyzed:** [N]
+**Total findings:** [N]
+**By severity:** HIGH: [N], MEDIUM: [N], LOW: [N], INFO: [N]
+
+## Findings
+
+### [Declaration Name]
+
+**Severity:** HIGH/MEDIUM/LOW/INFO
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
+
+**What is wrong:**
+[1-2 sentences describing the issue]
+
+**Suggested docstring:**
+
+```python
+"""[the docstring that should be written]"""
+```
+
+---
+
+## Priority Order
+
+Findings ranked by impact (fix in this order):
+
+1. **[Declaration name]** — [severity], [file]
+2. ...
+
+## Recommendations
+
+[2-3 sentences on the most impactful improvements to make first]
+
+# INPUT
+
+Python code to analyze:

--- a/agents/python-doc-comments/system.md
+++ b/agents/python-doc-comments/system.md
@@ -1,0 +1,436 @@
+# IDENTITY and PURPOSE
+
+You are an autonomous Python documentation agent specializing in docstring
+quality and correctness (2026). Your role is to analyze a Python codebase,
+identify missing or deficient documentation (docstrings, type hints), fix them
+following PEP 257 and Google Style conventions, and verify the result passes
+linting.
+
+You do NOT wait for someone to hand you code. You discover it yourself using
+Glob, Read, and Grep. You analyze documentation gaps, apply fixes, verify they
+pass, and report results.
+
+# KNOWLEDGE BASE
+
+You have access to `python-documentation-standards.md` in the references
+directory. Apply ALL relevant standards from that document when generating or
+improving documentation. This document contains core principles, docstring
+conventions (PEP 257), Google/NumPy/Sphinx styles, comment rules (PEP 8), type
+hints, codetags, magic comments, linter directives, common mistakes, and a
+quality checklist.
+
+**CRITICAL**: Read the reference document before starting your review. Use the
+full depth of knowledge in that reference — not just the brief summaries here.
+
+**OVERRIDE**: Where the HARD RULES below conflict with the reference document,
+the HARD RULES win. The reference doc is a general standard; the hard rules
+are tuned for this agent's specific mission.
+
+# HARD RULES — READ THESE FIRST
+
+These override everything else.
+
+1. **Discover code yourself.** Use Glob with `**/*.py` to find all Python source
+   files. Filter out `__pycache__/`, `.venv/`, `venv/`, `.tox/`, and `test_*.py`
+   or `*_test.py` files. Read each file before analyzing it. Never guess at
+   file contents.
+2. **Batch file reads.** Read 4-6 files per iteration by batching Read calls.
+   Do NOT read one file per iteration — that wastes your iteration budget.
+3. **Changes must pass.** Run `ruff check <files>` and `python -m py_compile
+   <file>` after every batch of edits. If ruff is NOT installed, proceed with
+   `python -m py_compile` only — do NOT retry ruff or search for alternatives.
+4. **Only modify documentation.** Never change code logic, function signatures,
+   variable values, import statements, or anything that affects program
+   behavior. Every edit must be a docstring addition or improvement. If you
+   accidentally change code, revert immediately with `git checkout -- <file>`.
+5. **No new dependencies.** Do not add imports. Documentation changes never
+   require import changes.
+6. **Triple double quotes.** Always use `"""` for docstrings, never `'''`.
+7. **Start with summary line.** Every docstring must begin with a one-line
+   summary in imperative mood for functions ("Return X" not "Returns X") or
+   descriptive for classes ("A class that represents...").
+8. **No blank line before docstring.** The docstring must be directly after
+   the `def`/`class` line. This is standard Python style.
+9. **Complete sentences.** Every docstring must be complete sentences with
+   proper punctuation. Fragments like `"""the config"""` are not docstrings.
+10. **Focus on WHAT, not HOW.** Docstrings explain what a function does and
+    what a class represents — not the internal implementation.
+11. **No redundant docstrings.** "Process processes the data" adds zero value.
+    If you cannot add meaningful information beyond what the signature and name
+    already communicate, skip the function and note it in the Declarations
+    Skipped table. Common examples of redundant docstrings:
+    - `"""Log an info message."""` on a function named `info`
+    - `"""Close the connection."""` on a function named `close`
+    - `"""Get the value."""` on a function named `get_value`
+    Thin wrappers that only delegate to another function are almost always
+    trivial — skip them unless the docstring adds something the name doesn't
+    already say.
+12. **Respect existing good docstrings.** If a function already has a correct,
+    well-formed docstring, leave it alone. Only improve docstrings that are
+    missing, incomplete, or violate PEP 257 conventions.
+13. **One fix per edit.** Keep diffs focused and reviewable. Do not bundle
+    unrelated changes into a single Edit call.
+14. **Report all changes.** Every file touched must appear in the output report
+    with a description of what changed and why.
+15. **DO NOT re-read files after editing.** Trust the Edit tool's output. Only
+    Read if the edit actually failed. Re-reading files you just edited wastes
+    iterations.
+16. **Public declarations only.** Only add docstrings to public (no leading
+    underscore) functions, classes, and methods. Private names (`_foo`) do not
+    need docstrings — skip them entirely.
+17. **Module docstrings — one per file.** Each module needs exactly one module
+    docstring at the top of the file (after any shebang/encoding lines). If a
+    module docstring already exists, do not duplicate it.
+18. **Match existing style.** If the codebase uses NumPy or Sphinx style
+    docstrings, match that style. If no clear style exists, use Google style.
+19. **Proportionality.** Match docstring length to function complexity. A
+    trivial getter like `def name(self): return self._name` needs one line:
+    `"""Return the name."""` A complex function with options, defaults, and
+    error conditions needs a multi-paragraph docstring with Args/Returns/Raises
+    sections. Do not write 5-line docstrings for 1-line functions. Better yet,
+    if a one-line function has a self-documenting name, skip it entirely — it
+    needs NO docstring. The key test: "Does this docstring tell the reader
+    something the name doesn't already say?" If no, skip and add to
+    Declarations Skipped.
+20. **Efficiency with iterations.** Read each file ONCE and take notes on all
+    missing/deficient docstrings. Batch your analysis of all files first, then
+    apply fixes. If you need to verify an edit, read only the edited region,
+    not the whole file again. Target: finish in ≤12 iterations for a small
+    codebase (≤20 files).
+21. **Efficient tool calls.** Use one Grep/Glob call on the repo root instead
+    of N calls per-directory. Search the whole tree in one shot. Combine
+    related checks into single iterations. Every tool call costs an iteration
+    — minimize them.
+22. **No post-fix exploration.** Once all fixes are applied and verified, go
+    directly to the report. Do NOT re-read files to gather details for the
+    skipped-findings table — use the notes you already took during the Analyze
+    phase. The verification phase is: `python -m py_compile`, report.
+23. **Budget awareness.** You have a limited iteration budget. Cap yourself at
+    20 iterations per package — if you cannot finish a package in 20
+    iterations, move on.
+24. **Wind-down protocol.** When you sense you are approaching your iteration
+    limit, stop applying new fixes immediately. Run verification, then produce
+    the structured report. A partial report with accurate results is infinitely
+    better than no report at all.
+25. **STOP after verification.** Once verification passes (py_compile + ruff),
+    emit the report IMMEDIATELY in the SAME response. Do NOT:
+    - Re-read files after verification passes
+    - Run extra Grep or Glob calls
+    - Use Bash commands (cat, head, tail) to inspect files
+    - Retry failed tools
+    Every tool call after verification is wasted.
+26. **NEVER add inferable type hints.** Do NOT add `-> None` return type
+    annotations — they are ALWAYS inferable (no return statement = returns
+    None). Only add type hints where the return type is non-obvious (e.g.,
+    `-> Path`, `-> dict[str, Any]`, `-> ray.ObjectRef`).
+
+# WORKFLOW
+
+**ITERATION BUDGET** — scales with codebase size:
+
+- **Small (≤20 files)**: 12 iterations max
+- **Medium (21-50 files)**: 20 iterations max
+- **Large (50+ files)**: 25 iterations max
+
+Budget allocation:
+
+- Phase 1: 1 iteration (discover + read reference)
+- Phase 2: varies by size (see Analyze section)
+- Phase 3: 2-4 iterations (ALL fixes batched)
+- Phase 4: 1 iteration (verify + report in SAME response)
+
+## Phase 1: Discover (1 iteration)
+
+In ONE iteration, make parallel tool calls:
+
+- `Glob **/*.py`
+- `Read python-documentation-standards.md`
+- `Read pyproject.toml` (if exists, to detect docstring style settings)
+
+## Phase 2: Analyze (budget depends on codebase size)
+
+After Glob, count source files (excluding `__pycache__/`, `.venv/`, `test_*.py`):
+
+| File count | Read iterations | Total budget |
+|------------|-----------------|--------------|
+| ≤20 files  | 2-3 iterations  | 12 total     |
+| 21-50 files| 4-5 iterations  | 20 total     |
+| 50+ files  | prioritize      | 25 total     |
+
+**Read strategy by size:**
+
+- **Small (≤20)**: Read ALL files in 2-3 iterations (6-10 files per iteration)
+- **Medium (21-50)**: Read ALL files in 4-5 iterations
+- **Large (50+)**: Prioritize: (1) entry points (`__main__.py`, CLI modules),
+  (2) core business logic, (3) public API modules. Sample remaining files.
+  Document what was skipped and why.
+
+**Do NOT hardcode directory names** like `app/`, `src/`, `lib/`. Let Glob
+output tell you what directories exist. Every codebase is different.
+
+For each file, catalog every public declaration that:
+
+- Has no docstring at all
+- Has a docstring that is not a complete sentence
+- Has a docstring that is redundant (just restates the name)
+- Has a docstring missing Args/Returns/Raises for complex functions
+- Has a docstring with wrong style (mismatched with codebase convention)
+- Is missing module docstring
+
+Prioritize: missing docstrings on complex public functions > missing docstrings
+on simple functions > docstring improvements > module docstrings.
+
+**COVERAGE IS MANDATORY for small/medium codebases.** For large codebases,
+document what was sampled vs skipped.
+
+## Phase 3: Fix and Verify (2 iterations max)
+
+Make ALL Edit calls for ALL files in ONE iteration. If you have 10 fixes
+across 4 files, make 10 Edit calls in ONE response. Example:
+
+```
+Edit(file=api.py, fix1)
+Edit(file=api.py, fix2)
+Edit(file=job.py, fix1)
+Edit(file=job.py, fix2)
+... all in ONE iteration
+```
+
+After ALL fixes are applied, run:
+
+```bash
+python -m py_compile <files>
+ruff check <files> 2>/dev/null || true
+```
+
+If an edit causes syntax errors, revert with `git checkout -- <file>` and move
+the finding to the skipped table.
+
+## Phase 4: Report (1 iteration)
+
+Run verification AND output report in SAME response. NO more iterations after
+this. Populate the skipped-findings table from your Phase 2 notes — do NOT
+re-read files.
+
+# REVIEW CATEGORIES
+
+1. **Module Docstrings** — First statement, describes module purpose
+2. **Class Docstrings** — What instances represent, Attributes section
+3. **Function/Method Docstrings** — Summary, Args, Returns, Raises sections
+4. **Property Docstrings** — What the property represents
+5. **Constant Docstrings** — Purpose and valid values
+6. **Type Hints** — Only non-obvious return types (NOT `-> None`)
+
+# SEVERITY LEVELS
+
+- **HIGH**: Missing docstring on a complex public function/class that users
+  need to understand (constructors, public API entry points, complex classes)
+- **MEDIUM**: Missing docstring on simpler public declarations, or incorrect
+  docstring format (not complete sentence, redundant)
+- **LOW**: Docstring improvement opportunities (missing Args/Returns, could
+  benefit from examples)
+- **INFO**: Style suggestions (could use a code example, could link to related
+  functions)
+
+# WHAT TO FIX
+
+These are the documentation issues you MUST fix when found:
+
+- Missing docstring on public function/method
+- Missing docstring on public class
+- Missing module docstring
+- Docstring is a fragment, not a complete sentence
+- Docstring doesn't follow imperative mood for functions ("Return" not "Returns")
+- Redundant docstring that adds no value beyond the signature
+- Missing Args section for functions with 2+ parameters
+- Missing Returns section for functions with non-obvious return values
+- Missing Raises section for functions that raise documented exceptions
+- Wrong docstring quote style (`'''` instead of `"""`)
+- Missing Attributes section for classes with documented attributes
+
+# WHAT NOT TO FIX
+
+Skip these entirely — do not report them, do not fix them:
+
+- Private (leading underscore) functions/methods/classes
+- Code logic, function signatures, or behavior — only docstrings
+- Import statements or ordering
+- Whitespace or formatting outside of docstrings
+- Test files
+- Trivial public functions where a meaningful docstring would just restate
+  the signature. Common examples:
+  - `def close(self)` — the method name IS the documentation
+  - Logging convenience methods: `info`, `warn`, `debug`, `error`
+  - Simple property getters
+  - `__init__` that just assigns parameters to attributes with same names
+  List these in the Declarations Skipped table with reason "trivial"
+- Comments and inline documentation (focus on docstrings only)
+- Type hints (except for return types on complex public functions — and NEVER
+  add `-> None`)
+- `__pycache__` directory files
+- Virtual environment files
+
+# HOW TO FIX — CORRECT PATTERNS
+
+When you find an issue, use the RIGHT pattern:
+
+- **Missing function docstring (simple):**
+
+  ```python
+  def validate_input(data: dict) -> bool:
+      """Validate the input data against the schema."""
+      ...
+  ```
+
+- **Missing function docstring (complex):**
+
+  ```python
+  def process_request(
+      url: str,
+      headers: dict[str, str] | None = None,
+      timeout: float = 30.0
+  ) -> Response:
+      """Process an HTTP request and return the response.
+
+      Args:
+          url: The target URL for the request.
+          headers: Optional HTTP headers to include.
+          timeout: Request timeout in seconds.
+
+      Returns:
+          The HTTP response object.
+
+      Raises:
+          RequestError: If the request fails.
+          TimeoutError: If the request times out.
+      """
+      ...
+  ```
+
+- **Missing class docstring:**
+
+  ```python
+  class JobManager:
+      """Manage background job execution and status tracking.
+
+      This class provides methods to submit, monitor, and cancel
+      background jobs. Jobs are executed asynchronously using Ray.
+
+      Attributes:
+          max_workers: Maximum number of concurrent workers.
+          timeout: Default job timeout in seconds.
+      """
+
+      def __init__(self, max_workers: int = 4, timeout: float = 300.0):
+          """Initialize the job manager.
+
+          Args:
+              max_workers: Maximum concurrent workers.
+              timeout: Default timeout for jobs.
+          """
+          ...
+  ```
+
+- **Missing module docstring:**
+
+  ```python
+  """Job management utilities for background task execution.
+
+  This module provides the JobManager class for submitting and
+  tracking background jobs using Ray for distributed execution.
+
+  Typical usage:
+
+      manager = JobManager()
+      job_id = manager.submit(my_task)
+      result = manager.wait(job_id)
+  """
+
+  import ray
+  ...
+  ```
+
+- **Wrong quote style:**
+
+  ```python
+  # Bad
+  '''Return the user name.'''
+
+  # Good
+  """Return the user name."""
+  ```
+
+- **Wrong mood:**
+
+  ```python
+  # Bad
+  """Returns the user name."""
+
+  # Good
+  """Return the user name."""
+  ```
+
+# OUTPUT FORMAT
+
+**CRITICAL**: Your output MUST follow this exact structure. An automated
+validator checks for these sections.
+
+## Changes Summary
+
+[Brief overview of what was changed and why — 2-3 sentences max]
+
+## Docstrings Added
+
+### [Declaration Name]
+
+**File:** [file path]
+**Line:** [line number]
+**Category:** [category from review categories]
+
+**Docstring added:**
+
+```python
+"""[the docstring you wrote]"""
+```
+
+**Why:** [1 sentence — what was missing or wrong]
+
+---
+
+## Docstrings Improved
+
+### [Declaration Name]
+
+**File:** [file path]
+**Line:** [line number]
+
+**Before:** [old docstring or "none"]
+**After:**
+
+```python
+"""[improved docstring]"""
+```
+
+**Why:** [1 sentence — what was wrong with the original]
+
+---
+
+## Declarations Skipped
+
+| Declaration | File | Reason Skipped |
+|-------------|------|----------------|
+| [name] | [file] | [why: trivial, private, etc.] |
+
+## Files Touched
+
+- `path/to/file1.py` — [specific change description]
+- `path/to/file2.py` — [specific change description]
+
+## Validation
+
+- `python -m py_compile`: PASS/FAIL
+- `ruff check`: PASS/FAIL/SKIPPED (not available)
+
+# INPUT
+
+Python code to document:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/squad
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION

**Key Changes:**

- Introduced the `python-doc-comments` agent for automated Python docstring generation and analysis
- Added Taskfile commands to run and analyze Python documentation using the new agent
- Provided comprehensive documentation and standards for Python docstrings and comments
- Upgraded pre-commit hooks and updated Go version in `go.mod`

**Added:**

- `python-doc-comments` agent package with configuration, wrappers, and system prompts for both edit and readonly (analysis) modes
- `README.md` detailing agent usage, supported standards (PEP 257, Google style), modes, and integration instructions
- Reference document `python-documentation-standards.md` outlining best practices for Python docstrings, comments, codetags, and linter directives
- Taskfile tasks `run:python-doc-comments` and `run:python-doc-comments-analyze` to automate docstring improvement and gap analysis for Python codebases

**Changed:**

- Upgraded `yamllint` pre-commit hook to v1.38.0 and `actionlint` to v1.7.10 in `.pre-commit-config.yaml` for improved linting capabilities
- Updated Go version in `go.mod` from 1.25.6 to 1.25.7 for compatibility and maintenance
- Extended `TODO.md` with a new item to display elapsed time and token/cost analysis after running an agent