### PR TITLE
feat: add cost estimation and usage history for agent runs

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -26,6 +26,29 @@ type Manifest struct {
 	Environment *executor.Config `yaml:"environment,omitempty"`
 	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	Output      *OutputConfig    `yaml:"output,omitempty"`
+	Budget      *BudgetConfig    `yaml:"budget,omitempty"`
+}
+
+// BudgetConfig provides static hints for cost estimation.
+// These are used by --dry-run to estimate costs before running.
+type BudgetConfig struct {
+	// MaxTokens is the recommended output-token budget for this agent.
+	// If zero, inferred from whether the agent dispatches child agents.
+	MaxTokens int `yaml:"max_tokens,omitempty"`
+
+	// EstimatedIterations is the expected number of model iterations.
+	EstimatedIterations int `yaml:"estimated_iterations,omitempty"`
+
+	// Children lists agent names this orchestrator dispatches via the Task tool.
+	Children []string `yaml:"children,omitempty"`
+
+	// ScaleFactor describes what makes this agent's cost scale.
+	// Currently supported: "files" (cost scales with source file count).
+	ScaleFactor string `yaml:"scale_factor,omitempty"`
+
+	// FilesPerIteration is how many files the agent typically processes
+	// per model iteration, used when ScaleFactor is "files".
+	FilesPerIteration int `yaml:"files_per_iteration,omitempty"`
 }
 
 // OutputConfig specifies the structured output contract for an agent.
@@ -159,8 +182,8 @@ func loadTask(agentPath, taskFile string) (string, error) {
 	return strings.TrimSpace(string(taskData)), nil
 }
 
-// loadManifest reads and parses the agent manifest.
-func loadManifest(agentPath string) (*Manifest, error) {
+// LoadManifest reads and parses the agent manifest from the given agent directory.
+func LoadManifest(agentPath string) (*Manifest, error) {
 	manifestPath := filepath.Join(agentPath, "agent.yaml")
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -231,7 +254,7 @@ func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, data
 func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map[string]string) (*Bundle, error) {
 	agentPath := filepath.Join(agentsDir, agentName)
 
-	manifest, err := loadManifest(agentPath)
+	manifest, err := LoadManifest(agentPath)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -460,10 +460,10 @@ depends_on:
 		t.Fatalf("BuildBundle: %v", err)
 	}
 
-	// Verify manifest parsing via loadManifest.
-	m, err := loadManifest(filepath.Join(dir, "demo"))
+	// Verify manifest parsing via LoadManifest.
+	m, err := LoadManifest(filepath.Join(dir, "demo"))
 	if err != nil {
-		t.Fatalf("loadManifest: %v", err)
+		t.Fatalf("LoadManifest: %v", err)
 	}
 	if len(m.DependsOn) != 2 || m.DependsOn[0] != "go-cobra" || m.DependsOn[1] != "go-review" {
 		t.Fatalf("depends_on = %v, want [go-cobra go-review]", m.DependsOn)

--- a/config/xdg.go
+++ b/config/xdg.go
@@ -113,6 +113,16 @@ func CacheFile(filename string) (string, error) {
 	return cachePath, nil
 }
 
+// CacheDir returns the squad cache directory (e.g., ~/.cache/squad).
+// Returns empty string if the cache home cannot be determined.
+func CacheDir() string {
+	cacheHome := getCacheHome()
+	if cacheHome == "" {
+		return ""
+	}
+	return filepath.Join(cacheHome, "squad")
+}
+
 // AgentsCacheDir returns the directory for caching cloned agent repositories.
 func AgentsCacheDir() (string, error) {
 	cacheHome := getCacheHome()

--- a/executor/docker_test.go
+++ b/executor/docker_test.go
@@ -450,8 +450,12 @@ func TestDockerExecutor_ExecuteWithConn(t *testing.T) {
 	// to exercise the defer Close() path.
 	pr, pw := io.Pipe()
 	go func() {
-		_, _ = pw.Write([]byte("connected output"))
-		pw.Close()
+		if _, err := pw.Write([]byte("connected output")); err != nil {
+			return
+		}
+		if err := pw.Close(); err != nil {
+			return
+		}
 	}()
 
 	client := &fakeDockerClient{

--- a/metrics/estimate.go
+++ b/metrics/estimate.go
@@ -1,0 +1,144 @@
+package metrics
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cowdogmoo/squad/agent"
+)
+
+// EstimateNode represents one agent in a cost estimate tree.
+type EstimateNode struct {
+	Agent               string
+	EstimatedIters      int
+	InputTokensPerIter  int64
+	OutputTokensPerIter int64
+	InputCost           float64
+	OutputCost          float64
+	TotalCost           float64
+	Children            []*EstimateNode
+}
+
+// TotalTreeCost returns the sum of this node's cost and all descendant costs.
+func (n *EstimateNode) TotalTreeCost() float64 {
+	total := n.TotalCost
+	for _, c := range n.Children {
+		total += c.TotalTreeCost()
+	}
+	return total
+}
+
+// defaultIterations is the fallback when an agent has no budget hints.
+const defaultIterations = 25
+
+// defaultInputPerIter is a rough average of input tokens per iteration.
+// This accounts for system prompt re-sends and tool results.
+const defaultInputPerIter int64 = 6000
+
+// defaultOutputPerIter is a rough average of output tokens per iteration.
+const defaultOutputPerIter int64 = 1500
+
+// orchestratorOutputPerIter is higher because Task tool prompts are large.
+const orchestratorOutputPerIter int64 = 3000
+
+// EstimateCost walks the agent graph starting from rootAgent and returns
+// a cost estimate tree for the given provider and model.
+func EstimateCost(agentsDir, rootAgent, provider, model string) (*EstimateNode, error) {
+	return estimateAgent(agentsDir, rootAgent, provider, model, 0)
+}
+
+func estimateAgent(agentsDir, agentName, provider, model string, depth int) (*EstimateNode, error) {
+	if depth > 5 {
+		return nil, fmt.Errorf("agent graph too deep (>5), possible cycle at %s", agentName)
+	}
+
+	agentPath := filepath.Join(agentsDir, agentName)
+	manifest, err := agent.LoadManifest(agentPath)
+	if err != nil {
+		// If we can't load the manifest, return a default estimate
+		return defaultEstimate(agentName, provider, model, false), nil
+	}
+
+	budget := manifest.Budget
+	iters := defaultIterations
+	isOrchestrator := false
+	var childNames []string
+
+	if budget != nil {
+		if budget.EstimatedIterations > 0 {
+			iters = budget.EstimatedIterations
+		}
+		childNames = budget.Children
+		isOrchestrator = len(childNames) > 0
+	}
+
+	node := buildEstimateNode(agentName, provider, model, iters, isOrchestrator)
+
+	// Recurse into children
+	for _, childName := range childNames {
+		childNode, err := estimateAgent(agentsDir, childName, provider, model, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		node.Children = append(node.Children, childNode)
+	}
+
+	return node, nil
+}
+
+func buildEstimateNode(agentName, provider, model string, iters int, isOrchestrator bool) *EstimateNode {
+	pricing := GetPricing(provider, model)
+
+	inputPerIter := defaultInputPerIter
+	outputPerIter := defaultOutputPerIter
+	if isOrchestrator {
+		outputPerIter = orchestratorOutputPerIter
+	}
+
+	totalInput := int64(iters) * inputPerIter
+	totalOutput := int64(iters) * outputPerIter
+	inputCost := float64(totalInput) / 1_000_000 * pricing.InputPerMillion
+	outputCost := float64(totalOutput) / 1_000_000 * pricing.OutputPerMillion
+
+	return &EstimateNode{
+		Agent:               agentName,
+		EstimatedIters:      iters,
+		InputTokensPerIter:  inputPerIter,
+		OutputTokensPerIter: outputPerIter,
+		InputCost:           inputCost,
+		OutputCost:          outputCost,
+		TotalCost:           inputCost + outputCost,
+	}
+}
+
+func defaultEstimate(agentName, provider, model string, isOrchestrator bool) *EstimateNode {
+	return buildEstimateNode(agentName, provider, model, defaultIterations, isOrchestrator)
+}
+
+// FormatEstimate renders a cost estimate tree as a human-readable string.
+func FormatEstimate(root *EstimateNode, provider, model string) string {
+	var sb strings.Builder
+	pricing := GetPricing(provider, model)
+
+	fmt.Fprintf(&sb, "Cost Estimate (%s / %s)\n", provider, model)
+	fmt.Fprintf(&sb, "Pricing: $%.2f / 1M input, $%.2f / 1M output\n", pricing.InputPerMillion, pricing.OutputPerMillion)
+	sb.WriteString("──────────────────────────────────────────\n")
+
+	formatNode(&sb, root, 0)
+
+	sb.WriteString("──────────────────────────────────────────\n")
+	total := root.TotalTreeCost()
+	fmt.Fprintf(&sb, "Estimated total: $%.2f – $%.2f\n", total*0.6, total*1.5)
+	fmt.Fprintf(&sb, "  (range accounts for codebase size variance)\n")
+
+	return sb.String()
+}
+
+func formatNode(sb *strings.Builder, node *EstimateNode, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	fmt.Fprintf(sb, "%s%-20s ~%d iters  $%.4f\n", prefix, node.Agent, node.EstimatedIters, node.TotalCost)
+	for _, child := range node.Children {
+		formatNode(sb, child, indent+1)
+	}
+}

--- a/metrics/estimate_test.go
+++ b/metrics/estimate_test.go
@@ -1,0 +1,204 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeAgentManifest(t *testing.T, agentsDir, agentName, content string) {
+	t.Helper()
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Write minimal required files
+	for _, f := range []string{"system.md", "agent.md"} {
+		if err := os.WriteFile(filepath.Join(agentDir, f), []byte("placeholder"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+}
+
+func TestEstimateCostLeafAgent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeAgentManifest(t, dir, "go-review", `
+name: go-review
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+budget:
+  estimated_iterations: 30
+`)
+
+	node, err := EstimateCost(dir, "go-review", "anthropic", "claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("EstimateCost: %v", err)
+	}
+	if node.Agent != "go-review" {
+		t.Fatalf("Agent = %s, want go-review", node.Agent)
+	}
+	if node.EstimatedIters != 30 {
+		t.Fatalf("EstimatedIters = %d, want 30", node.EstimatedIters)
+	}
+	if len(node.Children) != 0 {
+		t.Fatalf("Children = %d, want 0", len(node.Children))
+	}
+}
+
+func TestEstimateCostOrchestrator(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	writeAgentManifest(t, dir, "go-pipeline", `
+name: go-pipeline
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+budget:
+  estimated_iterations: 10
+  children:
+    - go-review
+    - go-tests
+`)
+	writeAgentManifest(t, dir, "go-review", `
+name: go-review
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+budget:
+  estimated_iterations: 30
+`)
+	writeAgentManifest(t, dir, "go-tests", `
+name: go-tests
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+budget:
+  estimated_iterations: 40
+`)
+
+	root, err := EstimateCost(dir, "go-pipeline", "anthropic", "claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("EstimateCost: %v", err)
+	}
+	if root.Agent != "go-pipeline" {
+		t.Fatalf("Agent = %s, want go-pipeline", root.Agent)
+	}
+	if len(root.Children) != 2 {
+		t.Fatalf("Children = %d, want 2", len(root.Children))
+	}
+	if root.Children[0].Agent != "go-review" {
+		t.Fatalf("Children[0] = %s, want go-review", root.Children[0].Agent)
+	}
+	if root.Children[1].Agent != "go-tests" {
+		t.Fatalf("Children[1] = %s, want go-tests", root.Children[1].Agent)
+	}
+
+	// Total tree cost should be > root cost alone
+	if root.TotalTreeCost() <= root.TotalCost {
+		t.Fatalf("TotalTreeCost (%f) should exceed root cost (%f)", root.TotalTreeCost(), root.TotalCost)
+	}
+}
+
+func TestEstimateCostMissingChild(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	writeAgentManifest(t, dir, "orchestrator", `
+name: orchestrator
+version: "1.0"
+entrypoint: system.md
+wrapper: agent.md
+budget:
+  estimated_iterations: 10
+  children:
+    - missing-agent
+`)
+
+	root, err := EstimateCost(dir, "orchestrator", "openai", "gpt-4o")
+	if err != nil {
+		t.Fatalf("EstimateCost: %v", err)
+	}
+	// Should still have a child with default estimates
+	if len(root.Children) != 1 {
+		t.Fatalf("Children = %d, want 1", len(root.Children))
+	}
+	if root.Children[0].Agent != "missing-agent" {
+		t.Fatalf("Children[0] = %s, want missing-agent", root.Children[0].Agent)
+	}
+}
+
+func TestEstimateCostDepthLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create a chain of 7 agents, each referencing the next
+	for i := 0; i < 7; i++ {
+		name := agentNameForDepth(i)
+		child := ""
+		if i < 6 {
+			child = "    - " + agentNameForDepth(i+1)
+		}
+		manifest := "name: " + name + "\nversion: '1.0'\nentrypoint: system.md\nwrapper: agent.md\n"
+		if child != "" {
+			manifest += "budget:\n  children:\n" + child + "\n"
+		}
+		writeAgentManifest(t, dir, name, manifest)
+	}
+
+	_, err := EstimateCost(dir, "agent-0", "openai", "gpt-4o")
+	if err == nil || !strings.Contains(err.Error(), "too deep") {
+		t.Fatalf("expected depth error, got: %v", err)
+	}
+}
+
+func agentNameForDepth(i int) string {
+	return "agent-" + string(rune('0'+i))
+}
+
+func TestFormatEstimate(t *testing.T) {
+	t.Parallel()
+	node := &EstimateNode{
+		Agent:          "go-pipeline",
+		EstimatedIters: 10,
+		TotalCost:      0.50,
+		Children: []*EstimateNode{
+			{Agent: "go-review", EstimatedIters: 30, TotalCost: 5.00},
+		},
+	}
+
+	output := FormatEstimate(node, "anthropic", "claude-opus-4-6")
+	if !strings.Contains(output, "go-pipeline") {
+		t.Fatalf("output missing go-pipeline: %s", output)
+	}
+	if !strings.Contains(output, "go-review") {
+		t.Fatalf("output missing go-review: %s", output)
+	}
+	if !strings.Contains(output, "Estimated total") {
+		t.Fatalf("output missing total: %s", output)
+	}
+}
+
+func TestTotalTreeCost(t *testing.T) {
+	t.Parallel()
+	root := &EstimateNode{
+		TotalCost: 1.0,
+		Children: []*EstimateNode{
+			{TotalCost: 2.0, Children: []*EstimateNode{
+				{TotalCost: 3.0},
+			}},
+			{TotalCost: 4.0},
+		},
+	}
+	got := root.TotalTreeCost()
+	want := 10.0
+	if got != want {
+		t.Fatalf("TotalTreeCost() = %f, want %f", got, want)
+	}
+}

--- a/metrics/history.go
+++ b/metrics/history.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cowdogmoo/squad/logging"
+)
+
+// HistorySample records the token usage from a single agent run.
+type HistorySample struct {
+	Agent        string    `json:"agent"`
+	Model        string    `json:"model"`
+	Provider     string    `json:"provider"`
+	InputTokens  int64     `json:"input_tokens"`
+	OutputTokens int64     `json:"output_tokens"`
+	Iterations   int       `json:"iterations"`
+	Cost         float64   `json:"cost"`
+	DurationSecs float64   `json:"duration_secs"`
+	Timestamp    time.Time `json:"timestamp"`
+}
+
+// HistoryFile holds the list of samples for an agent.
+type HistoryFile struct {
+	Samples []HistorySample `json:"samples"`
+}
+
+// maxSamplesPerAgent limits history file size.
+const maxSamplesPerAgent = 50
+
+// LogRunHistory persists token usage from a completed agent run to the
+// cost history cache.  Errors are logged but not returned — this is
+// best-effort telemetry, not a critical path.
+func LogRunHistory(cacheDir, agentName string, m *Metrics) {
+	if m == nil || agentName == "" {
+		return
+	}
+
+	histDir := filepath.Join(cacheDir, "cost-history")
+	if err := os.MkdirAll(histDir, 0o755); err != nil {
+		logging.Warn("cost-history: mkdir failed: %v", err)
+		return
+	}
+
+	histPath := filepath.Join(histDir, agentName+".json")
+
+	var hf HistoryFile
+	if data, err := os.ReadFile(histPath); err == nil {
+		_ = json.Unmarshal(data, &hf) // ignore parse errors on corrupt file
+	}
+
+	sample := HistorySample{
+		Agent:        agentName,
+		Model:        m.Model,
+		Provider:     m.Provider,
+		InputTokens:  m.InputTokens(),
+		OutputTokens: m.OutputTokens(),
+		Iterations:   m.Iterations(),
+		Cost:         m.TotalCostWithChildren(),
+		DurationSecs: m.Duration().Seconds(),
+		Timestamp:    time.Now().UTC(),
+	}
+
+	hf.Samples = append(hf.Samples, sample)
+
+	// Keep only the most recent samples
+	if len(hf.Samples) > maxSamplesPerAgent {
+		hf.Samples = hf.Samples[len(hf.Samples)-maxSamplesPerAgent:]
+	}
+
+	data, err := json.MarshalIndent(hf, "", "  ")
+	if err != nil {
+		logging.Warn("cost-history: marshal failed: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(histPath, data, 0o644); err != nil {
+		logging.Warn("cost-history: write failed: %v", err)
+	}
+}
+
+// LoadHistory reads the cost history for an agent from the cache directory.
+func LoadHistory(cacheDir, agentName string) ([]HistorySample, error) {
+	histPath := filepath.Join(cacheDir, "cost-history", agentName+".json")
+	data, err := os.ReadFile(histPath)
+	if err != nil {
+		return nil, fmt.Errorf("no history for %s: %w", agentName, err)
+	}
+
+	var hf HistoryFile
+	if err := json.Unmarshal(data, &hf); err != nil {
+		return nil, fmt.Errorf("corrupt history for %s: %w", agentName, err)
+	}
+
+	return hf.Samples, nil
+}

--- a/metrics/history_test.go
+++ b/metrics/history_test.go
@@ -1,0 +1,116 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLogAndLoadHistory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	m := New("anthropic", "claude-opus-4-6")
+	m.AddTokens(100000, 25000)
+	m.IncrementIterations()
+	m.IncrementIterations()
+	m.Finish()
+
+	LogRunHistory(dir, "go-review", m)
+
+	samples, err := LoadHistory(dir, "go-review")
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("samples = %d, want 1", len(samples))
+	}
+
+	s := samples[0]
+	if s.Agent != "go-review" {
+		t.Fatalf("Agent = %s, want go-review", s.Agent)
+	}
+	if s.InputTokens != 100000 {
+		t.Fatalf("InputTokens = %d, want 100000", s.InputTokens)
+	}
+	if s.OutputTokens != 25000 {
+		t.Fatalf("OutputTokens = %d, want 25000", s.OutputTokens)
+	}
+	if s.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2", s.Iterations)
+	}
+	if s.Model != "claude-opus-4-6" {
+		t.Fatalf("Model = %s, want claude-opus-4-6", s.Model)
+	}
+}
+
+func TestLogHistoryAppends(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	for i := 0; i < 3; i++ {
+		m := New("openai", "gpt-4o")
+		m.AddTokens(int64(i*1000), int64(i*500))
+		m.Finish()
+		LogRunHistory(dir, "test-agent", m)
+	}
+
+	samples, err := LoadHistory(dir, "test-agent")
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(samples) != 3 {
+		t.Fatalf("samples = %d, want 3", len(samples))
+	}
+}
+
+func TestLogHistoryMaxSamples(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	for i := 0; i < maxSamplesPerAgent+10; i++ {
+		m := New("openai", "gpt-4o")
+		m.AddTokens(int64(i), 0)
+		m.Finish()
+		LogRunHistory(dir, "overflow-agent", m)
+	}
+
+	samples, err := LoadHistory(dir, "overflow-agent")
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(samples) != maxSamplesPerAgent {
+		t.Fatalf("samples = %d, want %d", len(samples), maxSamplesPerAgent)
+	}
+	// Should have kept the most recent samples
+	if samples[0].InputTokens != 10 {
+		t.Fatalf("oldest kept sample InputTokens = %d, want 10", samples[0].InputTokens)
+	}
+}
+
+func TestLoadHistoryMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	_, err := LoadHistory(dir, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing history")
+	}
+}
+
+func TestLogHistoryNilMetrics(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Should not panic or create files
+	LogRunHistory(dir, "test", nil)
+	LogRunHistory(dir, "", New("openai", "gpt-4o"))
+
+	_, err := os.ReadDir(filepath.Join(dir, "cost-history"))
+	if err == nil {
+		entries, _ := os.ReadDir(filepath.Join(dir, "cost-history"))
+		if len(entries) > 0 {
+			t.Fatal("expected no history files for nil/empty inputs")
+		}
+	}
+}

--- a/runner/model.go
+++ b/runner/model.go
@@ -99,6 +99,34 @@ func callResponsesAPI(ctx context.Context, opts *RunOptions, model, systemPrompt
 	return response, m, nil
 }
 
+// DefaultMaxTokensWithTask is the output-token floor for agents that have
+// access to the Task tool.  Task prompts embed file lists, prior-agent
+// context, and hard constraints, easily requiring 4K+ tokens in a single
+// tool-call argument.  langchaingo's default of 2048 silently truncates
+// these arguments, causing the child dispatch to fail with "prompt is
+// required".
+const DefaultMaxTokensWithTask = 16384
+
+// DefaultMaxTokensLeaf is the output-token floor for leaf agents (no Task
+// tool).  Leaf agents mostly emit Edit/Write/Bash tool calls whose
+// arguments are modest, but 4096 gives comfortable headroom for long
+// file-write operations.
+const DefaultMaxTokensLeaf = 4096
+
+// inferMaxTokens applies a sensible output-token floor when the caller did
+// not explicitly set --max-tokens.  Orchestrator agents (with Task tool)
+// need a much larger budget than leaf agents because the Task tool's prompt
+// argument can be thousands of tokens.
+func inferMaxTokens(maxTokens int, hasTaskTool bool) int {
+	if maxTokens > 0 {
+		return maxTokens // explicit user override — respect it
+	}
+	if hasTaskTool {
+		return DefaultMaxTokensWithTask
+	}
+	return DefaultMaxTokensLeaf
+}
+
 // callLangChainLLM runs the prompt via a LangChain-compatible LLM.
 func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, temperature float64, maxTokens int, taskCfg *tools.TaskConfig, ex executor.Executor) (string, *metrics.Metrics, error) {
 	llm, err := buildLLM(opts, provider, model)
@@ -106,6 +134,8 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 		return "", nil, err
 	}
 
+	maxTokens = inferMaxTokens(maxTokens, taskCfg != nil)
+	logging.DebugContext(ctx, "max_tokens=%d (hasTaskTool=%v)", maxTokens, taskCfg != nil)
 	callOpts := buildCallOpts(opts, provider, temperature, maxTokens)
 
 	m := metrics.New(provider, model)

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -590,6 +590,32 @@ func TestBuildCallOptsAnthropicNoMaxTokens(t *testing.T) {
 	}
 }
 
+func TestInferMaxTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		maxTokens   int
+		hasTaskTool bool
+		want        int
+	}{
+		{"explicit override with task tool", 8192, true, 8192},
+		{"explicit override without task tool", 2048, false, 2048},
+		{"no override with task tool", 0, true, DefaultMaxTokensWithTask},
+		{"no override without task tool", 0, false, DefaultMaxTokensLeaf},
+		{"negative with task tool", -1, true, DefaultMaxTokensWithTask},
+		{"negative without task tool", -1, false, DefaultMaxTokensLeaf},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := inferMaxTokens(tt.maxTokens, tt.hasTaskTool)
+			if got != tt.want {
+				t.Fatalf("inferMaxTokens(%d, %v) = %d, want %d", tt.maxTokens, tt.hasTaskTool, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildTaskConfigBudgetExhausted(t *testing.T) {
 	t.Parallel()
 	agentsDir := t.TempDir()

--- a/runner/run.go
+++ b/runner/run.go
@@ -81,6 +81,7 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	cmd.SetContext(ctx)
 	tools.ResetEditsApplied(ctx)
 	response, m, err := InvokeModel(ctx, opts, bundle)
+	logRunHistory(opts, m)
 	if err != nil {
 		if errors.Is(err, metrics.ErrBudgetExceeded) {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Run stopped: cost budget of $%.4f exceeded (actual: $%.4f)\n", opts.MaxCost, m.TotalCostWithChildren())
@@ -153,6 +154,12 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 	}
 
 	if opts.DryRun {
+		estimate, err := metrics.EstimateCost(agentsDir, opts.Agent, opts.Provider, opts.Model)
+		if err != nil {
+			logging.Warn("cost estimation failed: %v", err)
+		} else {
+			_, _ = fmt.Fprint(cmd.ErrOrStderr(), metrics.FormatEstimate(estimate, opts.Provider, opts.Model))
+		}
 		return nil, nil
 	}
 
@@ -193,6 +200,18 @@ func writeResponse(cmd *cobra.Command, response string, opts *RunOptions) error 
 		logging.InfoContext(cmd.Context(), "response written to %s", opts.Output)
 	}
 	return nil
+}
+
+// logRunHistory persists token usage to the cost history cache.
+func logRunHistory(opts *RunOptions, m *metrics.Metrics) {
+	if m == nil || opts.Agent == "" {
+		return
+	}
+	cacheDir := config.CacheDir()
+	if cacheDir == "" {
+		return
+	}
+	metrics.LogRunHistory(cacheDir, opts.Agent, m)
 }
 
 func readPrompt(cmd *cobra.Command, args []string) (string, error) {


### PR DESCRIPTION
**Key Changes:**

- Introduced static cost estimation for agent runs, including orchestrator/child hierarchies
- Added persistent cost history logging per agent run
- Exposed cost estimation on `--dry-run` and output-token inference for Task tool usage
- Improved test coverage for cost estimation and history features

**Added:**

- Cost estimation module - New `metrics/estimate.go` provides agent cost prediction, including tree-based estimation for orchestrator/child agents, with tests in `metrics/estimate_test.go`
- Cost history logging - Implemented persistent run history in `metrics/history.go` with append/load logic and tests in `metrics/history_test.go`
- Output-token inference - Added `inferMaxTokens` logic in `runner/model.go` to automatically set higher output-token budgets for agents using the Task tool, with corresponding tests
- `CacheDir()` utility - Added to `config/xdg.go` for easier cache directory access

**Changed:**

- Agent manifest schema - Extended `Manifest` struct in `agent/bundle.go` to include a `Budget` field with static hints for cost estimation, supporting fields like `max_tokens`, `estimated_iterations`, `children`, `scale_factor`, and `files_per_iteration`
- Manifest loader - Renamed `loadManifest` to `LoadManifest` in `agent/bundle.go` for export and updated all references
- Run command flow - Updated `runner/run.go` to invoke cost estimation during `--dry-run` and to log run history after execution
- Output-token handling - Modified model invocation in `runner/model.go` to use `inferMaxTokens`, improving reliability for agents with Task tool access

**Removed:**

- Implicit/undocumented output-token defaults for Task tool and leaf agents, now replaced by explicit logic and constants