### PR TITLE
feat: add background task execution and result collection to Task tool

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^mailto:"
+    },
+    {
+      "pattern": "github.com/[Cc]ow[Dd]og[Mm]oo/squad-agents"
     }
   ],
   "timeout": "20s",

--- a/runner/model.go
+++ b/runner/model.go
@@ -204,6 +204,7 @@ func buildTaskConfig(opts *RunOptions) *tools.TaskConfig {
 		AgentsDir:     opts.AgentsDir,
 		WorkingDir:    opts.WorkingDir,
 		MaxIterations: opts.MaxIterations,
+		Registry:      tools.NewBackgroundTaskRegistry(),
 		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
 			// Child agents inherit parent's template variables
 			childBundle, err := agent.BuildBundle(agentsDir, agentName, prompt, workingDir, mode, opts.Vars)

--- a/tools/task.go
+++ b/tools/task.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/metrics"
@@ -15,6 +17,101 @@ type taskDepthKey struct{}
 
 // MaxTaskDepth is the maximum nesting depth for Task tool invocations.
 const MaxTaskDepth = 3
+
+// MaxConcurrentTasks limits concurrent background tasks per session.
+const MaxConcurrentTasks = 4
+
+// BackgroundTaskResult holds the result of a background task.
+type BackgroundTaskResult struct {
+	Output  string
+	Metrics *metrics.Metrics
+	Err     error
+	Done    chan struct{}
+}
+
+// BackgroundTaskRegistry manages background task spawning and results.
+type BackgroundTaskRegistry struct {
+	mu        sync.RWMutex
+	tasks     map[string]*BackgroundTaskResult
+	counter   uint64
+	semaphore chan struct{}
+}
+
+// NewBackgroundTaskRegistry creates a new registry with semaphore limiting.
+func NewBackgroundTaskRegistry() *BackgroundTaskRegistry {
+	return &BackgroundTaskRegistry{
+		tasks:     make(map[string]*BackgroundTaskResult),
+		semaphore: make(chan struct{}, MaxConcurrentTasks),
+	}
+}
+
+// SpawnTask runs a task in the background and returns its ID immediately.
+func (r *BackgroundTaskRegistry) SpawnTask(ctx context.Context, cfg TaskConfig, args taskArgs, workDir string) string {
+	id := fmt.Sprintf("bg-%d", atomic.AddUint64(&r.counter, 1))
+	result := &BackgroundTaskResult{
+		Done: make(chan struct{}),
+	}
+
+	r.mu.Lock()
+	r.tasks[id] = result
+	r.mu.Unlock()
+
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				result.Err = fmt.Errorf("task panicked: %v", rec)
+			}
+			close(result.Done)
+		}()
+
+		// Acquire semaphore slot
+		select {
+		case r.semaphore <- struct{}{}:
+			defer func() { <-r.semaphore }()
+		case <-ctx.Done():
+			result.Err = ctx.Err()
+			return
+		}
+
+		depth := TaskDepth(ctx)
+		childCtx := WithTaskDepth(ctx, depth+1)
+		logging.InfoContext(ctx, "Task tool: spawning background child agent=%s id=%s depth=%d", args.Agent, id, depth+1)
+
+		response, childMetrics, err := cfg.CallModel(childCtx, cfg.AgentsDir, args.Agent, args.Prompt, workDir, args.Mode)
+		result.Output = response
+		result.Metrics = childMetrics
+		result.Err = err
+
+		if len(result.Output) > maxToolOutput {
+			result.Output = result.Output[:maxToolOutput] + "\n...output truncated"
+		}
+
+		metricsInfo := ""
+		if childMetrics != nil {
+			metricsInfo = fmt.Sprintf(" tokens=%d", childMetrics.TotalTokens())
+		}
+		logging.InfoContext(ctx, "Task tool: background child agent=%s id=%s completed (%d bytes%s)", args.Agent, id, len(result.Output), metricsInfo)
+	}()
+
+	return id
+}
+
+// GetResult returns the result for a task ID, blocking until complete if wait is true.
+func (r *BackgroundTaskRegistry) GetResult(taskID string, wait bool) (*BackgroundTaskResult, bool) {
+	r.mu.RLock()
+	result, ok := r.tasks[taskID]
+	r.mu.RUnlock()
+
+	if !ok {
+		return nil, false
+	}
+
+	if wait {
+		<-result.Done
+	}
+
+	return result, true
+}
 
 // WithTaskDepth returns a new context with the given task depth.
 func WithTaskDepth(ctx context.Context, depth int) context.Context {
@@ -40,6 +137,7 @@ type TaskConfig struct {
 	WorkingDir    string
 	MaxIterations int
 	CallModel     CallModelFunc
+	Registry      *BackgroundTaskRegistry
 }
 
 type taskArgs struct {
@@ -47,6 +145,7 @@ type taskArgs struct {
 	Prompt     string `json:"prompt"`
 	Mode       string `json:"mode,omitempty"`
 	WorkingDir string `json:"working_dir,omitempty"`
+	Background bool   `json:"background,omitempty"`
 }
 
 func definitionTask() llms.Tool {
@@ -54,7 +153,7 @@ func definitionTask() llms.Tool {
 		Type: "function",
 		Function: &llms.FunctionDefinition{
 			Name:        "Task",
-			Description: "Spawn a child agent run. The child inherits the current context and tools but runs with its own iteration budget.",
+			Description: "Spawn a child agent run. The child inherits the current context and tools but runs with its own iteration budget. Use background=true for parallel execution, then call TaskResult to collect output.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -62,6 +161,7 @@ func definitionTask() llms.Tool {
 					"prompt":      map[string]any{"type": "string", "description": "Prompt/instructions for the child agent."},
 					"mode":        map[string]any{"type": "string", "description": "Optional agent mode override (e.g. readonly)."},
 					"working_dir": map[string]any{"type": "string", "description": "Optional working directory override for the child."},
+					"background":  map[string]any{"type": "boolean", "description": "If true, spawn task in background and return task ID immediately. Use TaskResult to collect output."},
 				},
 				"required": []string{"agent", "prompt"},
 			},
@@ -96,6 +196,16 @@ func taskTool(cfg TaskConfig) func(ctx context.Context, rawArgs []byte) (string,
 			workDir = resolved
 		}
 
+		// Background task: spawn and return ID immediately
+		if args.Background {
+			if cfg.Registry == nil {
+				return "", fmt.Errorf("background tasks not supported (registry not initialized)")
+			}
+			taskID := cfg.Registry.SpawnTask(ctx, cfg, args, workDir)
+			return fmt.Sprintf("Task started in background. Task ID: %s\nUse TaskResult(task_id=\"%s\") to collect the output when ready.", taskID, taskID), nil
+		}
+
+		// Blocking task: wait for completion
 		childCtx := WithTaskDepth(ctx, depth+1)
 		logging.InfoContext(ctx, "Task tool: spawning child agent=%s depth=%d", args.Agent, depth+1)
 
@@ -115,5 +225,59 @@ func taskTool(cfg TaskConfig) func(ctx context.Context, rawArgs []byte) (string,
 		}
 		logging.InfoContext(ctx, "Task tool: child agent=%s completed (%d bytes%s)", args.Agent, len(response), metricsInfo)
 		return response, nil
+	}
+}
+
+func definitionTaskResult() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "TaskResult",
+			Description: "Collect the result of a background task spawned with Task(background=true). Blocks until the task completes.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"task_id": map[string]any{"type": "string", "description": "The task ID returned by Task(background=true)."},
+				},
+				"required": []string{"task_id"},
+			},
+		},
+	}
+}
+
+type taskResultArgs struct {
+	TaskID string `json:"task_id"`
+}
+
+func taskResultTool(cfg TaskConfig) func(ctx context.Context, rawArgs []byte) (string, error) {
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		var args taskResultArgs
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return "", fmt.Errorf("invalid TaskResult args: %w", err)
+		}
+		if args.TaskID == "" {
+			return "", fmt.Errorf("task_id is required")
+		}
+
+		if cfg.Registry == nil {
+			return "", fmt.Errorf("background tasks not supported (registry not initialized)")
+		}
+
+		result, ok := cfg.Registry.GetResult(args.TaskID, true)
+		if !ok {
+			return "", fmt.Errorf("unknown task ID: %s", args.TaskID)
+		}
+
+		if result.Err != nil {
+			return "", fmt.Errorf("task %s failed: %w", args.TaskID, result.Err)
+		}
+
+		metricsInfo := ""
+		if result.Metrics != nil {
+			metricsInfo = fmt.Sprintf(" (tokens=%d)", result.Metrics.TotalTokens())
+		}
+		logging.InfoContext(ctx, "TaskResult: collected result for %s (%d bytes%s)", args.TaskID, len(result.Output), metricsInfo)
+
+		return result.Output, nil
 	}
 }

--- a/tools/task_test.go
+++ b/tools/task_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cowdogmoo/squad/metrics"
 )
@@ -154,5 +155,279 @@ func TestTaskToolDepthLimit(t *testing.T) {
 	ctx := WithTaskDepth(context.Background(), MaxTaskDepth)
 	if _, err := tool(ctx, payload); err == nil {
 		t.Fatalf("expected depth limit error")
+	}
+}
+
+func TestBackgroundTaskBasic(t *testing.T) {
+	dir := t.TempDir()
+	registry := NewBackgroundTaskRegistry()
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   registry,
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			return "background result", nil, nil
+		},
+	}
+
+	tool := taskTool(cfg)
+	resultTool := taskResultTool(cfg)
+
+	// Spawn background task
+	payload, _ := json.Marshal(map[string]any{
+		"agent":      "child",
+		"prompt":     "do work",
+		"background": true,
+	})
+
+	out, err := tool(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("taskTool background: %v", err)
+	}
+	if !strings.Contains(out, "bg-1") {
+		t.Fatalf("expected task ID in output, got: %s", out)
+	}
+
+	// Collect result
+	resultPayload, _ := json.Marshal(map[string]string{
+		"task_id": "bg-1",
+	})
+
+	result, err := resultTool(context.Background(), resultPayload)
+	if err != nil {
+		t.Fatalf("taskResultTool: %v", err)
+	}
+	if result != "background result" {
+		t.Fatalf("unexpected result: %s", result)
+	}
+}
+
+func TestBackgroundTaskSemaphore(t *testing.T) {
+	dir := t.TempDir()
+	registry := NewBackgroundTaskRegistry()
+
+	started := make(chan struct{}, MaxConcurrentTasks+1)
+	block := make(chan struct{})
+
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   registry,
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			started <- struct{}{}
+			<-block
+			return "done", nil, nil
+		},
+	}
+
+	tool := taskTool(cfg)
+
+	// Spawn MaxConcurrentTasks + 1 tasks
+	for i := 0; i < MaxConcurrentTasks+1; i++ {
+		payload, _ := json.Marshal(map[string]any{
+			"agent":      "child",
+			"prompt":     fmt.Sprintf("task %d", i),
+			"background": true,
+		})
+		_, err := tool(context.Background(), payload)
+		if err != nil {
+			t.Fatalf("taskTool: %v", err)
+		}
+	}
+
+	// Wait for MaxConcurrentTasks to start
+	for i := 0; i < MaxConcurrentTasks; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("expected %d tasks to start, only %d did", MaxConcurrentTasks, i)
+		}
+	}
+
+	// Verify the 5th task hasn't started yet (semaphore blocking)
+	select {
+	case <-started:
+		t.Fatalf("5th task should be blocked by semaphore")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: 5th task is waiting
+	}
+
+	// Unblock one task
+	block <- struct{}{}
+
+	// Now the 5th task should start
+	select {
+	case <-started:
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatalf("5th task should have started after one completed")
+	}
+
+	// Unblock remaining tasks
+	close(block)
+}
+
+func TestBackgroundTaskCancel(t *testing.T) {
+	dir := t.TempDir()
+	registry := NewBackgroundTaskRegistry()
+
+	started := make(chan struct{})
+
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   registry,
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			close(started)
+			<-ctx.Done()
+			return "", nil, ctx.Err()
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tool := taskTool(cfg)
+	payload, _ := json.Marshal(map[string]any{
+		"agent":      "child",
+		"prompt":     "do work",
+		"background": true,
+	})
+
+	out, err := tool(ctx, payload)
+	if err != nil {
+		t.Fatalf("taskTool: %v", err)
+	}
+	if !strings.Contains(out, "bg-1") {
+		t.Fatalf("expected task ID")
+	}
+
+	// Wait for task to start
+	<-started
+
+	// Cancel context
+	cancel()
+
+	// Collect result - should have context error
+	result, ok := registry.GetResult("bg-1", true)
+	if !ok {
+		t.Fatalf("expected to find task result")
+	}
+	if result.Err == nil {
+		t.Fatalf("expected error from cancelled task")
+	}
+}
+
+func TestBackgroundTaskPanic(t *testing.T) {
+	dir := t.TempDir()
+	registry := NewBackgroundTaskRegistry()
+
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   registry,
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			panic("test panic")
+		},
+	}
+
+	tool := taskTool(cfg)
+	payload, _ := json.Marshal(map[string]any{
+		"agent":      "child",
+		"prompt":     "do work",
+		"background": true,
+	})
+
+	_, err := tool(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("taskTool: %v", err)
+	}
+
+	resultTool := taskResultTool(cfg)
+	resultPayload, _ := json.Marshal(map[string]string{
+		"task_id": "bg-1",
+	})
+
+	_, err = resultTool(context.Background(), resultPayload)
+	if err == nil {
+		t.Fatalf("expected error from panicked task")
+	}
+	if !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("expected panic error, got: %v", err)
+	}
+}
+
+func TestTaskResultInvalidID(t *testing.T) {
+	dir := t.TempDir()
+	registry := NewBackgroundTaskRegistry()
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   registry,
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			return "", nil, nil
+		},
+	}
+
+	resultTool := taskResultTool(cfg)
+
+	tests := []struct {
+		name         string
+		payload      []byte
+		wantContains string
+	}{
+		{
+			name:         "invalid json",
+			payload:      []byte("{"),
+			wantContains: "invalid TaskResult args",
+		},
+		{
+			name:         "missing task_id",
+			payload:      []byte(`{}`),
+			wantContains: "task_id is required",
+		},
+		{
+			name:         "unknown task_id",
+			payload:      []byte(`{"task_id":"bg-999"}`),
+			wantContains: "unknown task ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resultTool(context.Background(), tt.payload)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestBackgroundTaskNoRegistry(t *testing.T) {
+	dir := t.TempDir()
+	cfg := TaskConfig{
+		AgentsDir:  "agents",
+		WorkingDir: dir,
+		Registry:   nil, // No registry
+		CallModel: func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
+			return "", nil, nil
+		},
+	}
+
+	tool := taskTool(cfg)
+	payload, _ := json.Marshal(map[string]any{
+		"agent":      "child",
+		"prompt":     "do work",
+		"background": true,
+	})
+
+	_, err := tool(context.Background(), payload)
+	if err == nil {
+		t.Fatalf("expected error when registry is nil")
+	}
+	if !strings.Contains(err.Error(), "registry not initialized") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -354,6 +354,9 @@ func BuildHandlers(workingDir string, taskCfg *TaskConfig) (map[string]Handler, 
 
 	if taskCfg != nil {
 		add(Handler{Def: definitionTask(), Call: taskTool(*taskCfg)})
+		if taskCfg.Registry != nil {
+			add(Handler{Def: definitionTaskResult(), Call: taskResultTool(*taskCfg)})
+		}
 	}
 
 	toolDefs := make([]llms.Tool, 0, len(handlers))


### PR DESCRIPTION
**Key Changes:**

- Introduced background task execution with immediate task ID return and result collection via TaskResult
- Implemented background task registry with concurrency limiting and result management
- Extended Task tool schema and handler logic to support background execution and result retrieval
- Added comprehensive tests for background task execution, semaphore limits, error handling, and result collection

**Added:**

- BackgroundTaskRegistry with semaphore-based concurrency control and result tracking in `tools/task.go`
- Background execution support in Task tool: allows spawning child agents asynchronously and returns task IDs immediately
- New TaskResult tool and handler for collecting results of background tasks, blocking until completion
- Full test coverage for background task logic, including concurrency, cancellation, panics, invalid IDs, and missing registry in `tools/task_test.go`

**Changed:**

- Task tool schema updated to include `background` boolean argument and improved description
- TaskConfig struct extended with optional `Registry` for background task support
- `BuildHandlers` in `tools/tools.go` now conditionally registers TaskResult tool if background registry is enabled
- Task tool handler logic modified to spawn background tasks or run blocking depending on the `background` argument
