### PR TITLE
feat: improve tool loop orchestration and logging for multi-tool agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ FIXME.md
 
 # Tool version files (machine-specific)
 .tool-versions
+
+# Go vendor directory
+vendor/

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -158,6 +158,25 @@ func loadManifest(agentPath string) (*Manifest, error) {
 	return &manifest, nil
 }
 
+// resolveEnvironmentTemplates processes template variables in environment options.
+func resolveEnvironmentTemplates(env *executor.Config, data TemplateData) error {
+	if env == nil || env.Options == nil {
+		return nil
+	}
+	for key, val := range env.Options {
+		tmpl, err := template.New(key).Parse(val)
+		if err != nil {
+			return fmt.Errorf("failed to parse environment option %s: %w", key, err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, data); err != nil {
+			return fmt.Errorf("failed to resolve environment option %s: %w", key, err)
+		}
+		env.Options[key] = buf.String()
+	}
+	return nil
+}
+
 // loadAndProcessPrompts loads system, wrapper, and task files, then processes them as templates.
 func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, data TemplateData) (system, wrapper, task string, err error) {
 	systemData, err := readFileInRoot(agentPath, manifest.EntryPoint)
@@ -253,6 +272,12 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 	combined.WriteString("\n\n## User Message\n\n")
 	combined.WriteString(userMessage)
 	combined.WriteString("\n")
+
+	if manifest.Environment != nil {
+		if err := resolveEnvironmentTemplates(manifest.Environment, data); err != nil {
+			return nil, err
+		}
+	}
 
 	return &Bundle{
 		System:      sys.String(),

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cowdogmoo/squad/executor"
 )
 
 // writeTestFiles writes multiple files to the given directory.
@@ -545,4 +547,55 @@ wrapper: wrapper.txt
 
 	// No output config should not inject contract.
 	assertNotContains(t, bundle.System, "Output Contract", "system")
+}
+
+func TestResolveEnvironmentTemplates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		if err := resolveEnvironmentTemplates(nil, TemplateData{}); err != nil {
+			t.Fatalf("expected nil error for nil config, got: %v", err)
+		}
+	})
+
+	t.Run("nil options", func(t *testing.T) {
+		t.Parallel()
+		cfg := &executor.Config{Type: "local"}
+		if err := resolveEnvironmentTemplates(cfg, TemplateData{}); err != nil {
+			t.Fatalf("expected nil error for nil options, got: %v", err)
+		}
+	})
+
+	t.Run("resolves templates", func(t *testing.T) {
+		t.Parallel()
+		cfg := &executor.Config{
+			Type: "local",
+			Options: map[string]string{
+				"mode":   "{{.Mode}}-resolved",
+				"static": "no-template-here",
+			},
+		}
+		data := TemplateData{Mode: "edit"}
+		if err := resolveEnvironmentTemplates(cfg, data); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Options["mode"] != "edit-resolved" {
+			t.Fatalf("expected resolved mode, got: %q", cfg.Options["mode"])
+		}
+		if cfg.Options["static"] != "no-template-here" {
+			t.Fatalf("static value changed: %q", cfg.Options["static"])
+		}
+	})
+
+	t.Run("invalid template syntax", func(t *testing.T) {
+		t.Parallel()
+		cfg := &executor.Config{
+			Type:    "local",
+			Options: map[string]string{"bad": "{{.Unclosed"},
+		}
+		if err := resolveEnvironmentTemplates(cfg, TemplateData{}); err == nil {
+			t.Fatalf("expected parse error for invalid template")
+		}
+	})
 }

--- a/executor/ssm.go
+++ b/executor/ssm.go
@@ -36,11 +36,26 @@ func NewSSMExecutor(cfg *Config) (*SSMExecutor, error) {
 // Execute runs a command on the EC2 instance via ssm send-command
 // and waits for the result.
 func (e *SSMExecutor) Execute(ctx context.Context, command string) ([]byte, error) {
-	// Send the command.
+	// Build the parameters as proper JSON so that multi-line commands
+	// (containing newlines) are correctly encoded.  The previous approach
+	// using fmt.Sprintf(`commands=[%q]`, command) relied on Go's %q verb
+	// which produces Go-escaped strings — the AWS CLI shorthand parser
+	// does not interpret \n as a newline, causing literal "backslash-n"
+	// to appear in commands and corrupt filenames.
+	params := struct {
+		Commands []string `json:"commands"`
+	}{
+		Commands: []string{command},
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal SSM parameters: %w", err)
+	}
+
 	sendArgs := e.baseArgs("ssm", "send-command",
 		"--instance-ids", e.instanceID,
 		"--document-name", "AWS-RunShellScript",
-		"--parameters", fmt.Sprintf(`commands=[%q]`, command),
+		"--parameters", string(paramsJSON),
 		"--output", "json",
 	)
 
@@ -93,6 +108,7 @@ func (e *SSMExecutor) Execute(ctx context.Context, command string) ([]byte, erro
 		StandardOutputContent string `json:"StandardOutputContent"`
 		StandardErrorContent  string `json:"StandardErrorContent"`
 		Status                string `json:"Status"`
+		ResponseCode          int    `json:"ResponseCode"`
 	}
 	if err := json.Unmarshal(getOut.Bytes(), &invocation); err != nil {
 		return getOut.Bytes(), fmt.Errorf("failed to parse invocation response: %w", err)
@@ -100,14 +116,25 @@ func (e *SSMExecutor) Execute(ctx context.Context, command string) ([]byte, erro
 
 	output := invocation.StandardOutputContent
 	if invocation.StandardErrorContent != "" {
-		output += "\n" + invocation.StandardErrorContent
+		output += "\nSTDERR:\n" + invocation.StandardErrorContent
 	}
 
-	if invocation.Status != "Success" {
-		return []byte(output), fmt.Errorf("command exited with status: %s", invocation.Status)
+	// Only treat SSM infrastructure failures as errors (e.g., delivery
+	// timeout, agent not reachable).  A command that runs but exits
+	// non-zero (Status "Failed", ResponseCode > 0) is a normal tool
+	// result — return the output so the model can interpret it.
+	switch invocation.Status {
+	case "Success":
+		return []byte(output), nil
+	case "Failed":
+		// Command executed but exited non-zero.  Append the exit code
+		// so the model knows, but don't return an error.
+		output += fmt.Sprintf("\n[exit code %d]", invocation.ResponseCode)
+		return []byte(output), nil
+	default:
+		// InProgress, TimedOut, Cancelled, etc. — real infrastructure issues.
+		return []byte(output), fmt.Errorf("command status: %s", invocation.Status)
 	}
-
-	return []byte(output), nil
 }
 
 // Close is a no-op for SSM (stateless per-command).

--- a/executor/ssm_test.go
+++ b/executor/ssm_test.go
@@ -276,10 +276,15 @@ func TestSSMExecutor_Execute_CommandFailedStatus(t *testing.T) {
 	ex := &SSMExecutor{instanceID: "i-abc123", runner: runner}
 
 	out, err := ex.Execute(context.Background(), "cmd")
-	if err == nil || !strings.Contains(err.Error(), "Failed") {
-		t.Fatalf("expected status error, got: %v", err)
+	// "Failed" status means the command ran but exited non-zero — this is
+	// treated as a normal tool result (no error), with an exit code appended.
+	if err != nil {
+		t.Fatalf("expected no error for Failed status, got: %v", err)
 	}
 	if !strings.Contains(string(out), "partial output") {
 		t.Fatalf("expected partial output, got: %q", string(out))
+	}
+	if !strings.Contains(string(out), "[exit code") {
+		t.Fatalf("expected exit code annotation, got: %q", string(out))
 	}
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -75,10 +75,23 @@ type CustomLogger struct {
 	ConsoleWriter io.Writer
 	OutputWriter  io.Writer
 	Verbose       bool
+	Prefix        string // Optional prefix prepended to all log messages (e.g., "[bg-1] ")
+}
+
+// WithPrefix returns a shallow copy of the logger with the given prefix.
+// The prefix is prepended to every log line, making it easy to distinguish
+// output from different child agents or background tasks.
+func (l *CustomLogger) WithPrefix(prefix string) *CustomLogger {
+	cp := *l
+	cp.Prefix = prefix
+	return &cp
 }
 
 func (l *CustomLogger) formatMessage(level LogLevel, message string, args ...interface{}) string {
 	formattedMsg := fmt.Sprintf(message, args...)
+	if l.Prefix != "" {
+		formattedMsg = l.Prefix + formattedMsg
+	}
 
 	if l.OutputType != ColorOutput {
 		return formattedMsg

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -278,3 +278,19 @@ func TestOutputWriterDefaultsToStdout(t *testing.T) {
 		t.Fatalf("expected outputWriter to default to stdout")
 	}
 }
+
+func TestWithPrefix(t *testing.T) {
+	t.Parallel()
+	orig := &CustomLogger{Prefix: "orig: "}
+	prefixed := orig.WithPrefix("new: ")
+
+	if prefixed.Prefix != "new: " {
+		t.Fatalf("expected prefix %q, got %q", "new: ", prefixed.Prefix)
+	}
+	if orig.Prefix != "orig: " {
+		t.Fatalf("original prefix mutated: got %q", orig.Prefix)
+	}
+	if prefixed == orig {
+		t.Fatalf("WithPrefix should return a new logger, not the same pointer")
+	}
+}

--- a/tools/task.go
+++ b/tools/task.go
@@ -75,6 +75,10 @@ func (r *BackgroundTaskRegistry) SpawnTask(ctx context.Context, cfg TaskConfig, 
 
 		depth := TaskDepth(ctx)
 		childCtx := WithTaskDepth(ctx, depth+1)
+		// Give child agents a prefixed logger so their output is distinguishable.
+		parentLogger := logging.FromContext(ctx)
+		childLogger := parentLogger.WithPrefix(fmt.Sprintf("[%s] ", id))
+		childCtx = logging.WithLogger(childCtx, childLogger)
 		logging.InfoContext(ctx, "Task tool: spawning background child agent=%s id=%s depth=%d", args.Agent, id, depth+1)
 
 		response, childMetrics, err := cfg.CallModel(childCtx, cfg.AgentsDir, args.Agent, args.Prompt, workDir, args.Mode)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -181,30 +181,29 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 			m.IncrementIterations()
 		}
 
-		choice := response.Choices[0]
-		if gi := choice.GenerationInfo; gi != nil {
-			logging.DebugContext(ctx, "generation info: %v", gi)
-			if m != nil {
-				extractTokenUsage(gi, m)
-			}
+		mergedContent, mergedToolCalls := mergeChoices(ctx, response.Choices, m)
+		if mergedContent != "" {
+			lastContent = mergedContent
 		}
-		if choice.Content != "" {
-			lastContent = choice.Content
-		}
-		if len(choice.ToolCalls) == 0 {
+		if len(mergedToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
-			return choice.Content, messages, nil, true
+			return mergedContent, messages, nil, true
 		}
-		logging.DebugContext(ctx, "model responded in %s with %d tool call(s)", iterDuration.Round(time.Millisecond), len(choice.ToolCalls))
+		// Log the model's reasoning/text before tool calls so operators can
+		// follow the agent's chain of thought.
+		if mergedContent != "" {
+			logging.InfoContext(ctx, "model: %s", TruncateString(strings.ReplaceAll(mergedContent, "\n", " "), 200))
+		}
+		logging.InfoContext(ctx, "model making %d tool call(s) in %s", len(mergedToolCalls), iterDuration.Round(time.Millisecond))
 
-		repeat.Update(choice.ToolCalls)
+		repeat.Update(mergedToolCalls)
 		if repeat.Exceeded() {
 			logging.InfoContext(ctx, "model called %s %d times in a row, breaking tool loop", repeat.LastName, repeat.Count)
 			break
 		}
 
-		messages = appendToolCallMessage(messages, choice.ToolCalls, ctx)
-		messages = executeToolCalls(ctx, messages, choice.ToolCalls, handlers)
+		messages = appendToolCallMessage(messages, mergedContent, mergedToolCalls, ctx)
+		messages = executeToolCalls(ctx, messages, mergedToolCalls, handlers)
 
 		if m != nil && m.BudgetExceeded() {
 			logging.InfoContext(ctx, "budget exceeded ($%.4f >= $%.4f max), stopping tool loop", m.TotalCostWithChildren(), m.MaxCost)
@@ -229,6 +228,27 @@ func extractTokenUsage(gi map[string]any, m *metrics.Metrics) {
 	if input > 0 || output > 0 {
 		m.AddTokens(input, output)
 	}
+}
+
+// mergeChoices collects text and tool calls across all response choices.
+// Anthropic returns separate content blocks (text, tool_use) as separate
+// Choices; we must collect tool calls across all of them.
+func mergeChoices(ctx context.Context, choices []*llms.ContentChoice, m *metrics.Metrics) (string, []llms.ToolCall) {
+	var content string
+	var toolCalls []llms.ToolCall
+	for _, ch := range choices {
+		if gi := ch.GenerationInfo; gi != nil {
+			logging.DebugContext(ctx, "generation info: %v", gi)
+			if m != nil {
+				extractTokenUsage(gi, m)
+			}
+		}
+		if ch.Content != "" {
+			content = ch.Content
+		}
+		toolCalls = append(toolCalls, ch.ToolCalls...)
+	}
+	return content, toolCalls
 }
 
 func extractTokenValue(gi map[string]any, keys []string) int64 {
@@ -306,14 +326,19 @@ func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent
 	return messages
 }
 
-func appendToolCallMessage(messages []llms.MessageContent, toolCalls []llms.ToolCall, ctx context.Context) []llms.MessageContent {
+func appendToolCallMessage(messages []llms.MessageContent, textContent string, toolCalls []llms.ToolCall, ctx context.Context) []llms.MessageContent {
 	toolNames := make([]string, 0, len(toolCalls))
-	toolCallParts := make([]llms.ContentPart, 0, len(toolCalls))
+	// Anthropic requires the assistant message to contain both the text
+	// block and all tool_use blocks together.  Include text first if present.
+	var parts []llms.ContentPart
+	if textContent != "" {
+		parts = append(parts, llms.TextContent{Text: textContent})
+	}
 	for _, toolCall := range toolCalls {
 		if toolCall.FunctionCall != nil && toolCall.FunctionCall.Name != "" {
 			toolNames = append(toolNames, toolCall.FunctionCall.Name)
 		}
-		toolCallParts = append(toolCallParts, llms.ToolCall{
+		parts = append(parts, llms.ToolCall{
 			ID:           toolCall.ID,
 			Type:         toolCall.Type,
 			FunctionCall: toolCall.FunctionCall,
@@ -324,19 +349,22 @@ func appendToolCallMessage(messages []llms.MessageContent, toolCalls []llms.Tool
 	}
 	return append(messages, llms.MessageContent{
 		Role:  llms.ChatMessageTypeAI,
-		Parts: toolCallParts,
+		Parts: parts,
 	})
 }
 
 func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]Handler) []llms.MessageContent {
+	// Batch all tool results into a single message.  Anthropic requires every
+	// tool_result to be in the same user message that follows the assistant
+	// message containing the corresponding tool_use blocks.
+	parts := make([]llms.ContentPart, 0, len(toolCalls))
 	for _, toolCall := range toolCalls {
-		toolResponse := executeToolCall(ctx, toolCall, handlers)
-		messages = append(messages, llms.MessageContent{
-			Role:  llms.ChatMessageTypeTool,
-			Parts: []llms.ContentPart{toolResponse},
-		})
+		parts = append(parts, executeToolCall(ctx, toolCall, handlers))
 	}
-	return messages
+	return append(messages, llms.MessageContent{
+		Role:  llms.ChatMessageTypeTool,
+		Parts: parts,
+	})
 }
 
 func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[string]Handler) llms.ToolCallResponse {
@@ -356,7 +384,9 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 	}
 
 	toolResponse.Name = toolCall.FunctionCall.Name
-	logging.DebugContext(ctx, "tool %s args: %s", toolCall.FunctionCall.Name, TruncateString(toolCall.FunctionCall.Arguments, 200))
+	argsSummary := toolArgsSummary(toolCall.FunctionCall.Name, toolCall.FunctionCall.Arguments)
+	logging.InfoContext(ctx, "  → %s %s", toolCall.FunctionCall.Name, argsSummary)
+	logging.DebugContext(ctx, "tool %s full args: %s", toolCall.FunctionCall.Name, TruncateString(toolCall.FunctionCall.Arguments, 500))
 	toolStart := time.Now()
 	output, err := handler.Call(ctx, []byte(toolCall.FunctionCall.Arguments))
 	toolDuration := time.Since(toolStart)
@@ -367,12 +397,69 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 		} else {
 			toolResponse.Content = fmt.Sprintf("error: %v", err)
 		}
-		logging.DebugContext(ctx, "tool %s failed in %s: %v", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), err)
+		logging.InfoContext(ctx, "  ✗ %s failed in %s: %s", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), TruncateString(err.Error(), 200))
 	} else {
 		toolResponse.Content = output
-		logging.DebugContext(ctx, "tool %s completed in %s (output-bytes=%d)", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), len(output))
+		logging.InfoContext(ctx, "  ✓ %s done in %s (%d bytes)", toolCall.FunctionCall.Name, toolDuration.Round(time.Millisecond), len(output))
 	}
 	return toolResponse
+}
+
+// toolArgsSummary extracts a short, human-readable summary from tool call arguments.
+// For Bash it shows the command, for Read/Write/Edit the path, for Grep the pattern, etc.
+// argString extracts the first matching string value from a parsed JSON args map.
+func argString(args map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := args[k]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// simpleArgKeys maps tool names to the single arg key that summarizes them.
+var simpleArgKeys = map[string]string{
+	"Read":  "path",
+	"Write": "path",
+	"Edit":  "path",
+	"Glob":  "pattern",
+}
+
+func toolArgsSummary(toolName, argsJSON string) string {
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return ""
+	}
+	if key, ok := simpleArgKeys[toolName]; ok {
+		return argString(args, key)
+	}
+	return toolArgsSummaryComplex(toolName, args)
+}
+
+func toolArgsSummaryComplex(toolName string, args map[string]interface{}) string {
+	switch toolName {
+	case "Bash":
+		if cmd := argString(args, "command"); cmd != "" {
+			return TruncateString(cmd, 120)
+		}
+	case "Grep":
+		p := argString(args, "pattern")
+		if path := argString(args, "path"); path != "" {
+			return p + " in " + path
+		}
+		return p
+	case "Task":
+		agent := argString(args, "agent")
+		prompt := TruncateString(argString(args, "prompt"), 80)
+		if agent != "" {
+			return fmt.Sprintf("agent=%s prompt=%q", agent, prompt)
+		}
+	case "TaskResult":
+		return "id=" + argString(args, "id")
+	}
+	return ""
 }
 
 func BuildHandlers(workingDir string, taskCfg *TaskConfig, ex executor.Executor) (map[string]Handler, []llms.Tool) {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1607,3 +1607,37 @@ func TestExecuteToolCallWithOutputAndError(t *testing.T) {
 		t.Fatalf("expected error in response, got: %s", resp.Content)
 	}
 }
+
+func TestToolArgsSummary(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		toolName string
+		argsJSON string
+		want     string
+	}{
+		{"invalid json", "Bash", "{bad", ""},
+		{"Read path", "Read", `{"path":"/tmp/foo"}`, "/tmp/foo"},
+		{"Write path", "Write", `{"path":"/tmp/bar"}`, "/tmp/bar"},
+		{"Edit path", "Edit", `{"path":"/tmp/baz"}`, "/tmp/baz"},
+		{"Glob pattern", "Glob", `{"pattern":"*.go"}`, "*.go"},
+		{"Bash command", "Bash", `{"command":"echo hello"}`, "echo hello"},
+		{"Bash empty command", "Bash", `{"command":""}`, ""},
+		{"Grep pattern only", "Grep", `{"pattern":"foo"}`, "foo"},
+		{"Grep pattern with path", "Grep", `{"pattern":"foo","path":"/src"}`, "foo in /src"},
+		{"Task with agent", "Task", `{"agent":"review","prompt":"check code quality and style"}`, `agent=review prompt="check code quality and style"`},
+		{"Task without agent", "Task", `{"prompt":"do stuff"}`, ""},
+		{"TaskResult", "TaskResult", `{"id":"abc-123"}`, "id=abc-123"},
+		{"unknown tool", "Unknown", `{"x":"y"}`, ""},
+		{"non-string value", "Read", `{"path":123}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := toolArgsSummary(tt.toolName, tt.argsJSON)
+			if got != tt.want {
+				t.Errorf("toolArgsSummary(%q, %q) = %q, want %q", tt.toolName, tt.argsJSON, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**Key Changes:**

- Enhanced tool loop to batch tool calls and responses for Anthropic compatibility
- Improved logging with prefixed loggers for background/child agents and detailed tool call summaries
- Fixed SSM executor command argument encoding to handle multiline commands and exit codes robustly
- Added template variable resolution for environment options in agent manifests

**Added:**

- Environment template resolution - Implemented `resolveEnvironmentTemplates` to process template variables in agent environment options (`agent/bundle.go`)
- Logger prefix support - Added `WithPrefix` method to `CustomLogger` for distinguishing output from different agents (`logging/logging.go`)
- Tool call argument summarization - Introduced `toolArgsSummary` and helpers to generate concise summaries for tool calls in logs (`tools/tools.go`)

**Changed:**

- Tool loop orchestration - Refactored `toolLoop` to merge model choices, batch tool calls and responses, and ensure Anthropic-compliant message grouping; improved operator visibility of agent reasoning and actions (`tools/tools.go`)
- Tool call logging - Updated tool execution logging to include human-readable argument summaries and clearer status indicators (`tools/tools.go`)
- Background task logging - Modified background task spawning to assign a prefixed logger to child agents, making their logs easily distinguishable (`tools/task.go`)
- SSM executor command handling - Changed parameter encoding to use proper JSON, correctly handling multiline commands; improved error handling and output formatting for SSM execution results (`executor/ssm.go`)

**Removed:**

- Redundant Go-escaped parameter formatting for SSM command execution, eliminating issues with literal backslash-n in multiline commands (`executor/ssm.go`)