### PR TITLE
feat: add agent output grading and agent scaffolding system

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -35,14 +35,37 @@ type TemplateData struct {
 	Mode string
 }
 
+// makeIncludeFunc creates an include function that reads from the _templates directory.
+// Templates can use {{include "hard-rules/universal.md"}} to include shared content.
+func makeIncludeFunc(agentsDir string) func(string) (string, error) {
+	return func(path string) (string, error) {
+		// Validate path doesn't escape _templates directory
+		if strings.Contains(path, "..") {
+			return "", fmt.Errorf("include path cannot contain '..': %s", path)
+		}
+
+		templatePath := filepath.Join(agentsDir, "_templates", path)
+		content, err := os.ReadFile(templatePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to include template %s: %w", path, err)
+		}
+		return strings.TrimSpace(string(content)), nil
+	}
+}
+
 // processTemplate executes a Go text/template with the given mode.
 // Templates can use {{if eq .Mode "edit"}}...{{end}} conditionals.
-func processTemplate(name, content, mode string) (string, error) {
+// Templates can use {{include "hard-rules/universal.md"}} to include shared content.
+func processTemplate(name, content, mode, agentsDir string) (string, error) {
 	if mode == "" {
 		mode = "edit"
 	}
 
-	tmpl, err := template.New(name).Parse(content)
+	funcMap := template.FuncMap{
+		"include": makeIncludeFunc(agentsDir),
+	}
+
+	tmpl, err := template.New(name).Funcs(funcMap).Parse(content)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template %s: %w", name, err)
 	}
@@ -100,7 +123,7 @@ func loadManifest(agentPath string) (*Manifest, error) {
 }
 
 // loadAndProcessPrompts loads system, wrapper, and task files, then processes them as templates.
-func loadAndProcessPrompts(agentPath string, manifest *Manifest, mode string) (system, wrapper, task string, err error) {
+func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, mode string) (system, wrapper, task string, err error) {
 	systemData, err := os.ReadFile(filepath.Join(agentPath, manifest.EntryPoint))
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to read system prompt: %w", err)
@@ -114,16 +137,16 @@ func loadAndProcessPrompts(agentPath string, manifest *Manifest, mode string) (s
 		return "", "", "", err
 	}
 
-	system, err = processTemplate("system", string(systemData), mode)
+	system, err = processTemplate("system", string(systemData), mode, agentsDir)
 	if err != nil {
 		return "", "", "", err
 	}
-	wrapper, err = processTemplate("wrapper", string(wrapperData), mode)
+	wrapper, err = processTemplate("wrapper", string(wrapperData), mode, agentsDir)
 	if err != nil {
 		return "", "", "", err
 	}
 	if taskContent != "" {
-		task, err = processTemplate("task", taskContent, mode)
+		task, err = processTemplate("task", taskContent, mode, agentsDir)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -147,7 +170,7 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string) (*Bundle
 		displayMode = "edit"
 	}
 
-	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(agentPath, manifest, mode)
+	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(agentPath, agentsDir, manifest, mode)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -167,6 +167,99 @@ wrapper: wrapper.txt
 	assertContains(t, string(bundle.Combined), "Begin.", "combined")
 }
 
+func TestBuildBundle_IncludeFunction(t *testing.T) {
+	// Create agents directory with _templates
+	dir := t.TempDir()
+	templatesDir := filepath.Join(dir, "_templates", "hard-rules")
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templatesDir, "test-rules.md"), []byte("Included rule content"), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	// Create agent with include directive
+	agentDir := filepath.Join(dir, "demo")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+
+	manifest := `name: Demo
+version: v1
+entrypoint: system.txt
+wrapper: wrapper.txt
+`
+	systemContent := `System prompt
+{{include "hard-rules/test-rules.md"}}
+End of system`
+	writeTestFiles(t, agentDir, map[string]string{
+		"agent.yaml":  manifest,
+		"system.txt":  systemContent,
+		"wrapper.txt": "wrapper",
+	})
+
+	bundle, err := BuildBundle(dir, "demo", "prompt", "/work", "edit")
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	assertContains(t, bundle.System, "Included rule content", "system")
+	assertContains(t, bundle.System, "System prompt", "system")
+	assertContains(t, bundle.System, "End of system", "system")
+}
+
+func TestBuildBundle_IncludePathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "demo")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+
+	manifest := `name: Demo
+version: v1
+entrypoint: system.txt
+wrapper: wrapper.txt
+`
+	systemContent := `{{include "../../../etc/passwd"}}`
+	writeTestFiles(t, agentDir, map[string]string{
+		"agent.yaml":  manifest,
+		"system.txt":  systemContent,
+		"wrapper.txt": "wrapper",
+	})
+
+	_, err := BuildBundle(dir, "demo", "prompt", "/work", "edit")
+	if err == nil {
+		t.Fatalf("expected error for path traversal")
+	}
+	assertContains(t, err.Error(), "cannot contain '..'", "error")
+}
+
+func TestBuildBundle_IncludeMissingTemplate(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "demo")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+
+	manifest := `name: Demo
+version: v1
+entrypoint: system.txt
+wrapper: wrapper.txt
+`
+	systemContent := `{{include "nonexistent.md"}}`
+	writeTestFiles(t, agentDir, map[string]string{
+		"agent.yaml":  manifest,
+		"system.txt":  systemContent,
+		"wrapper.txt": "wrapper",
+	})
+
+	_, err := BuildBundle(dir, "demo", "prompt", "/work", "edit")
+	if err == nil {
+		t.Fatalf("expected error for missing template")
+	}
+	assertContains(t, err.Error(), "failed to include template", "error")
+}
+
 func TestBuildBundleErrors(t *testing.T) {
 	baseManifest := `name: Demo
 version: v1

--- a/agents/_templates/hard-rules/efficiency.md
+++ b/agents/_templates/hard-rules/efficiency.md
@@ -1,0 +1,63 @@
+# Efficiency Rules
+
+Maximize output quality while minimizing iteration count.
+
+## Iteration Budget
+
+Budget allocation scales with codebase size:
+
+| Codebase Size | File Count | Max Iterations |
+|---------------|------------|----------------|
+| Small         | ≤20 files  | 12 iterations  |
+| Medium        | 21-50 files| 20 iterations  |
+| Large         | 50+ files  | 25 iterations  |
+
+## Phase Budget Allocation
+
+- **Phase 1 (Discover):** 1 iteration — Glob + reference reads
+- **Phase 2 (Analyze):** varies by size — read ALL files, run static analysis
+- **Phase 3 (Fix):** 2-4 iterations — ALL fixes batched
+- **Phase 4 (Report):** 1 iteration — verify + report in SAME response
+
+## Read Strategy by Size
+
+- **Small (≤20):** Read ALL files in 2-3 iterations (6-10 files per iteration)
+- **Medium (21-50):** Read ALL files in 4-5 iterations
+- **Large (50+):** Prioritize entry points and core modules. Sample remaining
+  files. Document what was skipped and why.
+
+## Batching Rules
+
+1. **Batch file reads.** Read 4-6 files per Read call. Never read one file
+   per iteration.
+
+2. **Batch edits by file.** Make ALL edits to a single file in ONE iteration.
+   If a file needs 5 fixes, make 5 Edit calls in the same response.
+
+3. **Efficient tool calls.** Use one Grep/Glob call on the repo root instead
+   of N calls per-directory. Search the whole tree in one shot.
+
+## Anti-Patterns to Avoid
+
+- Reading one file per iteration
+- Re-reading files after editing (trust the Edit tool's output)
+- Making one edit per iteration instead of batching
+- Running extra tool calls after verification passes
+- Retrying failed tools instead of moving on
+
+## Coverage vs Efficiency Balance
+
+**Coverage is mandatory** for small/medium codebases. Do NOT skip files to
+save iterations — that defeats the purpose of the review. For large codebases,
+document what was sampled vs skipped.
+
+## Wind-Down Protocol
+
+When approaching your iteration limit:
+
+1. Stop applying new fixes immediately
+2. Run final verification
+3. Produce the structured report
+4. Populate skipped-findings from notes taken during analysis
+
+A partial report with accurate results is infinitely better than no report at all.

--- a/agents/_templates/hard-rules/universal.md
+++ b/agents/_templates/hard-rules/universal.md
@@ -1,0 +1,73 @@
+# Universal Hard Rules
+
+These rules apply to ALL review agents. They override everything else.
+
+## Discovery & Analysis
+
+1. **Discover code yourself.** Use Glob to find all relevant source files.
+   Filter out test files, vendor directories, and cache folders. Read each
+   file before analyzing it. Never guess at file contents.
+
+2. **Batch file reads.** Read 4-6 files per iteration by batching Read calls.
+   Do NOT read one file per iteration — that wastes your iteration budget.
+
+3. **Cross-reference files.** Check that types, functions, and error handling
+   are consistent across package/module boundaries — not just within single files.
+
+## Change Discipline
+
+4. **No cosmetic-only changes.** Skip doc comments, import ordering, naming
+   style preferences, and whitespace adjustments. Every edit must fix a
+   functional or best-practice violation. Doc comments are the #1 false
+   positive — ban them explicitly.
+
+5. **Changes must pass verification.** Run the appropriate verification
+   command (build, lint, tests) after every batch of edits. If verification
+   fails, fix the error or revert before continuing.
+
+6. **Follow existing conventions.** Read surrounding code before editing.
+   Match the existing style for error messages, variable naming, logging,
+   and code organization. Check existing imports before adding new ones.
+
+7. **Preserve backwards compatibility.** Do not rename exported/public
+   functions, change function signatures, remove exported types, or alter
+   the public API surface. If something is wrong but published, note it —
+   do not change it.
+
+8. **Test-asserted behavior is UNFIXABLE.** Before applying ANY fix, search
+   for tests that reference the function or type you are changing. If a test
+   asserts the current behavior, the fix is **FORBIDDEN**. Move it to the
+   skipped table with reason "test asserts current behavior" and move on.
+   You CANNOT edit test files, so you cannot change what the tests expect.
+
+9. **Do no harm.** Every fix must be strictly better than the original code.
+   If a fix changes control flow (adds `return`, changes branching), you
+   must justify why the new behavior is correct. If the only available fix
+   is a lateral move (equally imperfect), skip it.
+
+10. **Proportionality.** Every fix must be proportional to the problem. A
+    micro-optimization for a 3-element loop is over-engineering, not a fix.
+    Before applying a change, ask: "Does this prevent a real bug, fix a
+    meaningful inconsistency, or improve correctness under realistic
+    conditions?" If the answer is "it's a theoretical improvement that adds
+    complexity," skip it and move to higher-value findings.
+
+## Efficiency
+
+11. **Efficiency with iterations.** Read each file ONCE and take notes. Do
+    not re-read files you have already analyzed. Batch your analysis of all
+    files first, then apply fixes. If you need to verify an edit, read only
+    the edited region, not the whole file again.
+
+12. **No post-fix exploration.** Once all fixes are applied and verified,
+    go directly to the report. Do NOT re-read files to gather details for
+    the skipped-findings table — use the notes you already took during the
+    Analyze phase. Do NOT run extra Grep scans for patterns you already
+    checked.
+
+13. **STOP after verification.** Once verification passes, emit the report
+    IMMEDIATELY in the SAME response. Do NOT:
+    - Re-read files after verification passes
+    - Run extra Grep or Glob calls
+    - Use Bash commands (cat, head, tail) to inspect files
+    Every tool call after verification is wasted.

--- a/agents/_templates/output/edit-format.md
+++ b/agents/_templates/output/edit-format.md
@@ -1,0 +1,41 @@
+# Edit Mode Output Format
+
+**CRITICAL**: Your output MUST follow this exact structure. An automated
+validator checks for these sections.
+
+## Changes Summary
+
+[Brief overview of what was changed and why — 2-3 sentences max]
+
+## Issues Found and Fixed
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
+
+**What was changed:**
+[1-2 sentences describing the change]
+
+**Why:**
+[1-2 sentences referencing best practices or standards]
+
+---
+
+## Issues Found but Skipped
+
+| Issue | Severity | File | Reason Skipped |
+|-------|----------|------|----------------|
+| [title] | [sev] | [file] | [why: too risky, needs new dep, test-asserted, etc.] |
+
+## Files Touched
+
+- `path/to/file1.ext` — [specific change description]
+- `path/to/file2.ext` — [specific change description]
+
+## Validation
+
+- `[verification command]`: PASS/FAIL
+- `[test command]`: PASS/FAIL/SKIPPED (not available)

--- a/agents/_templates/output/readonly-format.md
+++ b/agents/_templates/output/readonly-format.md
@@ -1,0 +1,37 @@
+# Read-Only Mode Output Format
+
+**CRITICAL**: Your output MUST follow this exact structure.
+
+## Analysis Summary
+
+**Files analyzed:** [N]
+**Total findings:** [N]
+**By severity:** CRITICAL: [N], HIGH: [N], MEDIUM: [N], LOW: [N], INFO: [N]
+
+## Findings
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category from review categories]
+**File:** [file path]
+**Line:** [line number]
+
+**What is wrong:**
+[1-2 sentences describing the issue]
+
+**Suggested fix:**
+[1-2 sentences or code snippet showing how to fix it]
+
+---
+
+## Priority Order
+
+Findings ranked by impact (fix in this order):
+
+1. **[Issue title]** — [severity], [file]
+2. ...
+
+## Recommendations
+
+[2-3 sentences on the most impactful improvements to make first]

--- a/agents/_templates/severity/standard.md
+++ b/agents/_templates/severity/standard.md
@@ -1,0 +1,7 @@
+# Severity Levels
+
+- **CRITICAL**: Affects correctness, security, or causes crashes/data loss
+- **HIGH**: Significant reliability or maintainability issues
+- **MEDIUM**: Best practice violations with real impact
+- **LOW**: Minor improvements
+- **INFO**: Suggestions for optimization

--- a/agents/ansible-molecule/system.md
+++ b/agents/ansible-molecule/system.md
@@ -421,7 +421,7 @@ When you find an issue, use the RIGHT pattern:
   # Good - verify packages role installs
   - name: Check required packages installed
     ansible.builtin.package:
-      name: "{{ item }}"
+      name: "{{"{{" }} item }}"
       state: present
     check_mode: true
     register: pkg_check

--- a/agents/ansible-review/system.md
+++ b/agents/ansible-review/system.md
@@ -197,12 +197,7 @@ re-read files.
 7. **Role Design** — Single responsibility, argument specs
 8. **Collection Structure** — galaxy.yml, runtime.yml, FQCN usage
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Security vulnerabilities, data exposure, execution failures
-- **HIGH**: Reliability issues, non-idempotent tasks, orphaned handlers
-- **MEDIUM**: Missing FQCN, poor variable naming, missing argument_specs
-- **LOW**: Missing task names, inconsistent YAML style
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 
@@ -259,12 +254,12 @@ Skip these entirely — do not report them, do not fix them:
 ```yaml
 # Executing a binary that does work
 - name: Execute runzero-explorer
-  ansible.builtin.command: "{{ runzero_explorer_path }}"
+  ansible.builtin.command: "{{"{{" }} runzero_explorer_path }}"
   changed_when: true  # ✓ Correct: this changes state, report it
 
 # Moving/renaming files
 - name: Rename file to destination
-  ansible.builtin.command: mv {{ src }} {{ dest }}
+  ansible.builtin.command: mv {{"{{" }} src }} {{"{{" }} dest }}
   changed_when: true  # ✓ Correct: mv changes filesystem state
 
 # Running a script that modifies state
@@ -278,7 +273,7 @@ Skip these entirely — do not report them, do not fix them:
 ```yaml
 # WRONG: removing changed_when entirely breaks ansible-lint
 - name: Execute runzero-explorer
-  ansible.builtin.command: "{{ runzero_explorer_path }}"
+  ansible.builtin.command: "{{"{{" }} runzero_explorer_path }}"
   # No changed_when = ansible-lint failure!
 
 # WRONG: changed_when: false on state-changing command
@@ -400,13 +395,13 @@ there are no defaults, don't create argument_specs.
   - name: Set database password
     ansible.builtin.mysql_user:
       name: app
-      password: "{{ db_password }}"
+      password: "{{"{{" }} db_password }}"
 
   # Good
   - name: Set database password
     ansible.builtin.mysql_user:
       name: app
-      password: "{{ db_password }}"
+      password: "{{"{{" }} db_password }}"
     no_log: true
   ```
 

--- a/agents/go-cobra/system.md
+++ b/agents/go-cobra/system.md
@@ -133,13 +133,7 @@ Follow this sequence exactly. Do not skip steps.
 9. **Shell Completions** — static, dynamic, flag completions
 10. **Production Readiness** — version info, graceful shutdown, secrets
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Affects correctness, security, or causes crashes
-- **HIGH**: Significant reliability or maintainability issues
-- **MEDIUM**: Best practice violations with real impact
-- **LOW**: Minor improvements
-- **INFO**: Suggestions for optimization
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 

--- a/agents/go-doc-comments/system.md
+++ b/agents/go-doc-comments/system.md
@@ -189,15 +189,7 @@ Follow this sequence exactly. Do not skip steps.
 9. **Cleanup Requirements** — document resource release needs
 10. **Modern Doc Features** — headings, doc links, lists, code blocks
 
-# SEVERITY LEVELS
-
-- **HIGH**: Missing doc comment on a complex exported function/type that users
-  need to understand (constructors, public API entry points, complex types)
-- **MEDIUM**: Missing doc comment on simpler exported declarations, or
-  incorrect comment format (wrong first word, fragment, redundant)
-- **LOW**: Comment improvement opportunities (missing error docs, missing
-  concurrency note, could use doc links)
-- **INFO**: Style suggestions (could use a list, could add a code example)
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 

--- a/agents/go-review/system.md
+++ b/agents/go-review/system.md
@@ -297,13 +297,7 @@ Reference the go-review-criteria.md document for detailed criteria.
 9. **Reliability** — nil checks, bounds checks, error propagation
 {{end}}
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Affects correctness, security, or causes crashes
-- **HIGH**: Significant reliability or maintainability issues
-- **MEDIUM**: Best practice violations with real impact
-- **LOW**: Minor improvements
-- **INFO**: Suggestions for optimization
+{{include "severity/standard.md"}}
 
 {{if eq .Mode "edit"}}
 

--- a/agents/go-security-audit/system.md
+++ b/agents/go-security-audit/system.md
@@ -209,18 +209,7 @@ Follow this sequence exactly. Do not skip steps.
     messages, stack traces exposed to users, errors that bypass security
     checks
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Remote code execution, authentication bypass, SQL injection,
-  command injection, hardcoded credentials that are actually exploitable
-- **HIGH**: XSS, path traversal, weak cryptography in security-critical
-  paths, missing authentication, unsafe deserialization
-- **MEDIUM**: Missing input validation at boundaries, insecure configurations,
-  race conditions with security impact, HTTP client without timeout
-- **LOW**: Information disclosure, verbose error messages, missing security
-  headers, theoretical vulnerabilities with no realistic attack vector
-- **INFO**: Security hardening recommendations, best practices not yet
-  implemented, defense-in-depth suggestions
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 

--- a/agents/go-taskfile/system.md
+++ b/agents/go-taskfile/system.md
@@ -141,13 +141,7 @@ Follow this sequence exactly. Do not skip steps.
 8. **Includes** - external taskfiles, variable passing, remote includes
 9. **Output** - logging, echo, silent mode usage
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Security issues, syntax errors that break parsing
-- **HIGH**: Missing required elements, hardcoded values, no error handling
-- **MEDIUM**: Best practice violations, inconsistent naming
-- **LOW**: Minor improvements, style consistency
-- **INFO**: Suggestions for optimization
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 
@@ -176,17 +170,17 @@ These are the anti-patterns you MUST fix when found:
 - **Missing version:** Add `version: "3"` at the top after the YAML header
 - **Missing desc:** Add `desc: "Brief description of task purpose"`
 - **Hardcoded values:** Extract to `vars:` section with meaningful name
-- **Hardcoded secrets:** Replace with `'{{.SECRET_VAR | default ""}}'` and
+- **Hardcoded secrets:** Replace with `'{{"{{"}}.SECRET_VAR | default ""}}'` and
   add precondition to validate it's set
 - **Missing preconditions:** Add validation for required inputs:
 
   ```yaml
   preconditions:
-    - sh: test -n "{{.REQUIRED_VAR}}"
+    - sh: test -n "{{"{{"}}.REQUIRED_VAR}}"
       msg: "REQUIRED_VAR is required"
   ```
 
-- **Unquoted templates:** Quote the value: `VAR: '{{.OTHER_VAR}}'`
+- **Unquoted templates:** Quote the value: `VAR: '{{"{{"}}.OTHER_VAR}}'`
 - **Missing silent:** Add `silent: true` to tasks that run other programs
 - **Inconsistent naming:** Use lowercase with colons: `namespace:action`
 - **User-controlled paths:** Add precondition to validate paths don't traverse,
@@ -196,7 +190,7 @@ These are the anti-patterns you MUST fix when found:
   # Only add this if the variable has no default or an unsafe default
   # Skip if the variable defaults to a safe path like /tmp
   preconditions:
-    - sh: echo "{{.USER_PATH}}" | grep -qv '\.\.'
+    - sh: echo "{{"{{"}}.USER_PATH}}" | grep -qv '\.\.'
       msg: "USER_PATH cannot contain path traversal (..)"
   ```
 

--- a/agents/python-doc-comments/system.md
+++ b/agents/python-doc-comments/system.md
@@ -221,16 +221,7 @@ re-read files.
 5. **Constant Docstrings** — Purpose and valid values
 6. **Type Hints** — Only non-obvious return types (NOT `-> None`)
 
-# SEVERITY LEVELS
-
-- **HIGH**: Missing docstring on a complex public function/class that users
-  need to understand (constructors, public API entry points, complex classes)
-- **MEDIUM**: Missing docstring on simpler public declarations, or incorrect
-  docstring format (not complete sentence, redundant)
-- **LOW**: Docstring improvement opportunities (missing Args/Returns, could
-  benefit from examples)
-- **INFO**: Style suggestions (could use a code example, could link to related
-  functions)
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 

--- a/agents/python-review/system.md
+++ b/agents/python-review/system.md
@@ -238,13 +238,7 @@ Reference the python-review-criteria.md document for detailed criteria.
 11. **Testing** — coverage, quality, pytest patterns
 12. **Reliability** — None checks, bounds checks, error propagation
 
-# SEVERITY LEVELS
-
-- **CRITICAL**: Affects correctness, security, or causes crashes
-- **HIGH**: Significant reliability or maintainability issues
-- **MEDIUM**: Best practice violations with real impact
-- **LOW**: Minor improvements
-- **INFO**: Suggestions for optimization
+{{include "severity/standard.md"}}
 
 # WHAT TO FIX
 

--- a/cmd/squad/grade.go
+++ b/cmd/squad/grade.go
@@ -1,0 +1,223 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cowdogmoo/squad/grading"
+	"github.com/spf13/cobra"
+)
+
+func newGradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "grade [output.md]",
+		Short: "Grade an agent run output",
+		Long: `Grade an agent run based on the quality rubric in docs/agent-quality.md.
+
+Computes automated scores for:
+  - Report Quality (10%): Are required sections present?
+  - Iteration Efficiency (15%): Did the agent stay within budget?
+
+Finding Quality (50%) and Skip Discipline (25%) require manual review.
+
+Examples:
+  # Grade from a file
+  squad grade output.md --agent go-review --iterations 15 --files 12
+
+  # Grade from stdin
+  cat output.md | squad grade - --agent go-review --iterations 15
+
+  # View grade history
+  squad grade --history --agent go-review
+
+  # View stats for an agent
+  squad grade --stats --agent go-review`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runGrade,
+	}
+
+	cmd.Flags().StringP("agent", "a", "", "Agent name (required for grading)")
+	cmd.Flags().IntP("iterations", "i", 0, "Number of iterations used")
+	cmd.Flags().IntP("files", "f", 0, "Number of source files in codebase")
+	cmd.Flags().String("run-id", "", "Optional run identifier for tracking")
+	cmd.Flags().Bool("save", true, "Save grade to history")
+	cmd.Flags().Bool("history", false, "Show grade history")
+	cmd.Flags().Bool("stats", false, "Show aggregate statistics")
+	cmd.Flags().Int("limit", 10, "Limit history results")
+	cmd.Flags().Bool("json", false, "Output as JSON")
+
+	return cmd
+}
+
+func runGrade(cmd *cobra.Command, args []string) error {
+	showHistory, _ := cmd.Flags().GetBool("history")
+	showStats, _ := cmd.Flags().GetBool("stats")
+	agentName, _ := cmd.Flags().GetString("agent")
+	limit, _ := cmd.Flags().GetInt("limit")
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	store, err := grading.NewStore()
+	if err != nil {
+		return fmt.Errorf("failed to initialize grade store: %w", err)
+	}
+
+	// History mode
+	if showHistory {
+		return displayHistory(cmd, store, agentName, limit, asJSON)
+	}
+
+	// Stats mode
+	if showStats {
+		if agentName == "" {
+			return fmt.Errorf("--agent is required for --stats")
+		}
+		return displayStats(cmd, store, agentName, asJSON)
+	}
+
+	// Grading mode
+	if len(args) == 0 {
+		return fmt.Errorf("output file required (use - for stdin)")
+	}
+
+	if agentName == "" {
+		return fmt.Errorf("--agent is required")
+	}
+
+	iterations, _ := cmd.Flags().GetInt("iterations")
+	fileCount, _ := cmd.Flags().GetInt("files")
+	runID, _ := cmd.Flags().GetString("run-id")
+	save, _ := cmd.Flags().GetBool("save")
+
+	// Read input
+	var content []byte
+	if args[0] == "-" {
+		content, err = readStdin()
+	} else {
+		content, err = os.ReadFile(args[0])
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// Parse and grade
+	parser := grading.NewParser()
+	parsed := parser.Parse(string(content))
+
+	result := grading.ComputeGrade(parsed, grading.GradeOptions{
+		Agent:      agentName,
+		Iterations: iterations,
+		FileCount:  fileCount,
+		RunID:      runID,
+	})
+
+	// Save if requested
+	if save {
+		if err := store.Save(result); err != nil {
+			return fmt.Errorf("failed to save grade: %w", err)
+		}
+	}
+
+	// Output
+	if asJSON {
+		return outputJSON(cmd, result)
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), grading.FormatResult(result))
+	return nil
+}
+
+func displayHistory(cmd *cobra.Command, store *grading.Store, agent string, limit int, asJSON bool) error {
+	grades, err := store.List(agent, limit)
+	if err != nil {
+		return err
+	}
+
+	if len(grades) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No grades found.")
+		return nil
+	}
+
+	if asJSON {
+		return outputJSON(cmd, grades)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Grade History (showing %d of %d):\n\n", len(grades), len(grades))
+	for _, g := range grades {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s  %-12s  Grade: %s  Score: %.0f%%  Iter: %d\n",
+			g.Timestamp.Format("2006-01-02 15:04"),
+			g.Agent,
+			g.Grade,
+			g.TotalScore,
+			g.Iterations)
+	}
+
+	return nil
+}
+
+func displayStats(cmd *cobra.Command, store *grading.Store, agent string, asJSON bool) error {
+	stats, err := store.Stats(agent)
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		return outputJSON(cmd, stats)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Statistics for %s:\n\n", stats.Agent)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Total Runs:    %d\n", stats.TotalRuns)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Latest Grade:  %s\n", stats.LatestGrade)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Score:     %.1f%%\n", stats.AvgScore)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Report:    %.1f%%\n", stats.AvgReportQuality)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Efficiency: %.1f%%\n\n", stats.AvgIterationEfficiency)
+
+	fmt.Fprintln(cmd.OutOrStdout(), "  Grade Distribution:")
+	for _, grade := range []string{"A+", "A", "A-", "B+", "B", "B-", "C", "D", "F"} {
+		if count, ok := stats.GradeCounts[grade]; ok && count > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "    %s: %d\n", grade, count)
+		}
+	}
+
+	return nil
+}
+
+func readStdin() ([]byte, error) {
+	return os.ReadFile("/dev/stdin")
+}
+
+func outputJSON(cmd *cobra.Command, v any) error {
+	return writeJSON(cmd.OutOrStdout(), v)
+}
+
+func writeJSON(w io.Writer, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(data, '\n'))
+	return err
+}

--- a/cmd/squad/grade.go
+++ b/cmd/squad/grade.go
@@ -146,7 +146,7 @@ func runGrade(cmd *cobra.Command, args []string) error {
 		return outputJSON(cmd, result)
 	}
 
-	fmt.Fprint(cmd.OutOrStdout(), grading.FormatResult(result))
+	_, _ = fmt.Fprint(cmd.OutOrStdout(), grading.FormatResult(result))
 	return nil
 }
 
@@ -157,7 +157,7 @@ func displayHistory(cmd *cobra.Command, store *grading.Store, agent string, limi
 	}
 
 	if len(grades) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No grades found.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No grades found.")
 		return nil
 	}
 
@@ -165,9 +165,9 @@ func displayHistory(cmd *cobra.Command, store *grading.Store, agent string, limi
 		return outputJSON(cmd, grades)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Grade History (showing %d of %d):\n\n", len(grades), len(grades))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Grade History (showing %d of %d):\n\n", len(grades), len(grades))
 	for _, g := range grades {
-		fmt.Fprintf(cmd.OutOrStdout(), "  %s  %-12s  Grade: %s  Score: %.0f%%  Iter: %d\n",
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s  %-12s  Grade: %s  Score: %.0f%%  Iter: %d\n",
 			g.Timestamp.Format("2006-01-02 15:04"),
 			g.Agent,
 			g.Grade,
@@ -188,17 +188,17 @@ func displayStats(cmd *cobra.Command, store *grading.Store, agent string, asJSON
 		return outputJSON(cmd, stats)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Statistics for %s:\n\n", stats.Agent)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Total Runs:    %d\n", stats.TotalRuns)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Latest Grade:  %s\n", stats.LatestGrade)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Score:     %.1f%%\n", stats.AvgScore)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Report:    %.1f%%\n", stats.AvgReportQuality)
-	fmt.Fprintf(cmd.OutOrStdout(), "  Avg Efficiency: %.1f%%\n\n", stats.AvgIterationEfficiency)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Statistics for %s:\n\n", stats.Agent)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Total Runs:    %d\n", stats.TotalRuns)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Latest Grade:  %s\n", stats.LatestGrade)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Avg Score:     %.1f%%\n", stats.AvgScore)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Avg Report:    %.1f%%\n", stats.AvgReportQuality)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Avg Efficiency: %.1f%%\n\n", stats.AvgIterationEfficiency)
 
-	fmt.Fprintln(cmd.OutOrStdout(), "  Grade Distribution:")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "  Grade Distribution:")
 	for _, grade := range []string{"A+", "A", "A-", "B+", "B", "B-", "C", "D", "F"} {
 		if count, ok := stats.GradeCounts[grade]; ok && count > 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "    %s: %d\n", grade, count)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s: %d\n", grade, count)
 		}
 	}
 

--- a/cmd/squad/init.go
+++ b/cmd/squad/init.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package main
+
+import "github.com/spf13/cobra"
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize squad resources",
+	Long: `Initialize squad resources such as agents and configuration.
+
+Available subcommands:
+  agent    Create a new agent from templates`,
+}
+
+func init() {
+	initCmd.AddCommand(newInitAgentCmd())
+}

--- a/cmd/squad/init_agent.go
+++ b/cmd/squad/init_agent.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2026 Jayson Grace <jayson.e.grace@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package main
+
+import (
+	"github.com/cowdogmoo/squad/templates"
+	"github.com/spf13/cobra"
+)
+
+func newInitAgentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent NAME",
+		Short: "Create a new agent from templates",
+		Long: `Create a new agent directory with scaffolded prompt files.
+
+This command creates a new agent in the agents directory with:
+- agent.yaml (manifest)
+- system.md (system prompt with mode conditionals)
+- agent.md (execution wrapper)
+- task.md (task instructions)
+- README.md (documentation)
+- references/<name>-guide.md (knowledge base template)
+
+Examples:
+  # Create a generic agent
+  squad init agent xss-testing
+
+  # Create a Bash script review agent
+  squad init agent bash-review --lang bash
+
+  # Create from an existing agent
+  squad init agent my-review --from go-review
+
+  # Force overwrite existing agent
+  squad init agent my-agent --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: runInitAgent,
+	}
+
+	cmd.Flags().StringP("lang", "l", "generic", "Language template (go, python, bash, ansible, generic)")
+	cmd.Flags().String("from", "", "Copy from existing agent instead of template")
+	cmd.Flags().StringP("description", "d", "", "Agent description (default: auto-generated)")
+	cmd.Flags().String("agents-dir", "agents", "Directory containing agents")
+	cmd.Flags().BoolP("force", "f", false, "Overwrite existing agent directory")
+
+	_ = cmd.RegisterFlagCompletionFunc("lang", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"go", "python", "bash", "ansible", "generic"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func runInitAgent(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := cmd.Context()
+
+	lang, _ := cmd.Flags().GetString("lang")
+	from, _ := cmd.Flags().GetString("from")
+	description, _ := cmd.Flags().GetString("description")
+	agentsDir, _ := cmd.Flags().GetString("agents-dir")
+	force, _ := cmd.Flags().GetBool("force")
+
+	if from != "" {
+		return templates.CopyAgent(ctx, agentsDir, from, name, force)
+	}
+
+	return templates.CreateAgent(ctx, templates.CreateOptions{
+		Name:        name,
+		Lang:        lang,
+		Description: description,
+		AgentsDir:   agentsDir,
+		Force:       force,
+	})
+}

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -64,6 +64,7 @@ It provides a clean config + logging foundation for agent workflows.`,
 	rootCmd.AddCommand(newRunCmd())
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(newGradeCmd())
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)
 

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -63,6 +63,7 @@ It provides a clean config + logging foundation for agent workflows.`,
 
 	rootCmd.AddCommand(newRunCmd())
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/tmc/langchaingo v0.1.14
+	golang.org/x/text v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -33,5 +34,4 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.35.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
 )

--- a/grading/grading.go
+++ b/grading/grading.go
@@ -1,0 +1,227 @@
+package grading
+
+import (
+	"fmt"
+	"time"
+)
+
+// GradeResult represents the computed grade for an agent run.
+type GradeResult struct {
+	// Identification
+	Agent     string    `json:"agent"`
+	Timestamp time.Time `json:"timestamp"`
+	RunID     string    `json:"run_id,omitempty"`
+
+	// Overall grade
+	Grade      string  `json:"grade"`
+	TotalScore float64 `json:"total_score"`
+
+	// Component scores (0-100)
+	ReportQuality       float64 `json:"report_quality"`
+	IterationEfficiency float64 `json:"iteration_efficiency"`
+
+	// Manual review indicators
+	FindingQualityReview bool `json:"finding_quality_review"`
+	SkipDisciplineReview bool `json:"skip_discipline_review"`
+
+	// Metadata
+	Iterations    int    `json:"iterations"`
+	FileCount     int    `json:"file_count"`
+	FilesTouched  int    `json:"files_touched"`
+	IssuesFixed   int    `json:"issues_fixed"`
+	IssuesSkipped int    `json:"issues_skipped"`
+	Mode          string `json:"mode"`
+
+	// Breakdown details
+	MissingSections []string `json:"missing_sections,omitempty"`
+	Notes           []string `json:"notes,omitempty"`
+}
+
+// GradeOptions configures the grading calculation.
+type GradeOptions struct {
+	Agent      string
+	Iterations int
+	FileCount  int
+	RunID      string
+}
+
+// iterationTargets defines iteration budgets by codebase size.
+var iterationTargets = []struct {
+	MaxFiles  int
+	Target    int
+	MaxAccept int
+}{
+	{20, 12, 18},     // Small
+	{50, 25, 35},     // Medium
+	{999999, 40, 60}, // Large
+}
+
+// ComputeGrade calculates the grade for a parsed agent output.
+func ComputeGrade(parsed *ParsedOutput, opts GradeOptions) *GradeResult {
+	result := &GradeResult{
+		Agent:      opts.Agent,
+		Timestamp:  time.Now(),
+		RunID:      opts.RunID,
+		Iterations: opts.Iterations,
+		FileCount:  opts.FileCount,
+		Mode:       parsed.Mode,
+
+		FilesTouched:  len(parsed.FilesTouched),
+		IssuesFixed:   len(parsed.IssuesFixed) + len(parsed.Findings),
+		IssuesSkipped: len(parsed.IssuesSkipped),
+
+		FindingQualityReview: true,
+		SkipDisciplineReview: true,
+	}
+
+	// Calculate report quality (10% of grade)
+	result.ReportQuality = calculateReportQuality(parsed, result)
+
+	// Calculate iteration efficiency (15% of grade)
+	result.IterationEfficiency = calculateIterationEfficiency(opts.Iterations, opts.FileCount, result)
+
+	// Calculate total automated score (25% of full grade)
+	// Report quality is 10% of grade, Iteration efficiency is 15%
+	// Max automated points = 25, so we compute what fraction they earned
+	automatedPoints := (result.ReportQuality/100)*10 + (result.IterationEfficiency/100)*15
+	result.TotalScore = (automatedPoints / 25) * 100 // Scale to 0-100
+
+	// Determine letter grade based on automated portion
+	result.Grade = calculateLetterGrade(result.TotalScore)
+
+	return result
+}
+
+func calculateReportQuality(parsed *ParsedOutput, result *GradeResult) float64 {
+	required := RequiredSections(parsed.Mode)
+	if len(required) == 0 {
+		return 100
+	}
+
+	present := 0
+	for _, section := range required {
+		if isSectionPresent(parsed, section) {
+			present++
+		} else {
+			result.MissingSections = append(result.MissingSections, section)
+		}
+	}
+
+	return float64(present) / float64(len(required)) * 100
+}
+
+func isSectionPresent(parsed *ParsedOutput, section string) bool {
+	switch section {
+	case "changes_summary":
+		return parsed.HasChangesSummary
+	case "analysis_summary":
+		return parsed.HasAnalysisSummary
+	case "files_touched":
+		return parsed.HasFilesTouched
+	case "validation":
+		return parsed.HasValidation
+	case "issues_fixed":
+		return parsed.HasIssuesFixed
+	case "issues_skipped":
+		return parsed.HasIssuesSkipped
+	case "findings":
+		return parsed.HasFindings
+	default:
+		return false
+	}
+}
+
+func calculateIterationEfficiency(iterations, fileCount int, result *GradeResult) float64 {
+	if iterations == 0 {
+		result.Notes = append(result.Notes, "No iteration count provided")
+		return 0
+	}
+
+	// Find the appropriate tier
+	var target, maxAccept int
+	for _, tier := range iterationTargets {
+		if fileCount <= tier.MaxFiles {
+			target = tier.Target
+			maxAccept = tier.MaxAccept
+			break
+		}
+	}
+
+	result.Notes = append(result.Notes,
+		fmt.Sprintf("Iteration target: %d (max acceptable: %d) for %d files", target, maxAccept, fileCount))
+
+	// Perfect score if at or below target
+	if iterations <= target {
+		return 100
+	}
+
+	// Linear degradation from target to max acceptable
+	if iterations <= maxAccept {
+		// 100% at target, 60% at maxAccept
+		ratio := float64(iterations-target) / float64(maxAccept-target)
+		return 100 - (ratio * 40)
+	}
+
+	// Beyond max acceptable: further penalty
+	// 60% at maxAccept, 0% at 2x maxAccept
+	overageRatio := float64(iterations-maxAccept) / float64(maxAccept)
+	score := 60 - (overageRatio * 60)
+	if score < 0 {
+		return 0
+	}
+	return score
+}
+
+func calculateLetterGrade(score float64) string {
+	switch {
+	case score >= 97:
+		return "A+"
+	case score >= 93:
+		return "A"
+	case score >= 90:
+		return "A-"
+	case score >= 87:
+		return "B+"
+	case score >= 83:
+		return "B"
+	case score >= 80:
+		return "B-"
+	case score >= 70:
+		return "C"
+	case score >= 60:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+// FormatResult returns a human-readable summary of the grade.
+func FormatResult(r *GradeResult) string {
+	s := fmt.Sprintf("Grade: %s (Automated Score: %.0f%%)\n", r.Grade, r.TotalScore)
+	s += fmt.Sprintf("  Report Quality:       %.0f%%\n", r.ReportQuality)
+	s += fmt.Sprintf("  Iteration Efficiency: %.0f%%\n", r.IterationEfficiency)
+	s += "\n"
+
+	if len(r.MissingSections) > 0 {
+		s += fmt.Sprintf("  Missing sections: %v\n", r.MissingSections)
+	}
+
+	s += fmt.Sprintf("  Iterations: %d | Files: %d | Touched: %d | Fixed: %d | Skipped: %d\n",
+		r.Iterations, r.FileCount, r.FilesTouched, r.IssuesFixed, r.IssuesSkipped)
+
+	if r.FindingQualityReview || r.SkipDisciplineReview {
+		s += "\n  ⚠ Manual review required:\n"
+		if r.FindingQualityReview {
+			s += "    - Finding Quality (50% of grade)\n"
+		}
+		if r.SkipDisciplineReview {
+			s += "    - Skip Discipline (25% of grade)\n"
+		}
+	}
+
+	for _, note := range r.Notes {
+		s += fmt.Sprintf("  Note: %s\n", note)
+	}
+
+	return s
+}

--- a/grading/grading_test.go
+++ b/grading/grading_test.go
@@ -1,0 +1,206 @@
+package grading
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeGrade_PerfectRun(t *testing.T) {
+	parsed := &ParsedOutput{
+		HasChangesSummary: true,
+		HasIssuesFixed:    true,
+		HasFilesTouched:   true,
+		HasValidation:     true,
+		ValidationPassed:  true,
+		Mode:              "edit",
+		FilesTouched:      []string{"file1.go", "file2.go"},
+		IssuesFixed:       []ParsedIssue{{Title: "Fix 1"}},
+	}
+
+	result := ComputeGrade(parsed, GradeOptions{
+		Agent:      "go-review",
+		Iterations: 10,
+		FileCount:  15,
+	})
+
+	// With all sections present (100%) and iterations under target (100%)
+	// Total automated score should be 100%
+	if result.ReportQuality != 100 {
+		t.Errorf("expected report quality 100, got %.0f", result.ReportQuality)
+	}
+
+	if result.IterationEfficiency != 100 {
+		t.Errorf("expected iteration efficiency 100, got %.0f", result.IterationEfficiency)
+	}
+
+	if result.Grade != "A+" {
+		t.Errorf("expected grade A+, got %s", result.Grade)
+	}
+
+	if result.Agent != "go-review" {
+		t.Errorf("expected agent 'go-review', got %s", result.Agent)
+	}
+}
+
+func TestComputeGrade_MissingSections(t *testing.T) {
+	parsed := &ParsedOutput{
+		HasChangesSummary: true,
+		HasIssuesFixed:    true,
+		// Missing: FilesTouched, Validation
+		Mode: "edit",
+	}
+
+	result := ComputeGrade(parsed, GradeOptions{
+		Agent:      "go-review",
+		Iterations: 10,
+		FileCount:  15,
+	})
+
+	// 2 of 4 sections present = 50% report quality
+	if result.ReportQuality != 50 {
+		t.Errorf("expected report quality 50, got %.0f", result.ReportQuality)
+	}
+
+	if len(result.MissingSections) != 2 {
+		t.Errorf("expected 2 missing sections, got %d", len(result.MissingSections))
+	}
+}
+
+func TestComputeGrade_IterationEfficiency(t *testing.T) {
+	tests := []struct {
+		name       string
+		iterations int
+		fileCount  int
+		wantScore  float64
+		wantRange  [2]float64 // min, max acceptable
+	}{
+		{"under target small", 10, 15, 100, [2]float64{100, 100}},
+		{"at target small", 12, 15, 100, [2]float64{100, 100}},
+		{"between target and max small", 15, 15, 0, [2]float64{60, 100}},
+		{"at max small", 18, 15, 60, [2]float64{60, 60}},
+		{"over max small", 24, 15, 0, [2]float64{0, 40}},
+
+		{"under target medium", 20, 30, 100, [2]float64{100, 100}},
+		{"at target medium", 25, 30, 100, [2]float64{100, 100}},
+		{"at max medium", 35, 30, 60, [2]float64{60, 60}},
+
+		{"under target large", 35, 60, 100, [2]float64{100, 100}},
+		{"at target large", 40, 60, 100, [2]float64{100, 100}},
+		{"at max large", 60, 60, 60, [2]float64{60, 60}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := &ParsedOutput{
+				HasChangesSummary: true,
+				HasIssuesFixed:    true,
+				HasFilesTouched:   true,
+				HasValidation:     true,
+				Mode:              "edit",
+			}
+
+			result := ComputeGrade(parsed, GradeOptions{
+				Agent:      "test",
+				Iterations: tt.iterations,
+				FileCount:  tt.fileCount,
+			})
+
+			if result.IterationEfficiency < tt.wantRange[0] || result.IterationEfficiency > tt.wantRange[1] {
+				t.Errorf("iterations=%d, files=%d: got efficiency %.0f, want between %.0f and %.0f",
+					tt.iterations, tt.fileCount, result.IterationEfficiency, tt.wantRange[0], tt.wantRange[1])
+			}
+		})
+	}
+}
+
+func TestComputeGrade_ReadonlyMode(t *testing.T) {
+	parsed := &ParsedOutput{
+		HasAnalysisSummary: true,
+		HasFindings:        true,
+		Mode:               "readonly",
+		Findings:           []ParsedIssue{{Title: "Finding 1"}, {Title: "Finding 2"}},
+	}
+
+	result := ComputeGrade(parsed, GradeOptions{
+		Agent:      "go-review",
+		Iterations: 8,
+		FileCount:  10,
+	})
+
+	// All 2 required sections present
+	if result.ReportQuality != 100 {
+		t.Errorf("expected report quality 100, got %.0f", result.ReportQuality)
+	}
+
+	if result.IssuesFixed != 2 {
+		t.Errorf("expected 2 issues (findings), got %d", result.IssuesFixed)
+	}
+}
+
+func TestCalculateLetterGrade(t *testing.T) {
+	tests := []struct {
+		score float64
+		want  string
+	}{
+		{100, "A+"},
+		{97, "A+"},
+		{95, "A"},
+		{93, "A"},
+		{91, "A-"},
+		{90, "A-"},
+		{88, "B+"},
+		{85, "B"},
+		{83, "B"},
+		{81, "B-"},
+		{75, "C"},
+		{70, "C"},
+		{65, "D"},
+		{60, "D"},
+		{55, "F"},
+		{0, "F"},
+	}
+
+	for _, tt := range tests {
+		got := calculateLetterGrade(tt.score)
+		if got != tt.want {
+			t.Errorf("calculateLetterGrade(%.0f) = %s, want %s", tt.score, got, tt.want)
+		}
+	}
+}
+
+func TestFormatResult(t *testing.T) {
+	result := &GradeResult{
+		Agent:                "go-review",
+		Grade:                "A",
+		TotalScore:           95,
+		ReportQuality:        100,
+		IterationEfficiency:  90,
+		Iterations:           14,
+		FileCount:            15,
+		FilesTouched:         3,
+		IssuesFixed:          2,
+		IssuesSkipped:        1,
+		Mode:                 "edit",
+		FindingQualityReview: true,
+		SkipDisciplineReview: true,
+		Notes:                []string{"Iteration target: 12 (max acceptable: 18) for 15 files"},
+	}
+
+	output := FormatResult(result)
+
+	if !strings.Contains(output, "Grade: A") {
+		t.Error("output should contain grade")
+	}
+
+	if !strings.Contains(output, "Report Quality") {
+		t.Error("output should contain report quality")
+	}
+
+	if !strings.Contains(output, "Manual review required") {
+		t.Error("output should indicate manual review needed")
+	}
+
+	if !strings.Contains(output, "Finding Quality") {
+		t.Error("output should mention finding quality review")
+	}
+}

--- a/grading/parser.go
+++ b/grading/parser.go
@@ -1,0 +1,236 @@
+// Package grading provides parsing and scoring for agent output reports.
+package grading
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ParsedOutput represents the structured data extracted from agent output.
+type ParsedOutput struct {
+	// Report sections detected
+	HasChangesSummary  bool
+	HasAnalysisSummary bool
+	HasFilesTouched    bool
+	HasValidation      bool
+	HasIssuesFixed     bool
+	HasIssuesSkipped   bool
+	HasFindings        bool
+
+	// Extracted data
+	FilesTouched     []string
+	IssuesFixed      []ParsedIssue
+	IssuesSkipped    []ParsedSkip
+	Findings         []ParsedIssue
+	ValidationPassed bool
+
+	// Metadata
+	Mode string // "edit" or "readonly"
+}
+
+// ParsedIssue represents a single issue found or fixed.
+type ParsedIssue struct {
+	Title    string
+	Severity string
+	Category string
+	File     string
+	Line     int
+}
+
+// ParsedSkip represents an issue that was skipped.
+type ParsedSkip struct {
+	Title  string
+	File   string
+	Reason string
+}
+
+// Parser extracts structured data from agent markdown output.
+type Parser struct {
+	sectionPatterns   map[string]*regexp.Regexp
+	filePattern       *regexp.Regexp
+	severityPattern   *regexp.Regexp
+	validationPattern *regexp.Regexp
+}
+
+// NewParser creates a new output parser.
+func NewParser() *Parser {
+	return &Parser{
+		sectionPatterns: map[string]*regexp.Regexp{
+			"changes_summary":  regexp.MustCompile(`(?i)^##\s*Changes\s+Summary`),
+			"analysis_summary": regexp.MustCompile(`(?i)^##\s*Analysis\s+Summary`),
+			"files_touched":    regexp.MustCompile(`(?i)^##\s*Files\s+Touched`),
+			"validation":       regexp.MustCompile(`(?i)^##\s*Validation`),
+			"issues_fixed":     regexp.MustCompile(`(?i)^##\s*Issues\s+Found\s+and\s+Fixed`),
+			"issues_skipped":   regexp.MustCompile(`(?i)^##\s*Issues\s+Found\s+but\s+Skipped`),
+			"findings":         regexp.MustCompile(`(?i)^##\s*Findings`),
+		},
+		filePattern:       regexp.MustCompile("^-\\s*`([^`]+)`"),
+		severityPattern:   regexp.MustCompile(`(?i)\*\*Severity:\*\*\s*(CRITICAL|HIGH|MEDIUM|LOW|INFO)`),
+		validationPattern: regexp.MustCompile(`(?i)(PASS|FAIL)`),
+	}
+}
+
+// parseState tracks the current parsing context.
+type parseState struct {
+	currentSection string
+	inSkipTable    bool
+}
+
+// Parse extracts structured data from agent output markdown.
+func (p *Parser) Parse(output string) *ParsedOutput {
+	result := &ParsedOutput{}
+	lines := strings.Split(output, "\n")
+	state := &parseState{}
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		p.detectSection(trimmed, result, state)
+		p.parseLineContent(trimmed, lines, i, result, state)
+	}
+
+	p.detectMode(result)
+	return result
+}
+
+func (p *Parser) detectSection(trimmed string, result *ParsedOutput, state *parseState) {
+	for name, pattern := range p.sectionPatterns {
+		if pattern.MatchString(trimmed) {
+			state.currentSection = name
+			p.markSectionPresent(result, name)
+			state.inSkipTable = false
+			return
+		}
+	}
+}
+
+func (p *Parser) parseLineContent(trimmed string, lines []string, idx int, result *ParsedOutput, state *parseState) {
+	switch state.currentSection {
+	case "files_touched":
+		p.parseFileLine(trimmed, result)
+	case "validation":
+		p.parseValidationLine(trimmed, result)
+	case "issues_fixed":
+		p.parseIssueLine(trimmed, lines, idx, &result.IssuesFixed)
+	case "findings":
+		p.parseIssueLine(trimmed, lines, idx, &result.Findings)
+	case "issues_skipped":
+		p.parseSkipTableLine(trimmed, result, state)
+	}
+}
+
+func (p *Parser) parseFileLine(trimmed string, result *ParsedOutput) {
+	if matches := p.filePattern.FindStringSubmatch(trimmed); len(matches) > 1 {
+		result.FilesTouched = append(result.FilesTouched, matches[1])
+	}
+}
+
+func (p *Parser) parseValidationLine(trimmed string, result *ParsedOutput) {
+	if matches := p.validationPattern.FindStringSubmatch(trimmed); len(matches) > 1 {
+		result.ValidationPassed = strings.ToUpper(matches[1]) == "PASS"
+	}
+}
+
+func (p *Parser) parseIssueLine(trimmed string, lines []string, idx int, issues *[]ParsedIssue) {
+	if strings.HasPrefix(trimmed, "### ") {
+		*issues = append(*issues, p.parseIssueBlock(lines, idx))
+	}
+}
+
+func (p *Parser) parseSkipTableLine(trimmed string, result *ParsedOutput, state *parseState) {
+	if !strings.HasPrefix(trimmed, "|") {
+		return
+	}
+	if strings.Contains(trimmed, "Issue") {
+		state.inSkipTable = true
+		return
+	}
+	if strings.Contains(trimmed, "---") {
+		return
+	}
+	if state.inSkipTable {
+		if skip := p.parseSkipRow(trimmed); skip.Title != "" {
+			result.IssuesSkipped = append(result.IssuesSkipped, skip)
+		}
+	}
+}
+
+func (p *Parser) detectMode(result *ParsedOutput) {
+	if result.HasChangesSummary || result.HasIssuesFixed {
+		result.Mode = "edit"
+	} else if result.HasAnalysisSummary || result.HasFindings {
+		result.Mode = "readonly"
+	}
+}
+
+func (p *Parser) markSectionPresent(result *ParsedOutput, section string) {
+	switch section {
+	case "changes_summary":
+		result.HasChangesSummary = true
+	case "analysis_summary":
+		result.HasAnalysisSummary = true
+	case "files_touched":
+		result.HasFilesTouched = true
+	case "validation":
+		result.HasValidation = true
+	case "issues_fixed":
+		result.HasIssuesFixed = true
+	case "issues_skipped":
+		result.HasIssuesSkipped = true
+	case "findings":
+		result.HasFindings = true
+	}
+}
+
+func (p *Parser) parseIssueBlock(lines []string, startIdx int) ParsedIssue {
+	issue := ParsedIssue{}
+
+	// Title from ### header
+	if startIdx < len(lines) {
+		title := strings.TrimPrefix(strings.TrimSpace(lines[startIdx]), "### ")
+		issue.Title = title
+	}
+
+	// Scan next few lines for metadata
+	for i := startIdx + 1; i < len(lines) && i < startIdx+10; i++ {
+		line := strings.TrimSpace(lines[i])
+
+		if strings.HasPrefix(line, "### ") || strings.HasPrefix(line, "## ") {
+			break
+		}
+
+		if matches := p.severityPattern.FindStringSubmatch(line); len(matches) > 1 {
+			issue.Severity = strings.ToUpper(matches[1])
+		}
+
+		if strings.HasPrefix(line, "**Category:**") {
+			issue.Category = strings.TrimSpace(strings.TrimPrefix(line, "**Category:**"))
+		}
+
+		if strings.HasPrefix(line, "**File:**") {
+			issue.File = strings.TrimSpace(strings.TrimPrefix(line, "**File:**"))
+		}
+	}
+
+	return issue
+}
+
+func (p *Parser) parseSkipRow(row string) ParsedSkip {
+	parts := strings.Split(row, "|")
+	if len(parts) < 5 {
+		return ParsedSkip{}
+	}
+
+	return ParsedSkip{
+		Title:  strings.TrimSpace(parts[1]),
+		File:   strings.TrimSpace(parts[3]),
+		Reason: strings.TrimSpace(parts[4]),
+	}
+}
+
+// RequiredSections returns the list of required sections for a given mode.
+func RequiredSections(mode string) []string {
+	if mode == "readonly" {
+		return []string{"analysis_summary", "findings"}
+	}
+	return []string{"changes_summary", "issues_fixed", "files_touched", "validation"}
+}

--- a/grading/parser_test.go
+++ b/grading/parser_test.go
@@ -1,0 +1,242 @@
+package grading
+
+import (
+	"testing"
+)
+
+func TestParser_EditModeOutput(t *testing.T) {
+	input := `## Changes Summary
+
+Fixed 3 issues related to error handling and logging consistency.
+
+## Issues Found and Fixed
+
+### Missing error check on file close
+
+**Severity:** HIGH
+**Category:** error-handling
+**File:** cmd/app/main.go
+**Line:** 45
+
+**What was changed:**
+Added deferred error check for file.Close().
+
+**Why:**
+Unchecked close errors can hide data loss.
+
+---
+
+### Inconsistent logging package
+
+**Severity:** MEDIUM
+**Category:** consistency
+**File:** pkg/util/helper.go
+**Line:** 12
+
+**What was changed:**
+Changed log.Printf to logging.Info.
+
+**Why:**
+Codebase uses custom logging package.
+
+---
+
+## Issues Found but Skipped
+
+| Issue | Severity | File | Reason Skipped |
+|-------|----------|------|----------------|
+| Potential nil pointer | LOW | pkg/api/handler.go | Test asserts current behavior |
+| Magic number | INFO | pkg/config/config.go | Too minor to fix |
+
+## Files Touched
+
+- ` + "`cmd/app/main.go`" + ` — Added error check for file close
+- ` + "`pkg/util/helper.go`" + ` — Switched to logging package
+
+## Validation
+
+- Build: PASS
+- Tests: PASS
+`
+
+	parser := NewParser()
+	result := parser.Parse(input)
+
+	t.Run("mode", func(t *testing.T) {
+		assertEqual(t, "edit", result.Mode)
+	})
+
+	t.Run("sections_detected", func(t *testing.T) {
+		assertTrue(t, result.HasChangesSummary, "HasChangesSummary")
+		assertTrue(t, result.HasIssuesFixed, "HasIssuesFixed")
+		assertTrue(t, result.HasIssuesSkipped, "HasIssuesSkipped")
+		assertTrue(t, result.HasFilesTouched, "HasFilesTouched")
+		assertTrue(t, result.HasValidation, "HasValidation")
+		assertTrue(t, result.ValidationPassed, "ValidationPassed")
+	})
+
+	t.Run("counts", func(t *testing.T) {
+		assertLen(t, result.FilesTouched, 2, "FilesTouched")
+		assertLen(t, result.IssuesFixed, 2, "IssuesFixed")
+		assertLen(t, result.IssuesSkipped, 2, "IssuesSkipped")
+	})
+
+	t.Run("first_issue_details", func(t *testing.T) {
+		if len(result.IssuesFixed) == 0 {
+			t.Skip("no issues to check")
+		}
+		issue := result.IssuesFixed[0]
+		assertEqual(t, "HIGH", issue.Severity)
+		assertEqual(t, "cmd/app/main.go", issue.File)
+	})
+
+	t.Run("skipped_issue_details", func(t *testing.T) {
+		if len(result.IssuesSkipped) == 0 {
+			t.Skip("no skipped issues to check")
+		}
+		skip := result.IssuesSkipped[0]
+		assertEqual(t, "Potential nil pointer", skip.Title)
+		assertEqual(t, "Test asserts current behavior", skip.Reason)
+	})
+}
+
+func assertEqual(t *testing.T, expected, actual string) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("expected %q, got %q", expected, actual)
+	}
+}
+
+func assertTrue(t *testing.T, value bool, name string) {
+	t.Helper()
+	if !value {
+		t.Errorf("expected %s to be true", name)
+	}
+}
+
+func assertLen[T any](t *testing.T, slice []T, expected int, name string) {
+	t.Helper()
+	if len(slice) != expected {
+		t.Errorf("expected %s to have %d items, got %d", name, expected, len(slice))
+	}
+}
+
+func TestParser_ReadonlyModeOutput(t *testing.T) {
+	input := `## Analysis Summary
+
+**Files analyzed:** 15
+**Total findings:** 8
+**By severity:** CRITICAL: 1, HIGH: 2, MEDIUM: 3, LOW: 1, INFO: 1
+
+## Findings
+
+### SQL injection vulnerability
+
+**Severity:** CRITICAL
+**Category:** security
+**File:** pkg/db/query.go
+**Line:** 78
+
+**What is wrong:**
+User input is concatenated directly into SQL query.
+
+**Suggested fix:**
+Use parameterized queries with ? placeholders.
+
+---
+
+### Missing input validation
+
+**Severity:** HIGH
+**Category:** security
+**File:** pkg/api/handler.go
+**Line:** 23
+
+**What is wrong:**
+Request body is used without validation.
+
+**Suggested fix:**
+Add validation middleware.
+
+---
+
+## Priority Order
+
+Findings ranked by impact (fix in this order):
+
+1. **SQL injection vulnerability** — CRITICAL, pkg/db/query.go
+2. **Missing input validation** — HIGH, pkg/api/handler.go
+
+## Recommendations
+
+Focus on the CRITICAL SQL injection issue first. Consider adding a security linter to CI.
+`
+
+	parser := NewParser()
+	result := parser.Parse(input)
+
+	if result.Mode != "readonly" {
+		t.Errorf("expected mode 'readonly', got %q", result.Mode)
+	}
+
+	if !result.HasAnalysisSummary {
+		t.Error("expected HasAnalysisSummary to be true")
+	}
+
+	if !result.HasFindings {
+		t.Error("expected HasFindings to be true")
+	}
+
+	if len(result.Findings) != 2 {
+		t.Errorf("expected 2 findings, got %d", len(result.Findings))
+	}
+
+	if len(result.Findings) > 0 {
+		finding := result.Findings[0]
+		if finding.Severity != "CRITICAL" {
+			t.Errorf("expected severity CRITICAL, got %q", finding.Severity)
+		}
+	}
+}
+
+func TestParser_MinimalOutput(t *testing.T) {
+	input := `## Changes Summary
+
+No issues found.
+
+## Files Touched
+
+(none)
+
+## Validation
+
+- Build: PASS
+`
+
+	parser := NewParser()
+	result := parser.Parse(input)
+
+	if result.Mode != "edit" {
+		t.Errorf("expected mode 'edit', got %q", result.Mode)
+	}
+
+	if !result.HasChangesSummary {
+		t.Error("expected HasChangesSummary to be true")
+	}
+
+	if len(result.FilesTouched) != 0 {
+		t.Errorf("expected 0 files touched, got %d", len(result.FilesTouched))
+	}
+}
+
+func TestRequiredSections(t *testing.T) {
+	editSections := RequiredSections("edit")
+	if len(editSections) != 4 {
+		t.Errorf("expected 4 required sections for edit mode, got %d", len(editSections))
+	}
+
+	readonlySections := RequiredSections("readonly")
+	if len(readonlySections) != 2 {
+		t.Errorf("expected 2 required sections for readonly mode, got %d", len(readonlySections))
+	}
+}

--- a/grading/store.go
+++ b/grading/store.go
@@ -1,0 +1,164 @@
+package grading
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Store persists grade results to disk.
+type Store struct {
+	path string
+}
+
+// GradeHistory holds all stored grades.
+type GradeHistory struct {
+	Grades []*GradeResult `json:"grades"`
+}
+
+// NewStore creates a store at the default location (~/.cache/squad/grades.json).
+func NewStore() (*Store, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cache directory: %w", err)
+	}
+
+	squadCache := filepath.Join(cacheDir, "squad")
+	if err := os.MkdirAll(squadCache, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return &Store{
+		path: filepath.Join(squadCache, "grades.json"),
+	}, nil
+}
+
+// NewStoreAt creates a store at a specific path.
+func NewStoreAt(path string) *Store {
+	return &Store{path: path}
+}
+
+// Save appends a grade result to the store.
+func (s *Store) Save(result *GradeResult) error {
+	history, err := s.load()
+	if err != nil {
+		history = &GradeHistory{}
+	}
+
+	history.Grades = append(history.Grades, result)
+
+	return s.write(history)
+}
+
+// List returns grades for a specific agent, sorted by timestamp (newest first).
+func (s *Store) List(agentName string, limit int) ([]*GradeResult, error) {
+	history, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []*GradeResult
+	for _, g := range history.Grades {
+		if agentName == "" || g.Agent == agentName {
+			filtered = append(filtered, g)
+		}
+	}
+
+	// Sort by timestamp descending
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].Timestamp.After(filtered[j].Timestamp)
+	})
+
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+
+	return filtered, nil
+}
+
+// ListAll returns all grades, sorted by timestamp (newest first).
+func (s *Store) ListAll(limit int) ([]*GradeResult, error) {
+	return s.List("", limit)
+}
+
+// Stats returns aggregate statistics for an agent.
+func (s *Store) Stats(agentName string) (*AgentStats, error) {
+	grades, err := s.List(agentName, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(grades) == 0 {
+		return nil, fmt.Errorf("no grades found for agent %q", agentName)
+	}
+
+	stats := &AgentStats{
+		Agent:       agentName,
+		TotalRuns:   len(grades),
+		GradeCounts: make(map[string]int),
+	}
+
+	var totalScore, totalReport, totalEfficiency float64
+	for _, g := range grades {
+		stats.GradeCounts[g.Grade]++
+		totalScore += g.TotalScore
+		totalReport += g.ReportQuality
+		totalEfficiency += g.IterationEfficiency
+	}
+
+	n := float64(len(grades))
+	stats.AvgScore = totalScore / n
+	stats.AvgReportQuality = totalReport / n
+	stats.AvgIterationEfficiency = totalEfficiency / n
+	stats.LatestGrade = grades[0].Grade
+
+	return stats, nil
+}
+
+// AgentStats provides aggregate statistics for an agent.
+type AgentStats struct {
+	Agent                  string         `json:"agent"`
+	TotalRuns              int            `json:"total_runs"`
+	LatestGrade            string         `json:"latest_grade"`
+	AvgScore               float64        `json:"avg_score"`
+	AvgReportQuality       float64        `json:"avg_report_quality"`
+	AvgIterationEfficiency float64        `json:"avg_iteration_efficiency"`
+	GradeCounts            map[string]int `json:"grade_counts"`
+}
+
+func (s *Store) load() (*GradeHistory, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return &GradeHistory{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read grades file: %w", err)
+	}
+
+	var history GradeHistory
+	if err := json.Unmarshal(data, &history); err != nil {
+		return nil, fmt.Errorf("failed to parse grades file: %w", err)
+	}
+
+	return &history, nil
+}
+
+func (s *Store) write(history *GradeHistory) error {
+	data, err := json.MarshalIndent(history, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal grades: %w", err)
+	}
+
+	if err := os.WriteFile(s.path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write grades file: %w", err)
+	}
+
+	return nil
+}
+
+// Path returns the store's file path.
+func (s *Store) Path() string {
+	return s.path
+}

--- a/grading/store_test.go
+++ b/grading/store_test.go
@@ -1,0 +1,194 @@
+package grading
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStore_SaveAndList(t *testing.T) {
+	// Create temp file for test store
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "grades.json")
+	store := NewStoreAt(storePath)
+
+	// Save a grade
+	result := &GradeResult{
+		Agent:               "go-review",
+		Timestamp:           time.Now(),
+		Grade:               "A",
+		TotalScore:          95,
+		ReportQuality:       100,
+		IterationEfficiency: 90,
+		Iterations:          12,
+		FileCount:           15,
+	}
+
+	if err := store.Save(result); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(storePath); os.IsNotExist(err) {
+		t.Error("store file was not created")
+	}
+
+	// List grades
+	grades, err := store.List("go-review", 10)
+	if err != nil {
+		t.Fatalf("failed to list: %v", err)
+	}
+
+	if len(grades) != 1 {
+		t.Errorf("expected 1 grade, got %d", len(grades))
+	}
+
+	if grades[0].Grade != "A" {
+		t.Errorf("expected grade A, got %s", grades[0].Grade)
+	}
+}
+
+func TestStore_ListFiltersAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStoreAt(filepath.Join(tmpDir, "grades.json"))
+
+	// Save grades for different agents
+	agents := []string{"go-review", "python-review", "go-review"}
+	for i, agent := range agents {
+		_ = store.Save(&GradeResult{
+			Agent:     agent,
+			Timestamp: time.Now().Add(time.Duration(i) * time.Minute),
+			Grade:     "A",
+		})
+	}
+
+	// List only go-review
+	grades, err := store.List("go-review", 10)
+	if err != nil {
+		t.Fatalf("failed to list: %v", err)
+	}
+
+	if len(grades) != 2 {
+		t.Errorf("expected 2 go-review grades, got %d", len(grades))
+	}
+
+	// List all
+	allGrades, err := store.ListAll(10)
+	if err != nil {
+		t.Fatalf("failed to list all: %v", err)
+	}
+
+	if len(allGrades) != 3 {
+		t.Errorf("expected 3 total grades, got %d", len(allGrades))
+	}
+}
+
+func TestStore_ListSortsByTimestamp(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStoreAt(filepath.Join(tmpDir, "grades.json"))
+
+	// Save grades with different timestamps (older first)
+	for i := 0; i < 3; i++ {
+		_ = store.Save(&GradeResult{
+			Agent:     "go-review",
+			Timestamp: time.Now().Add(time.Duration(i) * time.Hour),
+			RunID:     string(rune('A' + i)),
+		})
+	}
+
+	grades, _ := store.List("", 10)
+
+	// Should be sorted newest first
+	for i := 1; i < len(grades); i++ {
+		if grades[i].Timestamp.After(grades[i-1].Timestamp) {
+			t.Error("grades should be sorted by timestamp descending")
+		}
+	}
+}
+
+func TestStore_ListWithLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStoreAt(filepath.Join(tmpDir, "grades.json"))
+
+	// Save 5 grades
+	for i := 0; i < 5; i++ {
+		_ = store.Save(&GradeResult{
+			Agent:     "go-review",
+			Timestamp: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	// List with limit 2
+	grades, _ := store.List("", 2)
+	if len(grades) != 2 {
+		t.Errorf("expected 2 grades with limit, got %d", len(grades))
+	}
+}
+
+func TestStore_Stats(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStoreAt(filepath.Join(tmpDir, "grades.json"))
+
+	// Save grades with different scores
+	testGrades := []struct {
+		grade      string
+		score      float64
+		report     float64
+		efficiency float64
+	}{
+		{"A+", 100, 100, 100},
+		{"A", 95, 100, 90},
+		{"B+", 88, 75, 100},
+	}
+
+	for i, tg := range testGrades {
+		_ = store.Save(&GradeResult{
+			Agent:               "go-review",
+			Timestamp:           time.Now().Add(time.Duration(i) * time.Minute),
+			Grade:               tg.grade,
+			TotalScore:          tg.score,
+			ReportQuality:       tg.report,
+			IterationEfficiency: tg.efficiency,
+		})
+	}
+
+	stats, err := store.Stats("go-review")
+	if err != nil {
+		t.Fatalf("failed to get stats: %v", err)
+	}
+
+	if stats.TotalRuns != 3 {
+		t.Errorf("expected 3 total runs, got %d", stats.TotalRuns)
+	}
+
+	if stats.LatestGrade != "B+" {
+		t.Errorf("expected latest grade B+, got %s", stats.LatestGrade)
+	}
+
+	expectedAvg := (100.0 + 95.0 + 88.0) / 3.0
+	if stats.AvgScore < expectedAvg-0.1 || stats.AvgScore > expectedAvg+0.1 {
+		t.Errorf("expected avg score %.1f, got %.1f", expectedAvg, stats.AvgScore)
+	}
+
+	if stats.GradeCounts["A+"] != 1 {
+		t.Errorf("expected 1 A+ grade, got %d", stats.GradeCounts["A+"])
+	}
+}
+
+func TestStore_StatsNoGrades(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStoreAt(filepath.Join(tmpDir, "grades.json"))
+
+	_, err := store.Stats("nonexistent")
+	if err == nil {
+		t.Error("expected error for agent with no grades")
+	}
+}
+
+func TestStore_Path(t *testing.T) {
+	store := NewStoreAt("/tmp/test.json")
+	if store.Path() != "/tmp/test.json" {
+		t.Errorf("expected path /tmp/test.json, got %s", store.Path())
+	}
+}

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -1,0 +1,39 @@
+# {{.NameTitle}} Agent
+
+{{.Description}}
+
+## Usage
+
+```bash
+# Edit mode (default) - agent can make changes
+squad run --agent {{.Name}}
+
+# Readonly mode - analysis only, no modifications
+squad run --agent {{.Name}} --mode readonly
+
+# With custom instructions
+squad run --agent {{.Name}} "Focus on the src/ directory"
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `agent.yaml` | Agent manifest with metadata and references |
+| `system.md` | Core system prompt (identity, rules, workflow) |
+| `agent.md` | Execution wrapper with mode-specific rules |
+| `task.md` | Default task instructions |
+| `references/{{.Name}}-guide.md` | Domain knowledge base |
+
+## Modes
+
+This agent supports conditional prompts via Go template syntax:
+
+- **Edit mode** (`--mode edit`, default): Agent can modify files
+- **Readonly mode** (`--mode readonly`): Agent only analyzes and reports
+
+## Customization
+
+1. Edit `system.md` to adjust identity, hard rules, and workflow
+2. Edit `references/{{.Name}}-guide.md` to add domain expertise
+3. Edit `task.md` to change default task instructions

--- a/templates/agent.md.tmpl
+++ b/templates/agent.md.tmpl
@@ -1,0 +1,75 @@
+# AGENT MODE
+
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+You are an autonomous {{.NameTitle}} agent. You discover code, analyze
+issues, apply fixes, and verify the result — all without human guidance.
+
+# EXECUTION RULES
+
+- **Discover first.** Use Glob to find all relevant source files, then Read
+  each file. Never guess at file contents.
+- **Verify after every batch.** Run verification commands after editing files.
+  Fix errors before moving on.
+- **Follow existing conventions.** Read surrounding code before editing. Match
+  the existing style. Use packages/modules already imported — do not introduce
+  parallel dependencies.
+- **No cosmetic changes.** Do not touch doc comments, import order, naming
+  style, or whitespace. Every edit must fix a real issue.
+- **Do no harm.** Every fix must be strictly better than the original. If your
+  fix changes control flow, verify the new behavior is correct. A wrong fix is
+  worse than no fix — skip if unsure.
+- **Be efficient with iterations.** Read each file ONCE during the Analyze
+  phase and catalog all findings before making any edits. Do not re-read
+  files you have already analyzed. Target ≤12 iterations for small codebases.
+- **Efficient tool calls.** Use one Grep/Glob on the repo root, not N calls
+  per-directory. Every tool call costs an iteration.
+- **No post-fix exploration.** Once fixes are applied and verification passes,
+  go STRAIGHT to the report. Do not re-read files for skipped-finding details.
+- **Proportional fixes only.** Every fix must be proportional to the problem.
+  Ask: "Does this prevent a real bug or fix a meaningful inconsistency?" If
+  the answer is "theoretical improvement that adds complexity," skip it.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from system.md.
+Do NOT write a freeform summary. The report MUST include ALL of these
+sections in order:
+
+1. `## Changes Summary` — 2-3 sentence overview
+2. `## Issues Found and Fixed` — each with Severity, Category, File, Line,
+   What was changed, and Why
+3. `## Issues Found but Skipped` — table with Issue, Severity, File, Reason
+4. `## Files Touched` — every file modified with change description
+5. `## Validation` — verification command results
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+You are a read-only {{.NameTitle}} analysis agent. You discover code, inspect
+it for issues and best-practice violations, and produce a structured report.
+You MUST NOT modify any files.
+
+# EXECUTION RULES
+
+- Use Glob to discover all relevant source files.
+- Read each source file to understand types, functions, and dependencies.
+- Use Grep to search for specific anti-patterns across the codebase.
+- Cross-reference between files to find consistency issues.
+- Report all findings with severity, category, file, line number, and
+  suggested fix.
+- Do NOT use the Edit or Write tools. Do NOT modify any files.
+
+# OUTPUT COMPLIANCE
+
+Your response MUST use the structured output format from the system prompt.
+Do NOT write a freeform summary. The report MUST include ALL of these
+sections in order:
+
+1. `## Analysis Summary` — files analyzed, total findings, by-severity counts
+2. `## Findings` — each with Severity, Category, File, Line, What is wrong,
+   and Suggested fix
+3. `## Priority Order` — ranked list of findings by impact
+4. `## Recommendations` — 2-3 sentences on most impactful improvements
+{{"{{"}}end{{"}}"}}
+
+# INPUT
+
+User request and any constraints.

--- a/templates/agent.yaml.tmpl
+++ b/templates/agent.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+name: {{.Name}}
+version: {{.Version}}
+description: {{.Description}}
+entrypoint: system.md
+wrapper: agent.md
+references:
+  - references/{{.Name}}-guide.md
+task: task.md

--- a/templates/reference.md.tmpl
+++ b/templates/reference.md.tmpl
@@ -1,0 +1,64 @@
+# {{.NameTitle}} Guide
+
+This document contains domain knowledge for the {{.NameTitle}} agent.
+
+## Overview
+
+TODO: Add an overview of what this agent checks for.
+
+## Categories
+
+TODO: Define the categories of issues this agent finds.
+
+### Category 1
+
+Description of what this category covers.
+
+**Patterns to check:**
+- Pattern 1
+- Pattern 2
+
+**Correct approach:**
+```
+Example of correct code/configuration
+```
+
+**Incorrect approach:**
+```
+Example of incorrect code/configuration
+```
+
+### Category 2
+
+Description of what this category covers.
+
+## Severity Guidelines
+
+| Severity | Criteria |
+|----------|----------|
+| CRITICAL | Security vulnerabilities, crashes, data loss |
+| HIGH | Reliability issues, significant bugs |
+| MEDIUM | Best practice violations with real impact |
+| LOW | Minor improvements, code smell |
+| INFO | Suggestions, optimizations |
+
+## Common Anti-Patterns
+
+TODO: List common anti-patterns this agent should detect.
+
+1. **Anti-pattern name** — Description and why it's problematic
+2. **Anti-pattern name** — Description and why it's problematic
+
+## Best Practices
+
+TODO: List best practices this agent should enforce.
+
+1. **Practice name** — Description and rationale
+2. **Practice name** — Description and rationale
+
+## References
+
+TODO: Add links to authoritative sources.
+
+- [Reference 1](https://example.com)
+- [Reference 2](https://example.com)

--- a/templates/scaffold.go
+++ b/templates/scaffold.go
@@ -1,0 +1,210 @@
+// Package templates provides embedded templates for scaffolding new agents.
+package templates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cowdogmoo/squad/logging"
+)
+
+// LangVerifyCommands maps language to verification commands for scaffolded agents.
+var LangVerifyCommands = map[string]string{
+	"go":      "go build ./... && go test ./...",
+	"python":  "ruff check . && python -m py_compile *.py",
+	"bash":    "shellcheck *.sh",
+	"ansible": "ansible-lint",
+	"generic": "",
+}
+
+// LangFilePatterns maps language to glob patterns for scaffolded agents.
+var LangFilePatterns = map[string]string{
+	"go":      "**/*.go",
+	"python":  "**/*.py",
+	"bash":    "**/*.sh",
+	"ansible": "**/*.yml",
+	"generic": "**/*",
+}
+
+// CreateOptions configures agent scaffolding.
+type CreateOptions struct {
+	Name        string
+	Lang        string
+	Description string
+	AgentsDir   string
+	Force       bool
+}
+
+// CreateAgent scaffolds a new agent from templates.
+func CreateAgent(ctx context.Context, opts CreateOptions) error {
+	if !IsValidAgentName(opts.Name) {
+		return fmt.Errorf("invalid agent name %q: must be lowercase alphanumeric with hyphens", opts.Name)
+	}
+
+	if _, ok := LangVerifyCommands[opts.Lang]; !ok {
+		return fmt.Errorf("unknown language %q: must be one of go, python, bash, ansible, generic", opts.Lang)
+	}
+
+	agentPath := filepath.Join(opts.AgentsDir, opts.Name)
+
+	if _, err := os.Stat(agentPath); err == nil {
+		if !opts.Force {
+			return fmt.Errorf("agent %q already exists at %s (use --force to overwrite)", opts.Name, agentPath)
+		}
+		logging.WarnContext(ctx, "Overwriting existing agent at %s", agentPath)
+	}
+
+	description := opts.Description
+	if description == "" {
+		description = generateDescription(opts.Name, opts.Lang)
+	}
+
+	if err := os.MkdirAll(filepath.Join(agentPath, "references"), 0o755); err != nil {
+		return fmt.Errorf("failed to create agent directory: %w", err)
+	}
+
+	data := AgentData{
+		Name:        opts.Name,
+		NameTitle:   ToTitleCase(opts.Name),
+		Description: description,
+		Lang:        opts.Lang,
+		Version:     "0.1.0",
+	}
+
+	files := map[string]string{
+		"agent.yaml":                            "agent.yaml.tmpl",
+		"system.md":                             "system.md.tmpl",
+		"agent.md":                              "agent.md.tmpl",
+		"task.md":                               "task.md.tmpl",
+		"README.md":                             "README.md.tmpl",
+		"references/" + opts.Name + "-guide.md": "reference.md.tmpl",
+	}
+
+	for outFile, tmplFile := range files {
+		content, err := Render(tmplFile, data)
+		if err != nil {
+			return fmt.Errorf("failed to render %s: %w", tmplFile, err)
+		}
+
+		outPath := filepath.Join(agentPath, outFile)
+		if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", outFile, err)
+		}
+		logging.InfoContext(ctx, "Created %s", outPath)
+	}
+
+	logging.InfoContext(ctx, "Agent %q created successfully at %s", opts.Name, agentPath)
+	logging.InfoContext(ctx, "Next steps:")
+	logging.InfoContext(ctx, "  1. Edit references/%s-guide.md with domain knowledge", opts.Name)
+	logging.InfoContext(ctx, "  2. Customize system.md with agent-specific rules")
+	logging.InfoContext(ctx, "  3. Test with: squad run --agent %s", opts.Name)
+
+	return nil
+}
+
+// CopyAgent copies an existing agent to a new name.
+func CopyAgent(ctx context.Context, agentsDir, from, to string, force bool) error {
+	if !IsValidAgentName(to) {
+		return fmt.Errorf("invalid agent name %q: must be lowercase alphanumeric with hyphens", to)
+	}
+
+	srcPath := filepath.Join(agentsDir, from)
+	dstPath := filepath.Join(agentsDir, to)
+
+	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+		return fmt.Errorf("source agent %q not found at %s", from, srcPath)
+	}
+
+	if _, err := os.Stat(dstPath); err == nil {
+		if !force {
+			return fmt.Errorf("agent %q already exists at %s (use --force to overwrite)", to, dstPath)
+		}
+		if err := os.RemoveAll(dstPath); err != nil {
+			return fmt.Errorf("failed to remove existing agent: %w", err)
+		}
+	}
+
+	if err := copyDir(srcPath, dstPath); err != nil {
+		return fmt.Errorf("failed to copy agent: %w", err)
+	}
+
+	manifestPath := filepath.Join(dstPath, "agent.yaml")
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+
+	updated := strings.Replace(string(content), "name: "+from, "name: "+to, 1)
+	if err := os.WriteFile(manifestPath, []byte(updated), 0o644); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	logging.InfoContext(ctx, "Agent %q copied from %q to %s", to, from, dstPath)
+	logging.InfoContext(ctx, "Don't forget to update the references and customize the prompts!")
+
+	return nil
+}
+
+// IsValidAgentName checks if the agent name is valid.
+func IsValidAgentName(name string) bool {
+	matched, _ := regexp.MatchString(`^[a-z][a-z0-9-]*[a-z0-9]$`, name)
+	return matched || (len(name) >= 2 && regexp.MustCompile(`^[a-z][a-z0-9]*$`).MatchString(name))
+}
+
+// ToTitleCase converts hyphenated-name to Title Case.
+func ToTitleCase(name string) string {
+	words := strings.Split(name, "-")
+	for i, word := range words {
+		if len(word) > 0 {
+			words[i] = strings.ToUpper(word[:1]) + word[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// generateDescription creates a default description based on name and language.
+func generateDescription(name, lang string) string {
+	titleName := ToTitleCase(name)
+
+	switch lang {
+	case "go":
+		return fmt.Sprintf("Autonomous %s agent for Go codebases", titleName)
+	case "python":
+		return fmt.Sprintf("Autonomous %s agent for Python codebases", titleName)
+	case "bash":
+		return fmt.Sprintf("Autonomous %s agent for Bash scripts", titleName)
+	case "ansible":
+		return fmt.Sprintf("Autonomous %s agent for Ansible playbooks and roles", titleName)
+	default:
+		return fmt.Sprintf("Autonomous %s agent", titleName)
+	}
+}
+
+// copyDir recursively copies a directory.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dstPath, content, info.Mode())
+	})
+}

--- a/templates/scaffold_test.go
+++ b/templates/scaffold_test.go
@@ -1,0 +1,419 @@
+package templates
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testHelper provides common test utilities
+type testHelper struct {
+	t      *testing.T
+	tmpDir string
+	ctx    context.Context
+}
+
+func newTestHelper(t *testing.T) *testHelper {
+	return &testHelper{
+		t:      t,
+		tmpDir: t.TempDir(),
+		ctx:    context.Background(),
+	}
+}
+
+func (h *testHelper) createAgent(name, lang string, force bool) error {
+	return CreateAgent(h.ctx, CreateOptions{
+		Name:      name,
+		Lang:      lang,
+		AgentsDir: h.tmpDir,
+		Force:     force,
+	})
+}
+
+func (h *testHelper) mustMkdir(path string) {
+	h.t.Helper()
+	if err := os.MkdirAll(filepath.Join(h.tmpDir, path), 0o755); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+func (h *testHelper) mustWriteFile(path, content string) {
+	h.t.Helper()
+	if err := os.WriteFile(filepath.Join(h.tmpDir, path), []byte(content), 0o644); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+func (h *testHelper) readFile(path string) string {
+	h.t.Helper()
+	content, err := os.ReadFile(filepath.Join(h.tmpDir, path))
+	if err != nil {
+		h.t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func (h *testHelper) fileExists(path string) bool {
+	_, err := os.Stat(filepath.Join(h.tmpDir, path))
+	return err == nil
+}
+
+func TestIsValidAgentName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid simple", "myagent", true},
+		{"valid with hyphen", "my-agent", true},
+		{"valid with numbers", "agent123", true},
+		{"valid complex", "go-review-v2", true},
+		{"valid two chars", "ab", true},
+		{"invalid uppercase", "MyAgent", false},
+		{"invalid starts with number", "123agent", false},
+		{"invalid starts with hyphen", "-agent", false},
+		{"invalid ends with hyphen", "agent-", false},
+		{"invalid underscore", "my_agent", false},
+		{"invalid single char", "a", false},
+		{"invalid empty", "", false},
+		{"invalid spaces", "my agent", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidAgentName(tt.input)
+			if got != tt.want {
+				t.Errorf("IsValidAgentName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToTitleCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple", "agent", "Agent"},
+		{"hyphenated", "go-review", "Go Review"},
+		{"multiple hyphens", "xss-security-audit", "Xss Security Audit"},
+		{"with numbers", "agent-v2", "Agent V2"},
+		{"single char segments", "a-b-c", "A B C"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToTitleCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToTitleCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateDescription(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		lang      string
+		wantSub   string // substring to check
+	}{
+		{"go agent", "code-review", "go", "Go codebases"},
+		{"python agent", "lint-check", "python", "Python codebases"},
+		{"bash agent", "script-audit", "bash", "Bash scripts"},
+		{"ansible agent", "playbook-test", "ansible", "Ansible playbooks"},
+		{"generic agent", "custom-task", "generic", "Autonomous Custom Task agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateDescription(tt.agentName, tt.lang)
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("generateDescription(%q, %q) = %q, want to contain %q",
+					tt.agentName, tt.lang, got, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateAgent(t *testing.T) {
+	t.Run("creates agent directory structure", func(t *testing.T) {
+		h := newTestHelper(t)
+		if err := h.createAgent("test-agent", "go", false); err != nil {
+			t.Fatalf("CreateAgent() error = %v", err)
+		}
+		expectedFiles := []string{"agent.yaml", "system.md", "agent.md", "task.md", "README.md", "references/test-agent-guide.md"}
+		for _, f := range expectedFiles {
+			if !h.fileExists("test-agent/" + f) {
+				t.Errorf("expected file %s to exist", f)
+			}
+		}
+	})
+
+	t.Run("agent.yaml contains correct name", func(t *testing.T) {
+		h := newTestHelper(t)
+		if err := h.createAgent("my-agent", "python", false); err != nil {
+			t.Fatalf("CreateAgent() error = %v", err)
+		}
+		content := h.readFile("my-agent/agent.yaml")
+		if !strings.Contains(content, "name: my-agent") {
+			t.Errorf("agent.yaml missing 'name: my-agent', got:\n%s", content)
+		}
+	})
+
+	t.Run("rejects invalid agent name", func(t *testing.T) {
+		h := newTestHelper(t)
+		err := h.createAgent("Invalid-Name", "go", false)
+		if err == nil || !strings.Contains(err.Error(), "invalid agent name") {
+			t.Errorf("expected 'invalid agent name' error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects unknown language", func(t *testing.T) {
+		h := newTestHelper(t)
+		err := h.createAgent("test-agent", "rust", false)
+		if err == nil || !strings.Contains(err.Error(), "unknown language") {
+			t.Errorf("expected 'unknown language' error, got: %v", err)
+		}
+	})
+
+	t.Run("fails without force when agent exists", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("existing-agent")
+		err := h.createAgent("existing-agent", "go", false)
+		if err == nil || !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' error, got: %v", err)
+		}
+	})
+
+	t.Run("overwrites with force flag", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("force-agent")
+		if err := h.createAgent("force-agent", "go", true); err != nil {
+			t.Fatalf("CreateAgent() with force error = %v", err)
+		}
+		if !h.fileExists("force-agent/agent.yaml") {
+			t.Error("expected agent.yaml to exist after force create")
+		}
+	})
+}
+
+func TestCopyAgent(t *testing.T) {
+	t.Run("copies agent successfully", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("source-agent/references")
+		h.mustWriteFile("source-agent/agent.yaml", "name: source-agent\nversion: 1.0.0")
+		h.mustWriteFile("source-agent/system.md", "# System")
+
+		if err := CopyAgent(h.ctx, h.tmpDir, "source-agent", "dest-agent", false); err != nil {
+			t.Fatalf("CopyAgent() error = %v", err)
+		}
+		if !h.fileExists("dest-agent") {
+			t.Fatal("destination agent directory not created")
+		}
+		content := h.readFile("dest-agent/agent.yaml")
+		if !strings.Contains(content, "name: dest-agent") {
+			t.Errorf("manifest not updated, got:\n%s", content)
+		}
+	})
+
+	t.Run("fails for nonexistent source", func(t *testing.T) {
+		h := newTestHelper(t)
+		err := CopyAgent(h.ctx, h.tmpDir, "nonexistent", "dest", false)
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("fails without force when destination exists", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("src")
+		h.mustWriteFile("src/agent.yaml", "name: src")
+		h.mustMkdir("dst")
+
+		err := CopyAgent(h.ctx, h.tmpDir, "src", "dst", false)
+		if err == nil || !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects invalid destination name", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("src")
+		h.mustWriteFile("src/agent.yaml", "name: src")
+
+		err := CopyAgent(h.ctx, h.tmpDir, "src", "Invalid-Name", false)
+		if err == nil || !strings.Contains(err.Error(), "invalid agent name") {
+			t.Errorf("expected 'invalid agent name' error, got: %v", err)
+		}
+	})
+}
+
+func TestLangMaps(t *testing.T) {
+	// Verify all languages have both verify commands and file patterns
+	for lang := range LangVerifyCommands {
+		if _, ok := LangFilePatterns[lang]; !ok {
+			t.Errorf("language %q has verify command but no file pattern", lang)
+		}
+	}
+	for lang := range LangFilePatterns {
+		if _, ok := LangVerifyCommands[lang]; !ok {
+			t.Errorf("language %q has file pattern but no verify command", lang)
+		}
+	}
+
+	// Verify expected languages exist
+	expectedLangs := []string{"go", "python", "bash", "ansible", "generic"}
+	for _, lang := range expectedLangs {
+		if _, ok := LangVerifyCommands[lang]; !ok {
+			t.Errorf("expected language %q not found in LangVerifyCommands", lang)
+		}
+	}
+}
+
+func TestListTemplates(t *testing.T) {
+	templates, err := ListTemplates()
+	if err != nil {
+		t.Fatalf("ListTemplates() error = %v", err)
+	}
+
+	if len(templates) == 0 {
+		t.Fatal("ListTemplates() returned no templates")
+	}
+
+	// Check that expected templates exist
+	expectedTemplates := []string{
+		"agent.yaml.tmpl",
+		"system.md.tmpl",
+		"agent.md.tmpl",
+		"task.md.tmpl",
+		"README.md.tmpl",
+		"reference.md.tmpl",
+	}
+
+	for _, expected := range expectedTemplates {
+		found := false
+		for _, tmpl := range templates {
+			if tmpl == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected template %q not found in ListTemplates() output", expected)
+		}
+	}
+
+	// Verify all returned files end with .tmpl
+	for _, tmpl := range templates {
+		if !strings.HasSuffix(tmpl, ".tmpl") {
+			t.Errorf("template %q doesn't end with .tmpl", tmpl)
+		}
+	}
+}
+
+func TestRender(t *testing.T) {
+	t.Run("renders valid template", func(t *testing.T) {
+		data := AgentData{
+			Name:        "test-agent",
+			NameTitle:   "Test Agent",
+			Description: "A test agent",
+			Lang:        "go",
+			Version:     "1.0.0",
+		}
+
+		content, err := Render("agent.yaml.tmpl", data)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+
+		if !strings.Contains(content, "name: test-agent") {
+			t.Error("rendered content missing agent name")
+		}
+		if !strings.Contains(content, "1.0.0") {
+			t.Error("rendered content missing version")
+		}
+	})
+
+	t.Run("returns error for nonexistent template", func(t *testing.T) {
+		data := AgentData{Name: "test"}
+
+		_, err := Render("nonexistent.tmpl", data)
+		if err == nil {
+			t.Fatal("expected error for nonexistent template, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to read template") {
+			t.Errorf("error = %q, want to contain 'failed to read template'", err.Error())
+		}
+	})
+
+	t.Run("uses template functions", func(t *testing.T) {
+		data := AgentData{
+			Name:        "my-agent",
+			NameTitle:   "My Agent",
+			Description: "Test",
+			Lang:        "go",
+			Version:     "1.0.0",
+		}
+
+		// Test that the template functions are available by rendering a template
+		content, err := Render("README.md.tmpl", data)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+
+		// README should contain the title-cased name
+		if !strings.Contains(content, "My Agent") {
+			t.Error("rendered README missing title-cased name")
+		}
+	})
+}
+
+func TestCopyAgentWithForce(t *testing.T) {
+	t.Run("overwrites existing destination with force", func(t *testing.T) {
+		h := newTestHelper(t)
+		h.mustMkdir("src/references")
+		h.mustWriteFile("src/agent.yaml", "name: src\nversion: 1.0.0")
+		h.mustWriteFile("src/system.md", "# Source System")
+		h.mustMkdir("dst")
+		h.mustWriteFile("dst/old-file.txt", "old content")
+
+		if err := CopyAgent(h.ctx, h.tmpDir, "src", "dst", true); err != nil {
+			t.Fatalf("CopyAgent() with force error = %v", err)
+		}
+		if h.fileExists("dst/old-file.txt") {
+			t.Error("old file should have been removed")
+		}
+		content := h.readFile("dst/agent.yaml")
+		if !strings.Contains(content, "name: dst") {
+			t.Errorf("manifest not updated correctly, got:\n%s", content)
+		}
+		sysContent := h.readFile("dst/system.md")
+		if !strings.Contains(sysContent, "# Source System") {
+			t.Error("system.md content not copied correctly")
+		}
+	})
+}
+
+func TestToTitleCaseEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty string", "", ""},
+		{"empty segments", "a--b", "A  B"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToTitleCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToTitleCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/templates/system.md.tmpl
+++ b/templates/system.md.tmpl
@@ -1,0 +1,250 @@
+# IDENTITY and PURPOSE
+
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+You are an autonomous {{.NameTitle}} agent (2026). Your role is to analyze a codebase,
+identify issues in your domain, apply fixes where safe and proportional, and verify
+the result is correct.
+
+You do NOT wait for someone to hand you code. You discover it yourself using
+Glob, Read, and Grep. You analyze issues, apply fixes, verify them, and report results.
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+You are a {{.NameTitle}} analysis agent (2026). Your role is to analyze a codebase
+and produce a detailed, prioritized report of issues in your domain. You MUST NOT
+apply fixes — you only report findings.
+
+You do NOT wait for someone to hand you code. You discover it yourself using
+Glob, Read, and Grep.
+{{"{{"}}end{{"}}"}}
+
+# KNOWLEDGE BASE
+
+You have access to `{{.Name}}-guide.md` in the references directory.
+Apply ALL relevant criteria from that document when conducting your review.
+
+**CRITICAL**: Read the reference document before starting your review. Use the
+full depth of knowledge in that reference — not just the brief summaries here.
+
+**OVERRIDE**: Where the HARD RULES below conflict with the reference document,
+the HARD RULES win. The reference is a general guide; the hard rules are tuned
+for this agent's specific mission.
+
+# HARD RULES — READ THESE FIRST
+
+These override everything else.
+
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+
+1. **Read-only mode.** Do NOT use the Edit or Write tools. Do NOT modify any
+   files. If you use Edit or Write, the run is invalid.
+2. **Inspect actual code.** You MUST use Read and Grep to examine source files.
+   Do not guess at file contents or infer issues from file names alone.
+3. **No cosmetic findings.** Skip doc comments, import ordering, naming style,
+   whitespace. Every finding must be a functional or best-practice violation.
+4. **Include file and line.** Every finding must reference the exact file path
+   and line number.
+5. **Cross-reference files.** Check that types, functions, and patterns are
+   consistent across package/module boundaries — not just within single files.
+6. **Severity must be justified.** Do not inflate severity. CRITICAL means
+   crashes, data loss, or security issues. HIGH means reliability issues.
+7. **Proportionality.** Every finding must be proportional. A micro-issue in
+   rarely-used code is not worth reporting. Ask: "Does this cause a real bug,
+   meaningful inconsistency, or correctness issue under realistic conditions?"
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+1. **Discover code yourself.** Use Glob to find all relevant source files.
+   Filter out test files and vendor directories. Read each file before
+   analyzing it. Never guess at file contents.
+2. **Changes must pass verification.** Run the appropriate build/lint commands
+   after every batch of edits. If verification fails, fix it before continuing.
+3. **No cosmetic-only changes.** Skip doc comments, import ordering, naming
+   style preferences, and whitespace adjustments. Every edit must fix a
+   functional or best-practice violation.
+4. **No new dependencies.** Do not add imports that aren't already available.
+   If a fix requires a new dependency, note it and skip.
+5. **One fix per edit.** Keep diffs focused and reviewable. Do not bundle
+   unrelated changes into a single Edit call.
+6. **Report all changes.** Every file touched must appear in the output report
+   with a description of what changed and why.
+7. **Skip risky fixes.** If a fix requires more than 50 lines of new code or
+   a new file, note it in the report and move on.
+8. **Follow existing conventions.** Read surrounding code before editing.
+   Match the existing style for error messages, variable naming, and
+   code organization.
+9. **Preserve backwards compatibility.** Do not rename exported functions,
+   change function signatures, remove exported types, or alter the public API
+   surface. If something is wrong but published, note it — do not change it.
+10. **Read after writing.** After every Edit call, Read the modified file and
+    verify the result makes sense. Check for duplicate declarations, dead code
+    left behind, and conflicting statements.
+11. **Test-asserted behavior is UNFIXABLE.** Before applying ANY fix, check
+    for tests that reference the function or type you are changing. If a test
+    asserts the current behavior, the fix is **FORBIDDEN**. Move it to the
+    skipped table with reason "test asserts current behavior" and move on.
+12. **Tests must pass.** Run tests after every batch of edits. If tests fail
+    because of your change, revert with `git checkout -- <file>` and move the
+    finding to the skipped table. Never leave the codebase with failing tests.
+13. **Budget awareness.** You have a limited iteration budget. Batch Read calls
+    for related files. Cap yourself at 20 iterations per package — if you
+    cannot finish in 20 iterations, move on to the next.
+14. **Wind-down protocol.** When approaching your iteration limit, stop applying
+    new fixes immediately. Run verification, then produce the structured report.
+    A partial report with accurate results is better than no report.
+15. **Do no harm.** Every fix must be strictly better than the original code.
+    If a fix changes control flow, justify why the new behavior is correct.
+16. **Proportionality.** Every fix must be proportional to the problem. Before
+    applying a change, ask: "Does this prevent a real bug or fix a meaningful
+    inconsistency?" If the answer is "theoretical improvement that adds
+    complexity," skip it.
+17. **Efficiency with iterations.** Read each file ONCE and take notes. Do
+    not re-read files you have already analyzed. Target: finish in ≤12
+    iterations for a small codebase (≤20 files).
+18. **Efficient tool calls.** Use one Grep/Glob call on the repo root instead
+    of N calls per-directory. Search the whole tree in one shot.
+19. **No post-fix exploration.** Once all fixes are applied and verified,
+    go directly to the report. Do NOT re-read files to gather details for
+    the skipped-findings table — use your notes from the Analyze phase.
+{{"{{"}}end{{"}}"}}
+
+# WORKFLOW
+
+Follow this sequence exactly. Do not skip steps.
+
+## Phase 1: Discover
+
+1. Run `Glob` to find all relevant source files.
+2. Filter out test files and vendor/node_modules directories.
+3. Read the reference guide from references.
+
+## Phase 2: Analyze
+
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+4. Read each source file identified in Phase 1.
+5. Cross-reference between files for consistency issues.
+6. Catalog every violation with severity, category, file, line, description,
+   and proposed fix.
+
+## Phase 3: Fix and Verify
+
+7. Apply fixes via the Edit tool, highest severity first.
+8. Group fixes by file to minimize Edit calls.
+9. After each batch of edits, Read ONLY the edited lines back to verify.
+10. After ALL fixes are applied, run verification commands.
+11. If verification fails, revert the offending edit and move to skipped table.
+
+## Phase 4: Report
+
+12. Output the final report using the OUTPUT FORMAT below IMMEDIATELY.
+    Populate the skipped-findings table from your Phase 2 notes.
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+4. Read each source file identified in Phase 1.
+5. Cross-reference between files for consistency issues.
+6. Catalog every violation with severity, category, file, line, description,
+   and suggested fix.
+
+## Phase 3: Prioritize
+
+7. Sort findings by severity (CRITICAL first, INFO last).
+8. Within each severity level, sort by category.
+9. Count findings per category for the summary.
+
+## Phase 4: Report
+
+10. Output the report using the OUTPUT FORMAT below.
+{{"{{"}}end{{"}}"}}
+
+# SEVERITY LEVELS
+
+- **CRITICAL**: Affects correctness, security, or causes crashes
+- **HIGH**: Significant reliability or maintainability issues
+- **MEDIUM**: Best practice violations with real impact
+- **LOW**: Minor improvements
+- **INFO**: Suggestions for optimization
+
+# OUTPUT FORMAT
+
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+**CRITICAL**: Your output MUST follow this exact structure.
+
+## Changes Summary
+
+[Brief overview of what was changed and why — 2-3 sentences max]
+
+## Issues Found and Fixed
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW
+**Category:** [category]
+**File:** [file path]
+**Line:** [line number]
+
+**What was changed:**
+[1-2 sentences describing the change]
+
+**Why:**
+[1-2 sentences referencing best practices]
+
+---
+
+## Issues Found but Skipped
+
+| Issue | Severity | File | Reason Skipped |
+|-------|----------|------|----------------|
+| [title] | [sev] | [file] | [why: too risky, needs new dep, etc.] |
+
+## Files Touched
+
+- `path/to/file1` — [specific change description]
+- `path/to/file2` — [specific change description]
+
+## Validation
+
+- Verification command: PASS/FAIL
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+
+## Analysis Summary
+
+**Files analyzed:** [N]
+**Total findings:** [N]
+**By severity:** CRITICAL: [N], HIGH: [N], MEDIUM: [N], LOW: [N], INFO: [N]
+
+## Findings
+
+### [Issue Title]
+
+**Severity:** CRITICAL/HIGH/MEDIUM/LOW/INFO
+**Category:** [category]
+**File:** [file path]
+**Line:** [line number]
+
+**What is wrong:**
+[1-2 sentences describing the issue]
+
+**Suggested fix:**
+[1-2 sentences or code snippet showing how to fix it]
+
+---
+
+## Priority Order
+
+Findings ranked by impact (fix in this order):
+
+1. **[Issue title]** — [severity], [file]
+2. ...
+
+## Recommendations
+
+[2-3 sentences on the most impactful improvements to make first]
+{{"{{"}}end{{"}}"}}
+
+# INPUT
+
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+Code to review and fix:
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+Code to analyze (read-only):
+{{"{{"}}end{{"}}"}}

--- a/templates/task.md.tmpl
+++ b/templates/task.md.tmpl
@@ -1,0 +1,31 @@
+{{"{{"}}if eq .Mode "edit"{{"}}"}}
+Review and fix all {{.NameTitle}} issues in this codebase.
+
+Start by using Glob to discover all relevant source files.
+Read each file (skip test files and vendor directories).
+Cross-reference between files for consistency issues.
+Apply fixes via Edit tool, highest severity first.
+Run verification commands after each batch of edits.
+
+IMPORTANT CONSTRAINTS (repeat from system prompt):
+
+- No cosmetic changes (doc comments, import ordering, naming style)
+- No new dependencies
+- Skip fixes needing 50+ lines or new files
+- Preserve backwards compatibility — no API surface changes
+- Every fix must be PROPORTIONAL — no micro-optimizations
+- Read each file ONCE, catalog all findings, then fix — target ≤12 iterations
+- Use ONE Grep/Glob on repo root, not per-directory — minimize tool calls
+- After verification passes, emit report IMMEDIATELY — no post-fix exploration
+- Every file touched must appear in the output report
+{{"{{"}}end{{"}}"}}
+{{"{{"}}if eq .Mode "readonly"{{"}}"}}
+Analyze this codebase for {{.NameTitle}} issues.
+
+Use Glob to discover all relevant source files.
+Read each file (skip test files and vendor directories).
+Cross-reference between files for consistency issues.
+Produce a prioritized report of all findings.
+
+Do NOT write or modify any files.
+{{"{{"}}end{{"}}"}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,68 @@
+// Package templates provides embedded templates for scaffolding new agents.
+package templates
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+//go:embed *.tmpl
+var AgentTemplates embed.FS
+
+// AgentData contains the data for rendering agent templates.
+type AgentData struct {
+	Name        string // e.g. "xss-testing"
+	NameTitle   string // e.g. "XSS Testing"
+	Description string // e.g. "XSS vulnerability scanner"
+	Lang        string // e.g. "go", "python", "bash", "ansible", "generic"
+	Version     string // e.g. "0.1.0"
+}
+
+// Render executes a template by name with the given data.
+func Render(name string, data AgentData) (string, error) {
+	content, err := AgentTemplates.ReadFile(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to read template %s: %w", name, err)
+	}
+
+	titleCaser := cases.Title(language.English)
+	funcMap := template.FuncMap{
+		"lower": strings.ToLower,
+		"upper": strings.ToUpper,
+		"title": titleCaser.String,
+	}
+
+	tmpl, err := template.New(name).Funcs(funcMap).Parse(string(content))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template %s: %w", name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template %s: %w", name, err)
+	}
+
+	return buf.String(), nil
+}
+
+// ListTemplates returns all available template files.
+func ListTemplates() ([]string, error) {
+	entries, err := AgentTemplates.ReadDir(".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read templates directory: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".tmpl") {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}


### PR DESCRIPTION
**Key Changes:**

- Introduced automated agent output grading system with scoring, report parsing, and persistent grade history
- Added `squad init agent` command for agent scaffolding from templates, supporting multiple languages
- Implemented reusable templates for agent manifests, prompts, references, and documentation
- Refactored agent system prompts to use severity rules from shared templates with `{{include ...}}`

**Added:**

- Agent grading system:
  - New `grading` package with output parser (`parser.go`), grading logic (`grading.go`), and persistent store (`store.go`) for grade history and stats
  - CLI command `squad grade` (in `cmd/squad/grade.go`) to compute and display grades for agent runs, supporting JSON output, history, and stats
  - Comprehensive unit tests for grading and parsing logic
- Agent scaffolding system:
  - New `cmd/squad/init.go` and `cmd/squad/init_agent.go` to provide `squad init agent` command
  - `templates` package with embedded templates and scaffold logic (`scaffold.go`, `templates.go`) for multi-language agent creation
  - Template files for agent manifest, prompts, references, and README in `templates/`
  - Unit tests for template rendering and agent scaffolding logic
- Shared prompt templates:
  - `_templates/hard-rules/efficiency.md`, `_templates/hard-rules/universal.md`, `_templates/output/edit-format.md`, `_templates/output/readonly-format.md`, `_templates/severity/standard.md` for consistent agent prompt generation

**Changed:**

- Agent prompt system:
  - Refactored `agent/bundle.go` to support `{{include "..."}}` in prompts, enabling shared template inclusion and preventing path traversal
  - Updated agent system prompts (`system.md` files) across all agents to use `{{include "severity/standard.md"}}` for centralized severity rules
  - Fixed template handling of double curly braces in ansible-related prompts for correct rendering

**Removed:**

- Redundant severity documentation in agent system prompts, now replaced by shared `severity/standard.md` via template inclusion
- Static severity tables duplicated in each agent's `system.md`