### PR TITLE
feat: add agent metrics tracking for token usage and iterations

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -944,7 +944,9 @@ tasks:
         - Do NOT edit-wait-edit-wait — batch ALL edits into ONE iteration
         - Do NOT re-read files after editing — trust Edit output
         - STOP after verification — emit report in SAME response, NO more iterations
-        - If ansible-lint not installed, proceed with syntax check only
+        - To check ansible-lint: run 'ansible-lint --version'. If it prints a version, USE IT.
+          WARNING messages about collection versions are NORMAL — they mean ansible-lint IS working.
+          Only 'command not found' means it's not installed (then use syntax-check only).
         - Every file touched must appear in the output report" \
           --agent ansible-review \
           --working-dir {{.WORKING_DIR}} \

--- a/agents/ansible-review/agent.md
+++ b/agents/ansible-review/agent.md
@@ -20,10 +20,17 @@ apply fixes, and verify the result passes linting — all without human guidance
   **NEVER remove changed_when entirely** — ansible-lint requires it on ALL
   command/shell tasks.
 - **Verify after every batch.** Run `ansible-lint .` after editing files.
-  If ansible-lint is NOT installed, proceed with syntax check only.
+  To check availability: run `ansible-lint --version`. If it prints a version,
+  it's available. WARNING messages about collection versions are normal and mean
+  ansible-lint IS working. Only "command not found" means it's not installed.
 - **No cosmetic changes.** Skip whitespace, comment style, import ordering.
 - **Proportional fixes.** Every fix must prevent a real bug, security issue,
   or meaningful inconsistency. No theoretical improvements.
+- **Create missing role files — only with real content.** If a role is missing
+  standard structure files AND you can derive meaningful content, CREATE THEM.
+  **DO NOT create empty/placeholder files.** A handlers/main.yml with just `[]`
+  is garbage. If there's nothing to derive (no notify statements, no undefined
+  vars), don't create the file.
 - **Be efficient with iterations.** Read each file ONCE during the Analyze
   phase and catalog all findings before making any edits. Do not re-read files
   you have already analyzed. Target ≤12 iterations for a small codebase

--- a/agents/ansible-review/system.md
+++ b/agents/ansible-review/system.md
@@ -48,9 +48,11 @@ These override everything else.
    guess at file contents.
 2. **Batch file reads.** Read 4-6 files per iteration by batching Read calls.
    Do NOT read one file per iteration — that wastes your iteration budget.
-3. **Changes must pass.** Run `ansible-lint .` after every batch of edits. If
-   ansible-lint is NOT installed, proceed with syntax validation only — do NOT
-   retry or search for alternatives.
+3. **Changes must pass.** Run `ansible-lint .` after every batch of edits.
+   To check availability: run `ansible-lint --version`. If it prints a version,
+   it's available. If you get "command not found", it's NOT installed — proceed
+   with `ansible-playbook --syntax-check` only. WARNING messages about collection
+   versions are NOT errors — they mean ansible-lint IS working.
 4. **FQCN is mandatory.** Any task using short module names (e.g., `copy:`)
    instead of FQCN (e.g., `ansible.builtin.copy:`) is a finding. Fix it.
 5. **Security focus.** Flag: hardcoded secrets, missing `no_log: true` on
@@ -86,6 +88,18 @@ These override everything else.
     - **NEVER remove changed_when entirely** — ansible-lint `no-changed-when` rule requires it
     - If you find `changed_when: false` on a state-changing command, change it to
       `changed_when: true`, do NOT delete the line. This is the #1 false positive to avoid.
+16. **Create missing role files — but only with real content.** If a role is
+    missing standard structure files AND you can derive meaningful content from
+    existing code, CREATE THEM:
+    - `meta/argument_specs.yml` — derive from defaults/main.yml
+    - `meta/main.yml` — role metadata, dependencies, platforms
+    - `handlers/main.yml` — derive from notify statements in tasks
+    - `defaults/main.yml` — if variables are used without defaults
+    - `vars/<os_family>.yml` — if platform-specific logic is scattered in tasks
+    **DO NOT create empty or placeholder files.** A file with just `---` and `[]`
+    is useless. If there are no notify statements, don't create handlers/main.yml.
+    If there are no variables in defaults, don't create argument_specs.yml. Only
+    create files that contain actual, derived content.
 
 # WORKFLOW
 
@@ -205,6 +219,7 @@ These are the issues you MUST fix when found:
 - `state: latest` on package tasks (use specific versions)
 - Missing `mode:` on file operations
 - `import_tasks` used with loops (should be `include_tasks`)
+- Missing role structure files (see hard rule 16)
 
 # WHAT NOT TO FIX
 
@@ -280,7 +295,74 @@ Skip these entirely — do not report them, do not fix them:
 
 # HOW TO FIX — CORRECT PATTERNS
 
-When you find an issue, use the RIGHT pattern:
+When you find an issue, use the RIGHT pattern. **Create missing files.** The whole
+point of this agent is to make code idiomatic. If a file is missing, create it.
+Derive content from existing code — the design is already there, just not in the
+right place.
+
+## Missing Role Structure Files
+
+**Only create these if you have real content to put in them.** Empty files are
+worse than missing files — they waste space and suggest the role was reviewed
+when it wasn't. If there are no notify statements, don't create handlers. If
+there are no defaults, don't create argument_specs.
+
+- **Missing `meta/argument_specs.yml`** — Derive from `defaults/main.yml`:
+
+  ```yaml
+  ---
+  argument_specs:
+    main:
+      short_description: Configure <role_name>
+      options:
+        <var_name>:
+          type: <str|int|bool|list|dict>
+          required: <true|false>
+          default: <value from defaults/main.yml>
+          description: <what this variable controls>
+  ```
+
+- **Missing `meta/main.yml`** — Create role metadata:
+
+  ```yaml
+  ---
+  galaxy_info:
+    author: <from git config or "Your Name">
+    description: <derive from role purpose>
+    license: MIT
+    min_ansible_version: "2.14"
+    platforms:
+      - name: <from existing when clauses, e.g., Debian, EL>
+        versions:
+          - all
+  dependencies: []
+  ```
+
+- **Missing `handlers/main.yml`** — Derive from notify statements in tasks:
+
+  ```yaml
+  ---
+  - name: <handler name from notify>
+    ansible.builtin.service:
+      name: <service name>
+      state: restarted
+  ```
+
+- **Missing `defaults/main.yml`** — Find undefined variables in tasks:
+
+  ```yaml
+  ---
+  # Extracted from task variable usage
+  <var_name>: <sensible default or empty string>
+  ```
+
+- **Missing `vars/<os_family>.yml`** — Extract from scattered when clauses:
+
+  If tasks have `when: ansible_os_family == 'Debian'` with different values,
+  create `vars/Debian.yml` and `vars/RedHat.yml` with the platform-specific
+  values, then use `include_vars` with `first_found`.
+
+## Code Fixes
 
 - **Missing FQCN:**
 

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -171,6 +171,9 @@ func newRunCmd() *cobra.Command {
 			return fmt.Errorf("prompt is required (pass args or pipe stdin)")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Silence usage for runtime errors (API key missing, etc).
+			// Args validation errors still show usage.
+			cmd.SilenceUsage = true
 			opts := newRunOptions(cmd)
 			return runner.ExecuteRun(cmd, args, opts)
 		},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,191 @@
+// Package metrics provides token usage tracking and cost analysis for agent runs.
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Metrics tracks resource usage for an agent run.
+type Metrics struct {
+	StartTime    time.Time
+	EndTime      time.Time
+	InputTokens  int64
+	OutputTokens int64
+	Iterations   int
+	Model        string
+	Provider     string
+}
+
+// New creates a new Metrics instance with the start time set to now.
+func New(provider, model string) *Metrics {
+	return &Metrics{
+		StartTime: time.Now(),
+		Provider:  provider,
+		Model:     model,
+	}
+}
+
+// AddTokens adds token counts to the running total.
+func (m *Metrics) AddTokens(input, output int64) {
+	m.InputTokens += input
+	m.OutputTokens += output
+}
+
+// IncrementIterations increments the iteration counter.
+func (m *Metrics) IncrementIterations() {
+	m.Iterations++
+}
+
+// Finish marks the end time.
+func (m *Metrics) Finish() {
+	m.EndTime = time.Now()
+}
+
+// Duration returns the elapsed time.
+func (m *Metrics) Duration() time.Duration {
+	if m.EndTime.IsZero() {
+		return time.Since(m.StartTime)
+	}
+	return m.EndTime.Sub(m.StartTime)
+}
+
+// TotalTokens returns the sum of input and output tokens.
+func (m *Metrics) TotalTokens() int64 {
+	return m.InputTokens + m.OutputTokens
+}
+
+// Cost calculates the estimated cost in USD based on model pricing.
+func (m *Metrics) Cost() float64 {
+	pricing := GetPricing(m.Provider, m.Model)
+	inputCost := float64(m.InputTokens) / 1_000_000 * pricing.InputPerMillion
+	outputCost := float64(m.OutputTokens) / 1_000_000 * pricing.OutputPerMillion
+	return inputCost + outputCost
+}
+
+// Pricing holds per-million-token costs for a model.
+type Pricing struct {
+	InputPerMillion  float64
+	OutputPerMillion float64
+}
+
+// GetPricing returns the pricing for a given provider and model.
+func GetPricing(provider, model string) Pricing {
+	model = strings.ToLower(model)
+	provider = strings.ToLower(provider)
+
+	switch provider {
+	case "openai", "openai-responses", "":
+		return getOpenAIPricing(model)
+	case "anthropic":
+		return getAnthropicPricing(model)
+	case "gemini":
+		return getGeminiPricing(model)
+	case "ollama":
+		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	default:
+		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	}
+}
+
+func getOpenAIPricing(model string) Pricing {
+	switch {
+	case strings.HasPrefix(model, "gpt-5"):
+		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 60.00}
+	case strings.HasPrefix(model, "gpt-4o-mini"):
+		return Pricing{InputPerMillion: 0.15, OutputPerMillion: 0.60}
+	case strings.HasPrefix(model, "gpt-4o"):
+		return Pricing{InputPerMillion: 2.50, OutputPerMillion: 10.00}
+	case strings.HasPrefix(model, "gpt-4-turbo"):
+		return Pricing{InputPerMillion: 10.00, OutputPerMillion: 30.00}
+	case strings.HasPrefix(model, "gpt-4"):
+		return Pricing{InputPerMillion: 30.00, OutputPerMillion: 60.00}
+	case strings.HasPrefix(model, "gpt-3.5"):
+		return Pricing{InputPerMillion: 0.50, OutputPerMillion: 1.50}
+	case strings.HasPrefix(model, "o1"):
+		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 60.00}
+	case strings.HasPrefix(model, "o3"):
+		return Pricing{InputPerMillion: 10.00, OutputPerMillion: 40.00}
+	default:
+		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	}
+}
+
+func getAnthropicPricing(model string) Pricing {
+	switch {
+	case strings.Contains(model, "opus"):
+		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 75.00}
+	case strings.Contains(model, "sonnet"):
+		return Pricing{InputPerMillion: 3.00, OutputPerMillion: 15.00}
+	case strings.Contains(model, "haiku"):
+		return Pricing{InputPerMillion: 0.25, OutputPerMillion: 1.25}
+	default:
+		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	}
+}
+
+func getGeminiPricing(model string) Pricing {
+	switch {
+	case strings.Contains(model, "pro"):
+		return Pricing{InputPerMillion: 1.25, OutputPerMillion: 5.00}
+	case strings.Contains(model, "flash"):
+		return Pricing{InputPerMillion: 0.075, OutputPerMillion: 0.30}
+	default:
+		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	}
+}
+
+// String returns a human-readable summary of the metrics.
+func (m *Metrics) String() string {
+	cost := m.Cost()
+	costStr := "N/A"
+	if cost > 0 {
+		costStr = fmt.Sprintf("$%.4f", cost)
+	} else if m.Provider == "ollama" {
+		costStr = "$0.00 (local)"
+	}
+
+	return fmt.Sprintf(
+		"Duration: %s | Iterations: %d | Tokens: %d in / %d out (%d total) | Cost: %s",
+		m.Duration().Round(time.Millisecond),
+		m.Iterations,
+		m.InputTokens,
+		m.OutputTokens,
+		m.TotalTokens(),
+		costStr,
+	)
+}
+
+// Summary returns a formatted multi-line summary for display.
+func (m *Metrics) Summary() string {
+	cost := m.Cost()
+	var costLine string
+	switch {
+	case cost > 0:
+		costLine = fmt.Sprintf("  Cost:       $%.4f", cost)
+	case m.Provider == "ollama":
+		costLine = "  Cost:       $0.00 (local)"
+	default:
+		costLine = "  Cost:       N/A (unknown pricing)"
+	}
+
+	return fmt.Sprintf(`
+Agent Metrics
+─────────────
+  Duration:   %s
+  Iterations: %d
+  Model:      %s (%s)
+  Tokens:     %d input / %d output (%d total)
+%s
+`,
+		m.Duration().Round(time.Millisecond),
+		m.Iterations,
+		m.Model,
+		m.Provider,
+		m.InputTokens,
+		m.OutputTokens,
+		m.TotalTokens(),
+		costLine,
+	)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cowdogmoo/squad/logging"
 )
 
 const (
@@ -105,7 +107,11 @@ func fetchPricing() {
 		pricingCacheMu.Unlock()
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logging.Warn("failed to close pricing response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		pricingCacheMu.Lock()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,9 +2,19 @@
 package metrics
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
+	"sync"
 	"time"
+)
+
+const (
+	// LiteLLM maintains a comprehensive pricing database updated by the community.
+	liteLLMPricingURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+	// Timeout for fetching pricing data.
+	fetchTimeout = 10 * time.Second
 )
 
 // Metrics tracks resource usage for an agent run.
@@ -70,81 +80,145 @@ type Pricing struct {
 	OutputPerMillion float64
 }
 
+// liteLLMModel represents a model entry from the LiteLLM pricing JSON.
+type liteLLMModel struct {
+	InputCostPerToken  float64 `json:"input_cost_per_token"`
+	OutputCostPerToken float64 `json:"output_cost_per_token"`
+	LiteLLMProvider    string  `json:"litellm_provider"`
+}
+
+var (
+	pricingCache     map[string]liteLLMModel
+	pricingCacheMu   sync.RWMutex
+	pricingFetched   bool
+	pricingFetchErr  error
+	pricingFetchOnce sync.Once
+)
+
+// fetchPricing downloads the LiteLLM pricing database.
+func fetchPricing() {
+	client := &http.Client{Timeout: fetchTimeout}
+	resp, err := client.Get(liteLLMPricingURL)
+	if err != nil {
+		pricingCacheMu.Lock()
+		pricingFetchErr = fmt.Errorf("failed to fetch pricing data: %w", err)
+		pricingCacheMu.Unlock()
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		pricingCacheMu.Lock()
+		pricingFetchErr = fmt.Errorf("pricing API returned status %d", resp.StatusCode)
+		pricingCacheMu.Unlock()
+		return
+	}
+
+	var data map[string]liteLLMModel
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		pricingCacheMu.Lock()
+		pricingFetchErr = fmt.Errorf("failed to parse pricing data: %w", err)
+		pricingCacheMu.Unlock()
+		return
+	}
+
+	pricingCacheMu.Lock()
+	pricingCache = data
+	pricingFetched = true
+	pricingFetchErr = nil
+	pricingCacheMu.Unlock()
+}
+
+// PricingStatus returns whether pricing data was loaded and any error that occurred.
+// Returns (loaded, modelCount, error).
+func PricingStatus() (bool, int, error) {
+	ensurePricingLoaded()
+
+	pricingCacheMu.RLock()
+	defer pricingCacheMu.RUnlock()
+
+	return pricingFetched, len(pricingCache), pricingFetchErr
+}
+
+// ensurePricingLoaded triggers a one-time fetch of pricing data.
+func ensurePricingLoaded() {
+	pricingFetchOnce.Do(fetchPricing)
+}
+
+// lookupLiteLLMPricing searches the LiteLLM cache for a model.
+func lookupLiteLLMPricing(provider, model string) (Pricing, bool) {
+	ensurePricingLoaded()
+
+	pricingCacheMu.RLock()
+	defer pricingCacheMu.RUnlock()
+
+	if !pricingFetched || pricingCache == nil {
+		return Pricing{}, false
+	}
+
+	// Try exact match with provider prefix (e.g., "openai/gpt-4o")
+	if entry, ok := pricingCache[provider+"/"+model]; ok {
+		return Pricing{
+			InputPerMillion:  entry.InputCostPerToken * 1_000_000,
+			OutputPerMillion: entry.OutputCostPerToken * 1_000_000,
+		}, true
+	}
+
+	// Try just the model name (many entries don't have provider prefix)
+	if entry, ok := pricingCache[model]; ok {
+		return Pricing{
+			InputPerMillion:  entry.InputCostPerToken * 1_000_000,
+			OutputPerMillion: entry.OutputCostPerToken * 1_000_000,
+		}, true
+	}
+
+	// Try with common provider mappings
+	providerMappings := map[string][]string{
+		"openai":           {"openai", "azure", "azure_ai"},
+		"openai-responses": {"openai", "azure"},
+		"anthropic":        {"anthropic", "bedrock", "vertex_ai"},
+		"gemini":           {"gemini", "vertex_ai", "vertex_ai-language-models"},
+	}
+
+	if prefixes, ok := providerMappings[provider]; ok {
+		for _, prefix := range prefixes {
+			if entry, found := pricingCache[prefix+"/"+model]; found {
+				return Pricing{
+					InputPerMillion:  entry.InputCostPerToken * 1_000_000,
+					OutputPerMillion: entry.OutputCostPerToken * 1_000_000,
+				}, true
+			}
+		}
+	}
+
+	return Pricing{}, false
+}
+
 // GetPricing returns the pricing for a given provider and model.
+// Pricing is fetched from LiteLLM's community-maintained database.
+// Returns zero pricing if the model is not found (displays as "pricing not available yet").
 func GetPricing(provider, model string) Pricing {
 	model = strings.ToLower(model)
 	provider = strings.ToLower(provider)
 
-	switch provider {
-	case "openai", "openai-responses", "":
-		return getOpenAIPricing(model)
-	case "anthropic":
-		return getAnthropicPricing(model)
-	case "gemini":
-		return getGeminiPricing(model)
-	case "ollama":
-		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
-	default:
+	// Ollama is always free (local inference)
+	if provider == "ollama" {
 		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
 	}
-}
 
-func getOpenAIPricing(model string) Pricing {
-	switch {
-	case strings.HasPrefix(model, "gpt-5"):
-		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 60.00}
-	case strings.HasPrefix(model, "gpt-4o-mini"):
-		return Pricing{InputPerMillion: 0.15, OutputPerMillion: 0.60}
-	case strings.HasPrefix(model, "gpt-4o"):
-		return Pricing{InputPerMillion: 2.50, OutputPerMillion: 10.00}
-	case strings.HasPrefix(model, "gpt-4-turbo"):
-		return Pricing{InputPerMillion: 10.00, OutputPerMillion: 30.00}
-	case strings.HasPrefix(model, "gpt-4"):
-		return Pricing{InputPerMillion: 30.00, OutputPerMillion: 60.00}
-	case strings.HasPrefix(model, "gpt-3.5"):
-		return Pricing{InputPerMillion: 0.50, OutputPerMillion: 1.50}
-	case strings.HasPrefix(model, "o1"):
-		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 60.00}
-	case strings.HasPrefix(model, "o3"):
-		return Pricing{InputPerMillion: 10.00, OutputPerMillion: 40.00}
-	default:
-		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
+	// Try LiteLLM lookup
+	if pricing, found := lookupLiteLLMPricing(provider, model); found {
+		return pricing
 	}
-}
 
-func getAnthropicPricing(model string) Pricing {
-	switch {
-	case strings.Contains(model, "opus"):
-		return Pricing{InputPerMillion: 15.00, OutputPerMillion: 75.00}
-	case strings.Contains(model, "sonnet"):
-		return Pricing{InputPerMillion: 3.00, OutputPerMillion: 15.00}
-	case strings.Contains(model, "haiku"):
-		return Pricing{InputPerMillion: 0.25, OutputPerMillion: 1.25}
-	default:
-		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
-	}
-}
-
-func getGeminiPricing(model string) Pricing {
-	switch {
-	case strings.Contains(model, "pro"):
-		return Pricing{InputPerMillion: 1.25, OutputPerMillion: 5.00}
-	case strings.Contains(model, "flash"):
-		return Pricing{InputPerMillion: 0.075, OutputPerMillion: 0.30}
-	default:
-		return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
-	}
+	// Model not found in LiteLLM database
+	return Pricing{InputPerMillion: 0, OutputPerMillion: 0}
 }
 
 // String returns a human-readable summary of the metrics.
 func (m *Metrics) String() string {
 	cost := m.Cost()
-	costStr := "N/A"
-	if cost > 0 {
-		costStr = fmt.Sprintf("$%.4f", cost)
-	} else if m.Provider == "ollama" {
-		costStr = "$0.00 (local)"
-	}
+	costStr := m.costString(cost)
 
 	return fmt.Sprintf(
 		"Duration: %s | Iterations: %d | Tokens: %d in / %d out (%d total) | Cost: %s",
@@ -160,14 +234,13 @@ func (m *Metrics) String() string {
 // Summary returns a formatted multi-line summary for display.
 func (m *Metrics) Summary() string {
 	cost := m.Cost()
-	var costLine string
-	switch {
-	case cost > 0:
-		costLine = fmt.Sprintf("  Cost:       $%.4f", cost)
-	case m.Provider == "ollama":
-		costLine = "  Cost:       $0.00 (local)"
-	default:
-		costLine = "  Cost:       N/A (unknown pricing)"
+	costLine := "  Cost:       " + m.costString(cost)
+
+	// Check if pricing fetch failed
+	var warningLine string
+	loaded, _, err := PricingStatus()
+	if !loaded && err != nil && strings.ToLower(m.Provider) != "ollama" {
+		warningLine = fmt.Sprintf("\n  ⚠ Pricing unavailable: %v", err)
 	}
 
 	return fmt.Sprintf(`
@@ -177,7 +250,7 @@ Agent Metrics
   Iterations: %d
   Model:      %s (%s)
   Tokens:     %d input / %d output (%d total)
-%s
+%s%s
 `,
 		m.Duration().Round(time.Millisecond),
 		m.Iterations,
@@ -187,5 +260,18 @@ Agent Metrics
 		m.OutputTokens,
 		m.TotalTokens(),
 		costLine,
+		warningLine,
 	)
+}
+
+// costString returns a formatted cost string.
+func (m *Metrics) costString(cost float64) string {
+	switch {
+	case cost > 0:
+		return fmt.Sprintf("$%.4f", cost)
+	case strings.ToLower(m.Provider) == "ollama":
+		return "$0.00 (local)"
+	default:
+		return "N/A (pricing not available yet)"
+	}
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,499 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+
+	if m.Provider != "openai" {
+		t.Fatalf("Provider = %q, want openai", m.Provider)
+	}
+	if m.Model != "gpt-4o" {
+		t.Fatalf("Model = %q, want gpt-4o", m.Model)
+	}
+	if m.StartTime.IsZero() {
+		t.Fatalf("StartTime should be set")
+	}
+	if m.InputTokens != 0 {
+		t.Fatalf("InputTokens = %d, want 0", m.InputTokens)
+	}
+	if m.OutputTokens != 0 {
+		t.Fatalf("OutputTokens = %d, want 0", m.OutputTokens)
+	}
+	if m.Iterations != 0 {
+		t.Fatalf("Iterations = %d, want 0", m.Iterations)
+	}
+}
+
+func TestAddTokens(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+
+	m.AddTokens(100, 50)
+	if m.InputTokens != 100 {
+		t.Fatalf("InputTokens = %d, want 100", m.InputTokens)
+	}
+	if m.OutputTokens != 50 {
+		t.Fatalf("OutputTokens = %d, want 50", m.OutputTokens)
+	}
+
+	// Accumulate more tokens
+	m.AddTokens(200, 100)
+	if m.InputTokens != 300 {
+		t.Fatalf("InputTokens = %d, want 300", m.InputTokens)
+	}
+	if m.OutputTokens != 150 {
+		t.Fatalf("OutputTokens = %d, want 150", m.OutputTokens)
+	}
+}
+
+func TestAddTokensZero(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+	m.AddTokens(100, 50)
+
+	// Adding zero should not change totals
+	m.AddTokens(0, 0)
+	if m.InputTokens != 100 {
+		t.Fatalf("InputTokens = %d, want 100", m.InputTokens)
+	}
+	if m.OutputTokens != 50 {
+		t.Fatalf("OutputTokens = %d, want 50", m.OutputTokens)
+	}
+}
+
+func TestIncrementIterations(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+
+	m.IncrementIterations()
+	if m.Iterations != 1 {
+		t.Fatalf("Iterations = %d, want 1", m.Iterations)
+	}
+
+	m.IncrementIterations()
+	m.IncrementIterations()
+	if m.Iterations != 3 {
+		t.Fatalf("Iterations = %d, want 3", m.Iterations)
+	}
+}
+
+func TestFinish(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+
+	if !m.EndTime.IsZero() {
+		t.Fatalf("EndTime should be zero before Finish()")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	m.Finish()
+
+	if m.EndTime.IsZero() {
+		t.Fatalf("EndTime should be set after Finish()")
+	}
+	if m.EndTime.Before(m.StartTime) {
+		t.Fatalf("EndTime should be after StartTime")
+	}
+}
+
+func TestDurationBeforeFinish(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+	time.Sleep(10 * time.Millisecond)
+
+	d := m.Duration()
+	if d < 10*time.Millisecond {
+		t.Fatalf("Duration() should be at least 10ms, got %v", d)
+	}
+}
+
+func TestDurationAfterFinish(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+	time.Sleep(10 * time.Millisecond)
+	m.Finish()
+
+	d1 := m.Duration()
+	time.Sleep(10 * time.Millisecond)
+	d2 := m.Duration()
+
+	// After Finish(), duration should be fixed
+	if d1 != d2 {
+		t.Fatalf("Duration() should be fixed after Finish(), got %v and %v", d1, d2)
+	}
+}
+
+func TestTotalTokens(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+
+	if m.TotalTokens() != 0 {
+		t.Fatalf("TotalTokens() = %d, want 0", m.TotalTokens())
+	}
+
+	m.AddTokens(1000, 500)
+	if m.TotalTokens() != 1500 {
+		t.Fatalf("TotalTokens() = %d, want 1500", m.TotalTokens())
+	}
+}
+
+func TestGetPricingOpenAI(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		model  string
+		input  float64
+		output float64
+	}{
+		{"gpt-5", 15.00, 60.00},
+		{"gpt-5-turbo", 15.00, 60.00},
+		{"gpt-4o", 2.50, 10.00},
+		{"gpt-4o-mini", 0.15, 0.60},
+		{"gpt-4o-mini-2024", 0.15, 0.60},
+		{"gpt-4-turbo", 10.00, 30.00},
+		{"gpt-4-turbo-preview", 10.00, 30.00},
+		{"gpt-4", 30.00, 60.00},
+		{"gpt-4-0613", 30.00, 60.00},
+		{"gpt-3.5-turbo", 0.50, 1.50},
+		{"o1", 15.00, 60.00},
+		{"o1-preview", 15.00, 60.00},
+		{"o3", 10.00, 40.00},
+		{"o3-mini", 10.00, 40.00},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			p := GetPricing("openai", tt.model)
+			if p.InputPerMillion != tt.input {
+				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
+			}
+			if p.OutputPerMillion != tt.output {
+				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
+			}
+		})
+	}
+}
+
+func TestGetPricingOpenAIResponses(t *testing.T) {
+	t.Parallel()
+	// openai-responses should use the same pricing as openai
+	p := GetPricing("openai-responses", "gpt-4o")
+	if p.InputPerMillion != 2.50 {
+		t.Fatalf("InputPerMillion = %v, want 2.50", p.InputPerMillion)
+	}
+}
+
+func TestGetPricingAnthropic(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		model  string
+		input  float64
+		output float64
+	}{
+		{"claude-3-opus", 15.00, 75.00},
+		{"claude-3-opus-20240229", 15.00, 75.00},
+		{"claude-3-sonnet", 3.00, 15.00},
+		{"claude-3-5-sonnet", 3.00, 15.00},
+		{"claude-3-haiku", 0.25, 1.25},
+		{"claude-3-5-haiku", 0.25, 1.25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			p := GetPricing("anthropic", tt.model)
+			if p.InputPerMillion != tt.input {
+				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
+			}
+			if p.OutputPerMillion != tt.output {
+				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
+			}
+		})
+	}
+}
+
+func TestGetPricingGemini(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		model  string
+		input  float64
+		output float64
+	}{
+		{"gemini-pro", 1.25, 5.00},
+		{"gemini-1.5-pro", 1.25, 5.00},
+		{"gemini-flash", 0.075, 0.30},
+		{"gemini-1.5-flash", 0.075, 0.30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			p := GetPricing("gemini", tt.model)
+			if p.InputPerMillion != tt.input {
+				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
+			}
+			if p.OutputPerMillion != tt.output {
+				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
+			}
+		})
+	}
+}
+
+func TestGetPricingOllama(t *testing.T) {
+	t.Parallel()
+	models := []string{"llama3", "mistral", "codellama", "phi3"}
+
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			p := GetPricing("ollama", model)
+			if p.InputPerMillion != 0 {
+				t.Fatalf("InputPerMillion = %v, want 0", p.InputPerMillion)
+			}
+			if p.OutputPerMillion != 0 {
+				t.Fatalf("OutputPerMillion = %v, want 0", p.OutputPerMillion)
+			}
+		})
+	}
+}
+
+func TestGetPricingUnknown(t *testing.T) {
+	t.Parallel()
+	p := GetPricing("unknown-provider", "unknown-model")
+	if p.InputPerMillion != 0 || p.OutputPerMillion != 0 {
+		t.Fatalf("unknown model should have zero pricing")
+	}
+}
+
+func TestGetPricingCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	// Provider and model should be case-insensitive
+	p1 := GetPricing("OpenAI", "GPT-4o")
+	p2 := GetPricing("openai", "gpt-4o")
+
+	if p1.InputPerMillion != p2.InputPerMillion {
+		t.Fatalf("pricing should be case-insensitive")
+	}
+}
+
+func TestCost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		provider     string
+		model        string
+		inputTokens  int64
+		outputTokens int64
+		wantCost     float64
+	}{
+		{
+			name:         "gpt-4o 1M tokens each",
+			provider:     "openai",
+			model:        "gpt-4o",
+			inputTokens:  1_000_000,
+			outputTokens: 1_000_000,
+			wantCost:     12.50, // 2.50 + 10.00
+		},
+		{
+			name:         "gpt-4o-mini 1M tokens each",
+			provider:     "openai",
+			model:        "gpt-4o-mini",
+			inputTokens:  1_000_000,
+			outputTokens: 1_000_000,
+			wantCost:     0.75, // 0.15 + 0.60
+		},
+		{
+			name:         "claude-3-sonnet 1M tokens each",
+			provider:     "anthropic",
+			model:        "claude-3-sonnet",
+			inputTokens:  1_000_000,
+			outputTokens: 1_000_000,
+			wantCost:     18.00, // 3.00 + 15.00
+		},
+		{
+			name:         "claude-3-haiku 1M tokens each",
+			provider:     "anthropic",
+			model:        "claude-3-haiku",
+			inputTokens:  1_000_000,
+			outputTokens: 1_000_000,
+			wantCost:     1.50, // 0.25 + 1.25
+		},
+		{
+			name:         "ollama free",
+			provider:     "ollama",
+			model:        "llama3",
+			inputTokens:  1_000_000,
+			outputTokens: 1_000_000,
+			wantCost:     0,
+		},
+		{
+			name:         "zero tokens",
+			provider:     "openai",
+			model:        "gpt-4o",
+			inputTokens:  0,
+			outputTokens: 0,
+			wantCost:     0,
+		},
+		{
+			name:         "small token count",
+			provider:     "openai",
+			model:        "gpt-4o",
+			inputTokens:  1000,
+			outputTokens: 500,
+			wantCost:     0.0075, // (1000/1M * 2.50) + (500/1M * 10.00) = 0.0025 + 0.005
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(tt.provider, tt.model)
+			m.AddTokens(tt.inputTokens, tt.outputTokens)
+			cost := m.Cost()
+			if cost != tt.wantCost {
+				t.Fatalf("Cost() = %v, want %v", cost, tt.wantCost)
+			}
+		})
+	}
+}
+
+func TestStringWithCost(t *testing.T) {
+	t.Parallel()
+	m := New("openai", "gpt-4o")
+	m.AddTokens(100, 50)
+	m.IncrementIterations()
+	m.Finish()
+
+	s := m.String()
+	if !strings.Contains(s, "Duration:") {
+		t.Fatalf("String() missing Duration")
+	}
+	if !strings.Contains(s, "Iterations: 1") {
+		t.Fatalf("String() missing Iterations")
+	}
+	if !strings.Contains(s, "100 in / 50 out") {
+		t.Fatalf("String() missing token counts")
+	}
+	if !strings.Contains(s, "150 total") {
+		t.Fatalf("String() missing total tokens")
+	}
+	if !strings.Contains(s, "$") {
+		t.Fatalf("String() missing cost")
+	}
+}
+
+func TestStringOllama(t *testing.T) {
+	t.Parallel()
+	m := New("ollama", "llama3")
+	m.AddTokens(1000, 500)
+	m.Finish()
+
+	s := m.String()
+	if !strings.Contains(s, "$0.00 (local)") {
+		t.Fatalf("String() should show $0.00 (local) for ollama, got: %s", s)
+	}
+}
+
+func TestStringUnknownPricing(t *testing.T) {
+	t.Parallel()
+	m := New("unknown", "unknown-model")
+	m.AddTokens(1000, 500)
+	m.Finish()
+
+	s := m.String()
+	if !strings.Contains(s, "N/A") {
+		t.Fatalf("String() should show N/A for unknown pricing, got: %s", s)
+	}
+}
+
+func TestSummaryWithCost(t *testing.T) {
+	t.Parallel()
+	m := New("anthropic", "claude-3-opus")
+	m.AddTokens(1000, 500)
+	m.IncrementIterations()
+	m.Finish()
+
+	summary := m.Summary()
+	if !strings.Contains(summary, "Agent Metrics") {
+		t.Fatalf("Summary() missing header")
+	}
+	if !strings.Contains(summary, "claude-3-opus") {
+		t.Fatalf("Summary() missing model name")
+	}
+	if !strings.Contains(summary, "anthropic") {
+		t.Fatalf("Summary() missing provider")
+	}
+	if !strings.Contains(summary, "Duration:") {
+		t.Fatalf("Summary() missing Duration")
+	}
+	if !strings.Contains(summary, "Iterations:") {
+		t.Fatalf("Summary() missing Iterations")
+	}
+	if !strings.Contains(summary, "Tokens:") {
+		t.Fatalf("Summary() missing Tokens")
+	}
+	if !strings.Contains(summary, "Cost:") {
+		t.Fatalf("Summary() missing Cost")
+	}
+	if !strings.Contains(summary, "$") {
+		t.Fatalf("Summary() missing dollar sign in cost")
+	}
+}
+
+func TestSummaryOllama(t *testing.T) {
+	t.Parallel()
+	m := New("ollama", "llama3")
+	m.AddTokens(1000, 500)
+	m.Finish()
+
+	summary := m.Summary()
+	if !strings.Contains(summary, "$0.00 (local)") {
+		t.Fatalf("Summary() should show $0.00 (local) for ollama")
+	}
+}
+
+func TestSummaryUnknownPricing(t *testing.T) {
+	t.Parallel()
+	m := New("unknown", "model")
+	m.AddTokens(1000, 500)
+	m.Finish()
+
+	summary := m.Summary()
+	if !strings.Contains(summary, "N/A (unknown pricing)") {
+		t.Fatalf("Summary() should show N/A for unknown pricing")
+	}
+}
+
+func TestMetricsIntegration(t *testing.T) {
+	t.Parallel()
+	// Simulate a typical agent run
+	m := New("openai", "gpt-4o")
+
+	// Simulate multiple iterations with token accumulation
+	for i := 0; i < 5; i++ {
+		m.IncrementIterations()
+		m.AddTokens(500, 200) // 500 input, 200 output per iteration
+	}
+
+	m.Finish()
+
+	if m.Iterations != 5 {
+		t.Fatalf("Iterations = %d, want 5", m.Iterations)
+	}
+	if m.InputTokens != 2500 {
+		t.Fatalf("InputTokens = %d, want 2500", m.InputTokens)
+	}
+	if m.OutputTokens != 1000 {
+		t.Fatalf("OutputTokens = %d, want 1000", m.OutputTokens)
+	}
+	if m.TotalTokens() != 3500 {
+		t.Fatalf("TotalTokens() = %d, want 3500", m.TotalTokens())
+	}
+
+	// Cost: (2500/1M * 2.50) + (1000/1M * 10.00) = 0.00625 + 0.01 = 0.01625
+	expectedCost := 0.01625
+	if m.Cost() != expectedCost {
+		t.Fatalf("Cost() = %v, want %v", m.Cost(), expectedCost)
+	}
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -143,107 +143,9 @@ func TestTotalTokens(t *testing.T) {
 	}
 }
 
-func TestGetPricingOpenAI(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		model  string
-		input  float64
-		output float64
-	}{
-		{"gpt-5", 15.00, 60.00},
-		{"gpt-5-turbo", 15.00, 60.00},
-		{"gpt-4o", 2.50, 10.00},
-		{"gpt-4o-mini", 0.15, 0.60},
-		{"gpt-4o-mini-2024", 0.15, 0.60},
-		{"gpt-4-turbo", 10.00, 30.00},
-		{"gpt-4-turbo-preview", 10.00, 30.00},
-		{"gpt-4", 30.00, 60.00},
-		{"gpt-4-0613", 30.00, 60.00},
-		{"gpt-3.5-turbo", 0.50, 1.50},
-		{"o1", 15.00, 60.00},
-		{"o1-preview", 15.00, 60.00},
-		{"o3", 10.00, 40.00},
-		{"o3-mini", 10.00, 40.00},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.model, func(t *testing.T) {
-			p := GetPricing("openai", tt.model)
-			if p.InputPerMillion != tt.input {
-				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
-			}
-			if p.OutputPerMillion != tt.output {
-				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
-			}
-		})
-	}
-}
-
-func TestGetPricingOpenAIResponses(t *testing.T) {
-	t.Parallel()
-	// openai-responses should use the same pricing as openai
-	p := GetPricing("openai-responses", "gpt-4o")
-	if p.InputPerMillion != 2.50 {
-		t.Fatalf("InputPerMillion = %v, want 2.50", p.InputPerMillion)
-	}
-}
-
-func TestGetPricingAnthropic(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		model  string
-		input  float64
-		output float64
-	}{
-		{"claude-3-opus", 15.00, 75.00},
-		{"claude-3-opus-20240229", 15.00, 75.00},
-		{"claude-3-sonnet", 3.00, 15.00},
-		{"claude-3-5-sonnet", 3.00, 15.00},
-		{"claude-3-haiku", 0.25, 1.25},
-		{"claude-3-5-haiku", 0.25, 1.25},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.model, func(t *testing.T) {
-			p := GetPricing("anthropic", tt.model)
-			if p.InputPerMillion != tt.input {
-				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
-			}
-			if p.OutputPerMillion != tt.output {
-				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
-			}
-		})
-	}
-}
-
-func TestGetPricingGemini(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		model  string
-		input  float64
-		output float64
-	}{
-		{"gemini-pro", 1.25, 5.00},
-		{"gemini-1.5-pro", 1.25, 5.00},
-		{"gemini-flash", 0.075, 0.30},
-		{"gemini-1.5-flash", 0.075, 0.30},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.model, func(t *testing.T) {
-			p := GetPricing("gemini", tt.model)
-			if p.InputPerMillion != tt.input {
-				t.Fatalf("InputPerMillion = %v, want %v", p.InputPerMillion, tt.input)
-			}
-			if p.OutputPerMillion != tt.output {
-				t.Fatalf("OutputPerMillion = %v, want %v", p.OutputPerMillion, tt.output)
-			}
-		})
-	}
-}
-
 func TestGetPricingOllama(t *testing.T) {
 	t.Parallel()
+	// Ollama is always free (local inference)
 	models := []string{"llama3", "mistral", "codellama", "phi3"}
 
 	for _, model := range models {
@@ -261,9 +163,11 @@ func TestGetPricingOllama(t *testing.T) {
 
 func TestGetPricingUnknown(t *testing.T) {
 	t.Parallel()
-	p := GetPricing("unknown-provider", "unknown-model")
+	// Unknown models should return zero pricing
+	p := GetPricing("unknown-provider", "unknown-model-xyz-123")
 	if p.InputPerMillion != 0 || p.OutputPerMillion != 0 {
-		t.Fatalf("unknown model should have zero pricing")
+		t.Fatalf("unknown model should have zero pricing, got input=%v output=%v",
+			p.InputPerMillion, p.OutputPerMillion)
 	}
 }
 
@@ -274,91 +178,46 @@ func TestGetPricingCaseInsensitive(t *testing.T) {
 	p2 := GetPricing("openai", "gpt-4o")
 
 	if p1.InputPerMillion != p2.InputPerMillion {
-		t.Fatalf("pricing should be case-insensitive")
+		t.Fatalf("pricing should be case-insensitive, got %v and %v",
+			p1.InputPerMillion, p2.InputPerMillion)
 	}
 }
 
-func TestCost(t *testing.T) {
+func TestGetPricingLiteLLMFetch(t *testing.T) {
+	// This test verifies that LiteLLM pricing is fetched for known models.
+	// It requires network access and may be skipped in CI.
+	if testing.Short() {
+		t.Skip("skipping network test in short mode")
+	}
+
+	// gpt-4o is a well-known model that should be in LiteLLM's database
+	p := GetPricing("openai", "gpt-4o")
+
+	// We don't check exact values since LiteLLM prices may change,
+	// but gpt-4o should have non-zero pricing
+	if p.InputPerMillion == 0 || p.OutputPerMillion == 0 {
+		t.Logf("Warning: gpt-4o returned zero pricing, LiteLLM fetch may have failed")
+	}
+}
+
+func TestCostCalculation(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name         string
-		provider     string
-		model        string
-		inputTokens  int64
-		outputTokens int64
-		wantCost     float64
-	}{
-		{
-			name:         "gpt-4o 1M tokens each",
-			provider:     "openai",
-			model:        "gpt-4o",
-			inputTokens:  1_000_000,
-			outputTokens: 1_000_000,
-			wantCost:     12.50, // 2.50 + 10.00
-		},
-		{
-			name:         "gpt-4o-mini 1M tokens each",
-			provider:     "openai",
-			model:        "gpt-4o-mini",
-			inputTokens:  1_000_000,
-			outputTokens: 1_000_000,
-			wantCost:     0.75, // 0.15 + 0.60
-		},
-		{
-			name:         "claude-3-sonnet 1M tokens each",
-			provider:     "anthropic",
-			model:        "claude-3-sonnet",
-			inputTokens:  1_000_000,
-			outputTokens: 1_000_000,
-			wantCost:     18.00, // 3.00 + 15.00
-		},
-		{
-			name:         "claude-3-haiku 1M tokens each",
-			provider:     "anthropic",
-			model:        "claude-3-haiku",
-			inputTokens:  1_000_000,
-			outputTokens: 1_000_000,
-			wantCost:     1.50, // 0.25 + 1.25
-		},
-		{
-			name:         "ollama free",
-			provider:     "ollama",
-			model:        "llama3",
-			inputTokens:  1_000_000,
-			outputTokens: 1_000_000,
-			wantCost:     0,
-		},
-		{
-			name:         "zero tokens",
-			provider:     "openai",
-			model:        "gpt-4o",
-			inputTokens:  0,
-			outputTokens: 0,
-			wantCost:     0,
-		},
-		{
-			name:         "small token count",
-			provider:     "openai",
-			model:        "gpt-4o",
-			inputTokens:  1000,
-			outputTokens: 500,
-			wantCost:     0.0075, // (1000/1M * 2.50) + (500/1M * 10.00) = 0.0025 + 0.005
-		},
+
+	// Test with Ollama (free)
+	m := New("ollama", "llama3")
+	m.AddTokens(1_000_000, 1_000_000)
+	if m.Cost() != 0 {
+		t.Fatalf("Ollama cost should be 0, got %v", m.Cost())
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := New(tt.provider, tt.model)
-			m.AddTokens(tt.inputTokens, tt.outputTokens)
-			cost := m.Cost()
-			if cost != tt.wantCost {
-				t.Fatalf("Cost() = %v, want %v", cost, tt.wantCost)
-			}
-		})
+	// Test with zero tokens
+	m2 := New("openai", "gpt-4o")
+	if m2.Cost() != 0 {
+		t.Fatalf("Zero tokens should have zero cost, got %v", m2.Cost())
 	}
 }
 
-func TestStringWithCost(t *testing.T) {
+func TestStringOutput(t *testing.T) {
 	t.Parallel()
 	m := New("openai", "gpt-4o")
 	m.AddTokens(100, 50)
@@ -377,9 +236,6 @@ func TestStringWithCost(t *testing.T) {
 	}
 	if !strings.Contains(s, "150 total") {
 		t.Fatalf("String() missing total tokens")
-	}
-	if !strings.Contains(s, "$") {
-		t.Fatalf("String() missing cost")
 	}
 }
 
@@ -402,12 +258,12 @@ func TestStringUnknownPricing(t *testing.T) {
 	m.Finish()
 
 	s := m.String()
-	if !strings.Contains(s, "N/A") {
-		t.Fatalf("String() should show N/A for unknown pricing, got: %s", s)
+	if !strings.Contains(s, "N/A (pricing not available yet)") {
+		t.Fatalf("String() should show pricing not available, got: %s", s)
 	}
 }
 
-func TestSummaryWithCost(t *testing.T) {
+func TestSummaryOutput(t *testing.T) {
 	t.Parallel()
 	m := New("anthropic", "claude-3-opus")
 	m.AddTokens(1000, 500)
@@ -436,9 +292,6 @@ func TestSummaryWithCost(t *testing.T) {
 	if !strings.Contains(summary, "Cost:") {
 		t.Fatalf("Summary() missing Cost")
 	}
-	if !strings.Contains(summary, "$") {
-		t.Fatalf("Summary() missing dollar sign in cost")
-	}
 }
 
 func TestSummaryOllama(t *testing.T) {
@@ -460,15 +313,15 @@ func TestSummaryUnknownPricing(t *testing.T) {
 	m.Finish()
 
 	summary := m.Summary()
-	if !strings.Contains(summary, "N/A (unknown pricing)") {
-		t.Fatalf("Summary() should show N/A for unknown pricing")
+	if !strings.Contains(summary, "N/A (pricing not available yet)") {
+		t.Fatalf("Summary() should show pricing not available")
 	}
 }
 
 func TestMetricsIntegration(t *testing.T) {
 	t.Parallel()
-	// Simulate a typical agent run
-	m := New("openai", "gpt-4o")
+	// Simulate a typical agent run with Ollama (guaranteed zero cost)
+	m := New("ollama", "llama3")
 
 	// Simulate multiple iterations with token accumulation
 	for i := 0; i < 5; i++ {
@@ -490,10 +343,60 @@ func TestMetricsIntegration(t *testing.T) {
 	if m.TotalTokens() != 3500 {
 		t.Fatalf("TotalTokens() = %d, want 3500", m.TotalTokens())
 	}
+	if m.Cost() != 0 {
+		t.Fatalf("Ollama cost should be 0, got %v", m.Cost())
+	}
+}
 
-	// Cost: (2500/1M * 2.50) + (1000/1M * 10.00) = 0.00625 + 0.01 = 0.01625
-	expectedCost := 0.01625
-	if m.Cost() != expectedCost {
-		t.Fatalf("Cost() = %v, want %v", m.Cost(), expectedCost)
+func TestCostString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		cost     float64
+		want     string
+	}{
+		{"positive cost", "openai", 1.2345, "$1.2345"},
+		{"zero cost ollama", "ollama", 0, "$0.00 (local)"},
+		{"zero cost unknown", "unknown", 0, "N/A (pricing not available yet)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Metrics{Provider: tt.provider}
+			got := m.costString(tt.cost)
+			if got != tt.want {
+				t.Fatalf("costString(%v) = %q, want %q", tt.cost, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPricingStatus(t *testing.T) {
+	// This test verifies PricingStatus returns sensible values.
+	// It requires network access for a successful fetch.
+	if testing.Short() {
+		t.Skip("skipping network test in short mode")
+	}
+
+	loaded, count, err := PricingStatus()
+
+	// If fetch succeeded, we should have models loaded
+	if loaded {
+		if count == 0 {
+			t.Fatal("PricingStatus reports loaded but count is 0")
+		}
+		if err != nil {
+			t.Fatalf("PricingStatus reports loaded but has error: %v", err)
+		}
+		t.Logf("Pricing loaded successfully: %d models", count)
+	} else {
+		// If not loaded, there should be an error explaining why
+		if err == nil {
+			t.Log("Warning: PricingStatus not loaded but no error reported")
+		} else {
+			t.Logf("Pricing not loaded: %v", err)
+		}
 	}
 }

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/tools"
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -68,7 +69,7 @@ func UseResponsesAPI(provider, model string) bool {
 }
 
 // RunWithTools drives a tool-calling loop using the OpenAI Responses API.
-func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, userPrompt, workingDir, organization string, temperature float64, maxTokens, maxIterations int, taskCfg *tools.TaskConfig) (string, error) {
+func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, userPrompt, workingDir, organization string, temperature float64, maxTokens, maxIterations int, taskCfg *tools.TaskConfig, m *metrics.Metrics) (string, error) {
 	client := newClient(apiKey, baseURL, organization)
 	handlers, toolDefs := tools.BuildHandlers(workingDir, taskCfg)
 	if maxIterations <= 0 {
@@ -99,8 +100,9 @@ func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, use
 		return "", fmt.Errorf("responses API call failed: %w", err)
 	}
 	logOutputItems(ctx, resp, "initial")
+	trackResponseMetrics(resp, m)
 
-	resp, text, err := toolLoop(ctx, client, resp, handlers, &rc, maxIterations)
+	resp, text, err := toolLoop(ctx, client, resp, handlers, &rc, maxIterations, m)
 	if err != nil {
 		return text, err
 	}
@@ -110,7 +112,7 @@ func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, use
 
 	// If the loop exited with pending function calls, resolve them with
 	// dummy outputs so PreviousResponseID chaining doesn't fail.
-	resp, text, err = resolvePendingCalls(ctx, client, resp, &rc)
+	resp, text, err = resolvePendingCalls(ctx, client, resp, &rc, m)
 	if err != nil {
 		return "", fmt.Errorf("responses API: resolvePendingCalls failed: %w", err)
 	}
@@ -118,7 +120,7 @@ func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, use
 		return text, nil
 	}
 
-	finalText, finalErr := requestFinal(ctx, client, resp.ID, systemPrompt, &rc)
+	finalText, finalErr := requestFinal(ctx, client, resp.ID, systemPrompt, &rc, m)
 	if finalErr == nil && finalText != "" {
 		return finalText, nil
 	}
@@ -126,6 +128,17 @@ func RunWithTools(ctx context.Context, apiKey, baseURL, model, systemPrompt, use
 		logging.DebugContext(ctx, "responses API: requestFinal error: %v", finalErr)
 	}
 	return "", fmt.Errorf("responses API: no usable text after tool loop (OutputText empty, requestFinal failed: %v)", finalErr)
+}
+
+// trackResponseMetrics extracts token usage from a response and adds it to metrics.
+func trackResponseMetrics(resp *oairesponses.Response, m *metrics.Metrics) {
+	if m == nil || resp == nil {
+		return
+	}
+	m.IncrementIterations()
+	if resp.Usage.InputTokens > 0 || resp.Usage.OutputTokens > 0 {
+		m.AddTokens(resp.Usage.InputTokens, resp.Usage.OutputTokens)
+	}
 }
 
 func newClient(apiKey, baseURL, organization string) openai.Client {
@@ -139,7 +152,7 @@ func newClient(apiKey, baseURL, organization string) openai.Client {
 	return openai.NewClient(clientOpts...)
 }
 
-func toolLoop(ctx context.Context, client openai.Client, resp *oairesponses.Response, handlers map[string]tools.Handler, rc *Config, maxIter int) (*oairesponses.Response, string, error) {
+func toolLoop(ctx context.Context, client openai.Client, resp *oairesponses.Response, handlers map[string]tools.Handler, rc *Config, maxIter int, m *metrics.Metrics) (*oairesponses.Response, string, error) {
 	var repeat tools.RepeatTracker
 	for i := 0; i < maxIter; i++ {
 		calls := ExtractFunctionCalls(resp)
@@ -176,6 +189,7 @@ func toolLoop(ctx context.Context, client openai.Client, resp *oairesponses.Resp
 			return resp, "", fmt.Errorf("responses API follow-up failed at iteration %d: %w", i+1, err)
 		}
 		logOutputItems(ctx, resp, fmt.Sprintf("follow-up-iter-%d", i+1))
+		trackResponseMetrics(resp, m)
 	}
 
 	text := resp.OutputText()
@@ -203,7 +217,7 @@ func checkRepeat(ctx context.Context, repeat *tools.RepeatTracker, calls []Funct
 	return false
 }
 
-func requestFinal(ctx context.Context, client openai.Client, previousID, systemPrompt string, rc *Config) (string, error) {
+func requestFinal(ctx context.Context, client openai.Client, previousID, systemPrompt string, rc *Config, m *metrics.Metrics) (string, error) {
 	if strings.TrimSpace(previousID) == "" {
 		return "", fmt.Errorf("missing previous response id")
 	}
@@ -228,6 +242,7 @@ func requestFinal(ctx context.Context, client openai.Client, previousID, systemP
 		return "", fmt.Errorf("responses API final call failed: %w", err)
 	}
 	logOutputItems(ctx, resp, "final-call")
+	trackResponseMetrics(resp, m)
 	text := resp.OutputText()
 	if text == "" {
 		return "", fmt.Errorf("responses API final call returned empty text")
@@ -239,7 +254,7 @@ func requestFinal(ctx context.Context, client openai.Client, previousID, systemP
 // resolvePendingCalls checks whether resp contains unresolved function_call
 // items and, if so, submits dummy outputs with ToolChoice=none so the
 // conversation is in a clean state for subsequent chaining.
-func resolvePendingCalls(ctx context.Context, client openai.Client, resp *oairesponses.Response, rc *Config) (*oairesponses.Response, string, error) {
+func resolvePendingCalls(ctx context.Context, client openai.Client, resp *oairesponses.Response, rc *Config, m *metrics.Metrics) (*oairesponses.Response, string, error) {
 	calls := ExtractFunctionCalls(resp)
 	if len(calls) == 0 {
 		return resp, resp.OutputText(), nil
@@ -279,6 +294,7 @@ func resolvePendingCalls(ctx context.Context, client openai.Client, resp *oaires
 		return resp, "", fmt.Errorf("resolve pending calls failed: %w", err)
 	}
 	logOutputItems(ctx, resolved, "resolve-pending")
+	trackResponseMetrics(resolved, m)
 	return resolved, resolved.OutputText(), nil
 }
 

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/tools"
 	openai "github.com/openai/openai-go/v3"
 	oairesponses "github.com/openai/openai-go/v3/responses"
@@ -349,6 +350,7 @@ func TestRunWithToolsNoToolCalls(t *testing.T) {
 		0,
 		1,
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
@@ -365,7 +367,7 @@ func TestRequestFinalMissingID(t *testing.T) {
 	t.Parallel()
 	client := openai.NewClient()
 	cfg := &Config{Model: "gpt-4o"}
-	if _, err := requestFinal(context.Background(), client, "", "sys", cfg); err == nil {
+	if _, err := requestFinal(context.Background(), client, "", "sys", cfg, nil); err == nil {
 		t.Fatalf("expected error")
 	}
 }
@@ -462,6 +464,7 @@ func TestRunWithToolsExhaustedWithPendingCalls(t *testing.T) {
 		0,
 		1, // maxIterations=1 → loop exits with pending calls
 		&tools.TaskConfig{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
@@ -560,6 +563,7 @@ func TestRunWithToolsFollowUp(t *testing.T) {
 		0,
 		2,
 		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
@@ -657,6 +661,7 @@ func TestRequestFinal(t *testing.T) {
 				"resp-1",
 				"system",
 				cfg,
+				nil,
 			)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("requestFinal() error = %v, wantErr %v", err, tt.wantErr)
@@ -744,10 +749,83 @@ func TestRunWithToolsErrors(t *testing.T) {
 				0,
 				1,
 				&tools.TaskConfig{},
+				nil,
 			)
 			if err == nil {
 				t.Fatalf("expected error")
 			}
 		})
+	}
+}
+
+func TestTrackResponseMetricsNilMetrics(t *testing.T) {
+	t.Parallel()
+	// Should not panic when metrics is nil
+	trackResponseMetrics(nil, nil) // nil response and nil metrics
+}
+
+func TestTrackResponseMetricsNilResponse(t *testing.T) {
+	t.Parallel()
+	m := &metrics.Metrics{}
+	trackResponseMetrics(nil, m)
+	// Should not increment or add tokens when response is nil
+	if m.Iterations != 0 {
+		t.Fatalf("Iterations = %d, want 0", m.Iterations)
+	}
+}
+
+func TestTrackResponseMetricsWithUsage(t *testing.T) {
+	t.Parallel()
+	m := metrics.New("openai", "gpt-4o")
+
+	// Create a mock response with usage data
+	resp := &oairesponses.Response{
+		Usage: oairesponses.ResponseUsage{
+			InputTokens:  1000,
+			OutputTokens: 500,
+		},
+	}
+
+	trackResponseMetrics(resp, m)
+
+	if m.Iterations != 1 {
+		t.Fatalf("Iterations = %d, want 1", m.Iterations)
+	}
+	if m.InputTokens != 1000 {
+		t.Fatalf("InputTokens = %d, want 1000", m.InputTokens)
+	}
+	if m.OutputTokens != 500 {
+		t.Fatalf("OutputTokens = %d, want 500", m.OutputTokens)
+	}
+}
+
+func TestTrackResponseMetricsAccumulates(t *testing.T) {
+	t.Parallel()
+	m := metrics.New("openai", "gpt-4o")
+
+	resp1 := &oairesponses.Response{
+		Usage: oairesponses.ResponseUsage{
+			InputTokens:  100,
+			OutputTokens: 50,
+		},
+	}
+	resp2 := &oairesponses.Response{
+		Usage: oairesponses.ResponseUsage{
+			InputTokens:  200,
+			OutputTokens: 100,
+		},
+	}
+
+	trackResponseMetrics(resp1, m)
+	trackResponseMetrics(resp2, m)
+
+	if m.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2", m.Iterations)
+	}
+	if m.InputTokens != 300 {
+		t.Fatalf("InputTokens = %d, want 300", m.InputTokens)
+	}
+	if m.OutputTokens != 150 {
+		t.Fatalf("OutputTokens = %d, want 150", m.OutputTokens)
 	}
 }

--- a/runner/model.go
+++ b/runner/model.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/ollama"
 	"github.com/cowdogmoo/squad/responses"
 	"github.com/cowdogmoo/squad/tools"
@@ -18,7 +19,7 @@ import (
 )
 
 // invokeModel resolves provider settings and calls the appropriate model backend.
-func invokeModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (string, error) {
+func invokeModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (string, *metrics.Metrics, error) {
 	provider := normalizeProvider(opts.Provider)
 	model := opts.Model
 	temperature := opts.Temperature
@@ -34,7 +35,7 @@ func invokeModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (s
 }
 
 // callModel dispatches the prompt to the appropriate model backend and returns the response.
-func callModel(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, error) {
+func callModel(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, *metrics.Metrics, error) {
 	if responses.UseResponsesAPI(provider, model) {
 		return callResponsesAPI(ctx, opts, model, systemPrompt, bundle, temperature, maxTokens, taskCfg)
 	}
@@ -42,13 +43,13 @@ func callModel(ctx context.Context, opts *RunOptions, provider, model, systemPro
 }
 
 // callResponsesAPI runs the prompt via the OpenAI Responses API.
-func callResponsesAPI(ctx context.Context, opts *RunOptions, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, error) {
+func callResponsesAPI(ctx context.Context, opts *RunOptions, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, *metrics.Metrics, error) {
 	apiKey := opts.APIKey
 	if apiKey == "" {
 		apiKey = os.Getenv("OPENAI_API_KEY")
 	}
 	if apiKey == "" {
-		return "", fmt.Errorf("API key required for OpenAI Responses API: use --api-key, config provider.token, or OPENAI_API_KEY env var")
+		return "", nil, fmt.Errorf("API key required for OpenAI Responses API: use --api-key, config provider.token, or OPENAI_API_KEY env var")
 	}
 
 	// Reasoning models (gpt-5*) consume output tokens on internal reasoning
@@ -60,33 +61,40 @@ func callResponsesAPI(ctx context.Context, opts *RunOptions, model, systemPrompt
 		maxTokens = responses.DefaultMaxOutputTokens
 	}
 
-	logging.InfoContext(ctx, "model call started via Responses API (model=%s)", model)
-	modelStart := time.Now()
-	response, err := responses.RunWithTools(ctx, apiKey, opts.BaseURL, model, systemPrompt, bundle.User, bundle.WorkDir, opts.Org, temperature, maxTokens, opts.MaxIterations, taskCfg)
-	if err != nil {
-		return "", fmt.Errorf("model call failed: %w", err)
+	provider := "openai"
+	if responses.UseResponsesAPI(opts.Provider, model) && opts.Provider == "openai-responses" {
+		provider = "openai-responses"
 	}
-	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
-	return response, nil
+
+	m := metrics.New(provider, model)
+	logging.InfoContext(ctx, "model call started via Responses API (model=%s)", model)
+	response, err := responses.RunWithTools(ctx, apiKey, opts.BaseURL, model, systemPrompt, bundle.User, bundle.WorkDir, opts.Org, temperature, maxTokens, opts.MaxIterations, taskCfg, m)
+	m.Finish()
+	if err != nil {
+		return "", m, fmt.Errorf("model call failed: %w", err)
+	}
+	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", m.Duration().Round(time.Millisecond), len(response))
+	return response, m, nil
 }
 
 // callLangChainLLM runs the prompt via a LangChain-compatible LLM.
-func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, error) {
+func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig) (string, *metrics.Metrics, error) {
 	llm, err := buildLLM(opts, provider, model)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	callOpts := buildCallOpts(opts, provider, temperature, maxTokens)
 
+	m := metrics.New(provider, model)
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
-	modelStart := time.Now()
-	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, opts.MaxIterations, taskCfg, callOpts...)
+	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, opts.MaxIterations, taskCfg, m, callOpts...)
+	m.Finish()
 	if err != nil {
-		return "", fmt.Errorf("model call failed: %w", err)
+		return "", m, fmt.Errorf("model call failed: %w", err)
 	}
-	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", time.Since(modelStart).Round(time.Millisecond), len(response))
-	return response, nil
+	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", m.Duration().Round(time.Millisecond), len(response))
+	return response, m, nil
 }
 
 // buildCallOpts constructs LLM call options from provider settings.
@@ -196,10 +204,10 @@ func buildTaskConfig(opts *RunOptions) *tools.TaskConfig {
 		AgentsDir:     opts.AgentsDir,
 		WorkingDir:    opts.WorkingDir,
 		MaxIterations: opts.MaxIterations,
-		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
 			childBundle, err := agent.BuildBundle(agentsDir, agentName, prompt, workingDir, mode)
 			if err != nil {
-				return "", fmt.Errorf("failed to build child agent bundle: %w", err)
+				return "", nil, fmt.Errorf("failed to build child agent bundle: %w", err)
 			}
 
 			childOpts := *opts

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -169,7 +169,7 @@ func TestCallLangChainLLMWithOllama(t *testing.T) {
 
 	opts := &RunOptions{Provider: "ollama", BaseURL: server.URL, MaxIterations: 1}
 	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
-	response, err := callLangChainLLM(
+	response, _, err := callLangChainLLM(
 		context.Background(),
 		opts,
 		"ollama",
@@ -244,7 +244,7 @@ func TestCallResponsesAPIRoundTrip(t *testing.T) {
 
 	opts := &RunOptions{APIKey: "key", BaseURL: server.URL, MaxIterations: 1}
 	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
-	response, err := callResponsesAPI(
+	response, _, err := callResponsesAPI(
 		context.Background(),
 		opts,
 		"gpt-5",
@@ -313,7 +313,7 @@ func TestBuildTaskConfigCallModel(t *testing.T) {
 	if cfg == nil {
 		t.Fatalf("expected task config")
 	}
-	_, err := cfg.CallModel(
+	_, _, err := cfg.CallModel(
 		context.Background(),
 		agentsDir,
 		agentName,
@@ -405,7 +405,7 @@ func TestCallModelRoutes(t *testing.T) {
 			}
 
 			bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
-			got, err := callModel(
+			got, _, err := callModel(
 				context.Background(),
 				opts,
 				tt.provider,
@@ -429,7 +429,7 @@ func TestCallModelRoutes(t *testing.T) {
 func TestCallLangChainLLMUnknownProvider(t *testing.T) {
 	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
 	opts := &RunOptions{Provider: "unknown"}
-	_, err := callLangChainLLM(
+	_, _, err := callLangChainLLM(
 		context.Background(),
 		opts,
 		"unknown",

--- a/runner/run.go
+++ b/runner/run.go
@@ -98,7 +98,7 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) {
 	if m == nil {
 		return
 	}
-	fmt.Fprintln(cmd.ErrOrStderr(), m.Summary())
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), m.Summary())
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.

--- a/runner/run.go
+++ b/runner/run.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/tools"
 	"github.com/spf13/cobra"
 )
@@ -71,12 +72,33 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	ctx := tools.InitEdits(cmd.Context())
 	cmd.SetContext(ctx)
 	tools.ResetEditsApplied(ctx)
-	response, err := invokeModel(ctx, opts, bundle)
+	response, m, err := invokeModel(ctx, opts, bundle)
 	if err != nil {
+		if m != nil {
+			printMetrics(cmd, m)
+		}
 		return err
 	}
 
-	return handleResponse(cmd, opts, response, workingDir)
+	if err := handleResponse(cmd, opts, response, workingDir); err != nil {
+		if m != nil {
+			printMetrics(cmd, m)
+		}
+		return err
+	}
+
+	if m != nil {
+		printMetrics(cmd, m)
+	}
+	return nil
+}
+
+// printMetrics outputs the metrics summary to stderr.
+func printMetrics(cmd *cobra.Command, m *metrics.Metrics) {
+	if m == nil {
+		return
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), m.Summary())
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.

--- a/runner/run.go
+++ b/runner/run.go
@@ -74,31 +74,29 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	tools.ResetEditsApplied(ctx)
 	response, m, err := invokeModel(ctx, opts, bundle)
 	if err != nil {
-		if m != nil {
-			printMetrics(cmd, m)
+		if metricsErr := printMetrics(cmd, m); metricsErr != nil {
+			logging.Warn("failed to print metrics: %v", metricsErr)
 		}
 		return err
 	}
 
 	if err := handleResponse(cmd, opts, response, workingDir); err != nil {
-		if m != nil {
-			printMetrics(cmd, m)
+		if metricsErr := printMetrics(cmd, m); metricsErr != nil {
+			logging.Warn("failed to print metrics: %v", metricsErr)
 		}
 		return err
 	}
 
-	if m != nil {
-		printMetrics(cmd, m)
-	}
-	return nil
+	return printMetrics(cmd, m)
 }
 
 // printMetrics outputs the metrics summary to stderr.
-func printMetrics(cmd *cobra.Command, m *metrics.Metrics) {
+func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 	if m == nil {
-		return
+		return nil
 	}
-	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), m.Summary())
+	_, err := fmt.Fprintln(cmd.ErrOrStderr(), m.Summary())
+	return err
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -439,7 +439,9 @@ func TestPrintMetrics(t *testing.T) {
 	m.IncrementIterations()
 	m.Finish()
 
-	printMetrics(cmd, m)
+	if err := printMetrics(cmd, m); err != nil {
+		t.Fatalf("printMetrics() returned error: %v", err)
+	}
 
 	output := errBuf.String()
 	if !strings.Contains(output, "Agent Metrics") {
@@ -465,8 +467,9 @@ func TestPrintMetricsNil(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetErr(&errBuf)
 
-	// Should not panic when metrics is nil
-	printMetrics(cmd, nil)
+	if err := printMetrics(cmd, nil); err != nil {
+		t.Fatalf("printMetrics(nil) returned error: %v", err)
+	}
 
 	if errBuf.Len() != 0 {
 		t.Fatalf("printMetrics(nil) should not output anything, got: %q", errBuf.String())

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/spf13/cobra"
 )
 
@@ -327,7 +328,7 @@ func TestInvokeModelMissingAPIKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	opts := &RunOptions{Provider: "openai-responses", Model: "gpt-5"}
 	bundle := &agent.Bundle{System: "sys", User: "user", WorkDir: "."}
-	_, err := invokeModel(context.Background(), opts, bundle)
+	_, _, err := invokeModel(context.Background(), opts, bundle)
 	if err == nil {
 		t.Fatalf("expected error for missing API key")
 	}
@@ -424,5 +425,50 @@ func TestExecuteRunSuccessOllama(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "ok") {
 		t.Fatalf("expected response output, got %q", buf.String())
+	}
+}
+
+func TestPrintMetrics(t *testing.T) {
+	t.Parallel()
+	var errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&errBuf)
+
+	m := metrics.New("openai", "gpt-4o")
+	m.AddTokens(1000, 500)
+	m.IncrementIterations()
+	m.Finish()
+
+	printMetrics(cmd, m)
+
+	output := errBuf.String()
+	if !strings.Contains(output, "Agent Metrics") {
+		t.Fatalf("printMetrics() missing header in output: %q", output)
+	}
+	if !strings.Contains(output, "gpt-4o") {
+		t.Fatalf("printMetrics() missing model in output: %q", output)
+	}
+	if !strings.Contains(output, "openai") {
+		t.Fatalf("printMetrics() missing provider in output: %q", output)
+	}
+	if !strings.Contains(output, "1000 input") {
+		t.Fatalf("printMetrics() missing input tokens in output: %q", output)
+	}
+	if !strings.Contains(output, "500 output") {
+		t.Fatalf("printMetrics() missing output tokens in output: %q", output)
+	}
+}
+
+func TestPrintMetricsNil(t *testing.T) {
+	t.Parallel()
+	var errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&errBuf)
+
+	// Should not panic when metrics is nil
+	printMetrics(cmd, nil)
+
+	if errBuf.Len() != 0 {
+		t.Fatalf("printMetrics(nil) should not output anything, got: %q", errBuf.String())
 	}
 }

--- a/tools/task.go
+++ b/tools/task.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/tmc/langchaingo/llms"
 )
 
@@ -30,7 +31,7 @@ func TaskDepth(ctx context.Context) int {
 
 // CallModelFunc is the function signature for invoking a model run from
 // within the Task tool. It mirrors the core model invocation path.
-type CallModelFunc func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error)
+type CallModelFunc func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error)
 
 // TaskConfig holds the configuration needed to spawn child agent runs
 // from within the Task tool.
@@ -98,7 +99,7 @@ func taskTool(cfg TaskConfig) func(ctx context.Context, rawArgs []byte) (string,
 		childCtx := WithTaskDepth(ctx, depth+1)
 		logging.InfoContext(ctx, "Task tool: spawning child agent=%s depth=%d", args.Agent, depth+1)
 
-		response, err := cfg.CallModel(childCtx, cfg.AgentsDir, args.Agent, args.Prompt, workDir, args.Mode)
+		response, childMetrics, err := cfg.CallModel(childCtx, cfg.AgentsDir, args.Agent, args.Prompt, workDir, args.Mode)
 		if err != nil {
 			return "", fmt.Errorf("child agent %q failed: %w", args.Agent, err)
 		}
@@ -108,7 +109,11 @@ func taskTool(cfg TaskConfig) func(ctx context.Context, rawArgs []byte) (string,
 			response = response[:maxToolOutput] + "\n...output truncated"
 		}
 
-		logging.InfoContext(ctx, "Task tool: child agent=%s completed (%d bytes)", args.Agent, len(response))
+		metricsInfo := ""
+		if childMetrics != nil {
+			metricsInfo = fmt.Sprintf(" tokens=%d", childMetrics.TotalTokens())
+		}
+		logging.InfoContext(ctx, "Task tool: child agent=%s completed (%d bytes%s)", args.Agent, len(response), metricsInfo)
 		return response, nil
 	}
 }

--- a/tools/task_test.go
+++ b/tools/task_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cowdogmoo/squad/metrics"
 )
 
 func TestTaskTool(t *testing.T) {
@@ -14,14 +16,14 @@ func TestTaskTool(t *testing.T) {
 	cfg := TaskConfig{
 		AgentsDir:  "agents",
 		WorkingDir: dir,
-		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
 			if TaskDepth(ctx) != 1 {
 				t.Fatalf("expected depth 1, got %d", TaskDepth(ctx))
 			}
 			if workingDir != filepath.Join(dir, "sub") {
 				t.Fatalf("unexpected working dir: %s", workingDir)
 			}
-			return "response", nil
+			return "response", nil, nil
 		},
 	}
 
@@ -46,8 +48,8 @@ func TestTaskToolErrors(t *testing.T) {
 	cfg := TaskConfig{
 		AgentsDir:  "agents",
 		WorkingDir: dir,
-		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
-			return "", fmt.Errorf("boom")
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			return "", nil, fmt.Errorf("boom")
 		},
 	}
 	tool := taskTool(cfg)
@@ -105,8 +107,8 @@ func TestTaskToolErrors(t *testing.T) {
 			config: TaskConfig{
 				AgentsDir:  "agents",
 				WorkingDir: dir,
-				CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
-					return longResponse, nil
+				CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+					return longResponse, nil, nil
 				},
 			},
 			wantOutput: "...output truncated",
@@ -140,8 +142,8 @@ func TestTaskToolErrors(t *testing.T) {
 }
 
 func TestTaskToolDepthLimit(t *testing.T) {
-	cfg := TaskConfig{WorkingDir: t.TempDir(), CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, error) {
-		return "", nil
+	cfg := TaskConfig{WorkingDir: t.TempDir(), CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+		return "", nil, nil
 	}}
 	tool := taskTool(cfg)
 	payload, _ := json.Marshal(map[string]string{

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/tmc/langchaingo/llms"
 )
 
@@ -111,7 +112,7 @@ func (t *RepeatTracker) Exceeded() bool {
 }
 
 // RunWithTools drives a tool-calling loop for LangChainGo-based models.
-func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, maxIterations int, taskCfg *TaskConfig, callOpts ...llms.CallOption) (string, error) {
+func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, maxIterations int, taskCfg *TaskConfig, m *metrics.Metrics, callOpts ...llms.CallOption) (string, error) {
 	handlers, toolDefs := BuildHandlers(workingDir, taskCfg)
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
@@ -120,7 +121,7 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	}
 
 	messages := buildInitialMessages(systemPrompt, userPrompt)
-	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, callOpts)
+	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, m, callOpts)
 	if done {
 		return lastContent, nil
 	}
@@ -128,10 +129,10 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		return lastContent, loopErr
 	}
 
-	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, callOpts)
+	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, m, callOpts)
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter int, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter int, m *metrics.Metrics, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
 	var lastContent string
 	var repeat RepeatTracker
 	for i := 0; i < maxIter; i++ {
@@ -148,9 +149,16 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 			return lastContent, messages, fmt.Errorf("model returned empty response"), false
 		}
 
+		if m != nil {
+			m.IncrementIterations()
+		}
+
 		choice := response.Choices[0]
 		if gi := choice.GenerationInfo; gi != nil {
 			logging.DebugContext(ctx, "generation info: %v", gi)
+			if m != nil {
+				extractTokenUsage(gi, m)
+			}
 		}
 		if choice.Content != "" {
 			lastContent = choice.Content
@@ -173,16 +181,66 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 	return lastContent, messages, nil, false
 }
 
-func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, maxIter int, callOpts []llms.CallOption) (string, error) {
+// extractTokenUsage extracts token counts from GenerationInfo and adds them to metrics.
+func extractTokenUsage(gi map[string]any, m *metrics.Metrics) {
+	if m == nil {
+		return
+	}
+	inputKeys := []string{"PromptTokens", "prompt_tokens", "InputTokens", "input_tokens"}
+	outputKeys := []string{"CompletionTokens", "completion_tokens", "OutputTokens", "output_tokens"}
+
+	input := extractTokenValue(gi, inputKeys)
+	output := extractTokenValue(gi, outputKeys)
+
+	if input > 0 || output > 0 {
+		m.AddTokens(input, output)
+	}
+}
+
+// extractTokenValue tries to extract a token count from the map using the given keys.
+func extractTokenValue(gi map[string]any, keys []string) int64 {
+	for _, key := range keys {
+		if v, ok := gi[key]; ok {
+			if val := toInt64(v); val > 0 {
+				return val
+			}
+		}
+	}
+	return 0
+}
+
+// toInt64 converts various numeric types to int64.
+func toInt64(v any) int64 {
+	switch t := v.(type) {
+	case int:
+		return int64(t)
+	case int64:
+		return t
+	case float64:
+		return int64(t)
+	default:
+		return 0
+	}
+}
+
+func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, maxIter int, m *metrics.Metrics, callOpts []llms.CallOption) (string, error) {
 	logging.InfoContext(ctx, "tool loop ended, requesting final response with tool_choice=none")
 	finalOpts := make([]llms.CallOption, len(callOpts), len(callOpts)+1)
 	copy(finalOpts, callOpts)
 	finalOpts = append(finalOpts, llms.WithToolChoice("none"))
 
 	response, err := llm.GenerateContent(ctx, messages, finalOpts...)
-	if err == nil && response != nil && len(response.Choices) > 0 && response.Choices[0].Content != "" {
-		logging.InfoContext(ctx, "final call produced response (%d bytes)", len(response.Choices[0].Content))
-		return response.Choices[0].Content, nil
+	if err == nil && response != nil && len(response.Choices) > 0 {
+		if m != nil {
+			m.IncrementIterations()
+			if gi := response.Choices[0].GenerationInfo; gi != nil {
+				extractTokenUsage(gi, m)
+			}
+		}
+		if response.Choices[0].Content != "" {
+			logging.InfoContext(ctx, "final call produced response (%d bytes)", len(response.Choices[0].Content))
+			return response.Choices[0].Content, nil
+		}
 	}
 
 	if lastContent != "" {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/tmc/langchaingo/llms"
 )
 
@@ -211,8 +212,8 @@ func TestBuildHandlers(t *testing.T) {
 					CallModel: func(
 						_ context.Context,
 						_, _, _, _, _ string,
-					) (string, error) {
-						return "", nil
+					) (string, *metrics.Metrics, error) {
+						return "", nil, nil
 					},
 				}
 			}
@@ -795,7 +796,7 @@ func TestRunWithToolsLoop(t *testing.T) {
 		},
 	}}
 
-	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 2, nil)
+	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 2, nil, nil)
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
 	}
@@ -807,7 +808,7 @@ func TestRunWithToolsLoop(t *testing.T) {
 func TestFinishToolLoopFallback(t *testing.T) {
 	t.Parallel()
 	llm := &fakeLLM{responses: []*llms.ContentResponse{{Choices: []*llms.ContentChoice{{Content: ""}}}}}
-	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, nil, nil)
 	if err != nil {
 		t.Fatalf("finishToolLoop() error = %v", err)
 	}
@@ -836,7 +837,7 @@ func TestRunWithToolsErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := RunWithTools(context.Background(), tt.llm, "", "user", t.TempDir(), 1, nil)
+			_, err := RunWithTools(context.Background(), tt.llm, "", "user", t.TempDir(), 1, nil, nil)
 			if err == nil {
 				t.Fatalf("expected error")
 			}
@@ -848,7 +849,7 @@ func TestFinishToolLoopFinalContent(t *testing.T) {
 	llm := &stubLLM{
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final"}}},
 	}
-	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil)
 	if err != nil {
 		t.Fatalf("finishToolLoop() error = %v", err)
 	}
@@ -859,8 +860,133 @@ func TestFinishToolLoopFinalContent(t *testing.T) {
 
 func TestFinishToolLoopErrorNoContent(t *testing.T) {
 	llm := &stubLLM{err: errors.New("boom")}
-	_, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil)
+	_, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil)
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestExtractTokenUsage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		gi         map[string]any
+		wantInput  int64
+		wantOutput int64
+	}{
+		{
+			name:       "nil gi",
+			gi:         nil,
+			wantInput:  0,
+			wantOutput: 0,
+		},
+		{
+			name:       "empty gi",
+			gi:         map[string]any{},
+			wantInput:  0,
+			wantOutput: 0,
+		},
+		{
+			name:       "PromptTokens/CompletionTokens (OpenAI style)",
+			gi:         map[string]any{"PromptTokens": 100, "CompletionTokens": 50},
+			wantInput:  100,
+			wantOutput: 50,
+		},
+		{
+			name:       "prompt_tokens/completion_tokens (snake_case)",
+			gi:         map[string]any{"prompt_tokens": 200, "completion_tokens": 100},
+			wantInput:  200,
+			wantOutput: 100,
+		},
+		{
+			name:       "InputTokens/OutputTokens (Anthropic style)",
+			gi:         map[string]any{"InputTokens": 300, "OutputTokens": 150},
+			wantInput:  300,
+			wantOutput: 150,
+		},
+		{
+			name:       "input_tokens/output_tokens (snake_case)",
+			gi:         map[string]any{"input_tokens": 400, "output_tokens": 200},
+			wantInput:  400,
+			wantOutput: 200,
+		},
+		{
+			name:       "int64 values",
+			gi:         map[string]any{"PromptTokens": int64(500), "CompletionTokens": int64(250)},
+			wantInput:  500,
+			wantOutput: 250,
+		},
+		{
+			name:       "float64 values",
+			gi:         map[string]any{"PromptTokens": float64(600), "CompletionTokens": float64(300)},
+			wantInput:  600,
+			wantOutput: 300,
+		},
+		{
+			name:       "only input tokens",
+			gi:         map[string]any{"PromptTokens": 100},
+			wantInput:  100,
+			wantOutput: 0,
+		},
+		{
+			name:       "only output tokens",
+			gi:         map[string]any{"CompletionTokens": 50},
+			wantInput:  0,
+			wantOutput: 50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := metrics.New("openai", "gpt-4o")
+			if tt.gi != nil {
+				extractTokenUsage(tt.gi, m)
+			}
+			if m.InputTokens != tt.wantInput {
+				t.Fatalf("InputTokens = %d, want %d", m.InputTokens, tt.wantInput)
+			}
+			if m.OutputTokens != tt.wantOutput {
+				t.Fatalf("OutputTokens = %d, want %d", m.OutputTokens, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestExtractTokenUsageNilMetrics(t *testing.T) {
+	t.Parallel()
+	// Should not panic when metrics is nil
+	gi := map[string]any{"PromptTokens": 100, "CompletionTokens": 50}
+	extractTokenUsage(gi, nil) // Should not panic
+}
+
+func TestRunWithToolsWithMetrics(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	llm := &fakeLLM{responses: []*llms.ContentResponse{
+		{Choices: []*llms.ContentChoice{{
+			Content: "done",
+			GenerationInfo: map[string]any{
+				"PromptTokens":     100,
+				"CompletionTokens": 50,
+			},
+		}}},
+	}}
+
+	m := metrics.New("openai", "gpt-4o")
+	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 2, nil, m)
+	if err != nil {
+		t.Fatalf("RunWithTools() error = %v", err)
+	}
+	if out != "done" {
+		t.Fatalf("output = %q, want %q", out, "done")
+	}
+	if m.Iterations != 1 {
+		t.Fatalf("Iterations = %d, want 1", m.Iterations)
+	}
+	if m.InputTokens != 100 {
+		t.Fatalf("InputTokens = %d, want 100", m.InputTokens)
+	}
+	if m.OutputTokens != 50 {
+		t.Fatalf("OutputTokens = %d, want 50", m.OutputTokens)
 	}
 }


### PR DESCRIPTION

**Key Changes:**

- Introduced agent metrics tracking for model calls, capturing input/output tokens and iteration counts
- Integrated metrics reporting and summary output into the agent runner workflow
- Updated core agent, tool, and model interfaces to propagate and accumulate metrics
- Added comprehensive unit tests for metrics collection and reporting

**Added:**

- Agent metrics tracking with input/output token counts, iteration counts, and duration via the `metrics.Metrics` structure, used throughout model, tool, and runner flows
- `trackResponseMetrics` function in `responses/responses.go` to accumulate token and iteration metrics for OpenAI Responses API calls
- Extraction of token usage from `GenerationInfo` in LangChainGo tool flows, with helper functions to parse and accumulate token counts
- `printMetrics` function in `runner/run.go` to output a summary of agent metrics to stderr after each run
- Extensive new tests for metrics accumulation, summary output, nil handling, and integration with model and tool execution

**Changed:**

- All core model invocation paths (`invokeModel`, `callModel`, `callResponsesAPI`, `callLangChainLLM`) now return a metrics object in addition to the response and error
- The `TaskConfig.CallModel` function signature and all related task tool invocations updated to propagate metrics from child agent runs
- Tool loop and final response handling in both OpenAI and LangChainGo flows now increment iteration metrics and accumulate token usage
- Runner logic updated to print metrics summary after completion or error, ensuring visibility of usage statistics for every run
- Tests for runner, model, and tool logic updated to validate new metrics parameters and output

**Removed:**

- Outdated handling of model call timing and logging replaced by metrics-based duration tracking and reporting