### PR TITLE
feat: add thread-safe containers and background command tools

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,6 +161,15 @@ func loadConfigWithViper(setup func(*viper.Viper) error) (*Config, *viper.Viper,
 		return nil, nil, fmt.Errorf("config unmarshal failed: %w", err)
 	}
 
+	// Resolve dynamic values (env vars, command substitution) in the token field.
+	if cfg.Provider.Token != "" {
+		resolved, err := ResolveValue(cfg.Provider.Token)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving provider.token: %w", err)
+		}
+		cfg.Provider.Token = resolved
+	}
+
 	return cfg, v, nil
 }
 

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -45,9 +45,10 @@ func resolveCommands(s string) (string, error) {
 			start := i + 2
 			j := start
 			for j < len(s) && depth > 0 {
-				if s[j] == '(' {
+				switch s[j] {
+				case '(':
 					depth++
-				} else if s[j] == ')' {
+				case ')':
 					depth--
 				}
 				if depth > 0 {

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const resolveTimeout = 10 * time.Second
+
+// ResolveValue performs variable and command substitution on a config string.
+//
+// Supported patterns:
+//   - $VAR or ${VAR} — replaced by the environment variable value
+//   - $(command args) — replaced by the stdout of the command
+//
+// Unset variables and failed commands return errors rather than empty strings,
+// so misconfigurations are caught early.
+func ResolveValue(s string) (string, error) {
+	if !strings.ContainsAny(s, "$") {
+		return s, nil
+	}
+
+	// Process command substitutions first.
+	resolved, err := resolveCommands(s)
+	if err != nil {
+		return "", err
+	}
+
+	// Then process environment variables.
+	return resolveEnvVars(resolved)
+}
+
+// resolveCommands replaces all $(command) patterns.
+func resolveCommands(s string) (string, error) {
+	var result strings.Builder
+	i := 0
+	for i < len(s) {
+		if i+1 < len(s) && s[i] == '$' && s[i+1] == '(' {
+			// Find matching close paren, tracking nesting.
+			depth := 1
+			start := i + 2
+			j := start
+			for j < len(s) && depth > 0 {
+				if s[j] == '(' {
+					depth++
+				} else if s[j] == ')' {
+					depth--
+				}
+				if depth > 0 {
+					j++
+				}
+			}
+			if depth != 0 {
+				return "", fmt.Errorf("unmatched $( in config value: %q", s)
+			}
+			cmd := s[start:j]
+			output, err := runCommand(cmd)
+			if err != nil {
+				return "", fmt.Errorf("command substitution $(%.40s) failed: %w", cmd, err)
+			}
+			result.WriteString(output)
+			i = j + 1
+		} else {
+			result.WriteByte(s[i])
+			i++
+		}
+	}
+	return result.String(), nil
+}
+
+// resolveEnvVars replaces $VAR and ${VAR} patterns.
+func resolveEnvVars(s string) (string, error) {
+	var result strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] != '$' {
+			result.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		// Skip $$ (literal dollar sign).
+		if i+1 < len(s) && s[i+1] == '$' {
+			result.WriteByte('$')
+			i += 2
+			continue
+		}
+
+		// ${VAR} form.
+		if i+1 < len(s) && s[i+1] == '{' {
+			end := strings.IndexByte(s[i+2:], '}')
+			if end < 0 {
+				return "", fmt.Errorf("unmatched ${ in config value: %q", s)
+			}
+			varName := s[i+2 : i+2+end]
+			val, ok := os.LookupEnv(varName)
+			if !ok {
+				return "", fmt.Errorf("unset environment variable ${%s} in config value", varName)
+			}
+			result.WriteString(val)
+			i = i + 2 + end + 1
+			continue
+		}
+
+		// $VAR form — collect alphanumeric + underscore.
+		j := i + 1
+		for j < len(s) && isVarChar(s[j]) {
+			j++
+		}
+		if j == i+1 {
+			// Lone $ not followed by valid var char — keep literal.
+			result.WriteByte('$')
+			i++
+			continue
+		}
+		varName := s[i+1 : j]
+		val, ok := os.LookupEnv(varName)
+		if !ok {
+			return "", fmt.Errorf("unset environment variable $%s in config value", varName)
+		}
+		result.WriteString(val)
+		i = j
+	}
+	return result.String(), nil
+}
+
+func isVarChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// runCommand executes a shell command and returns its trimmed stdout.
+func runCommand(command string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveValue_PlainString(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", got)
+	}
+}
+
+func TestResolveValue_EnvVar(t *testing.T) {
+	t.Setenv("SQUAD_TEST_RESOLVE_VAR", "secret123")
+	got, err := ResolveValue("key=$SQUAD_TEST_RESOLVE_VAR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "key=secret123" {
+		t.Fatalf("expected 'key=secret123', got %q", got)
+	}
+}
+
+func TestResolveValue_EnvVarBraces(t *testing.T) {
+	t.Setenv("SQUAD_TEST_RESOLVE_BRACE", "val")
+	got, err := ResolveValue("${SQUAD_TEST_RESOLVE_BRACE}_suffix")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "val_suffix" {
+		t.Fatalf("expected 'val_suffix', got %q", got)
+	}
+}
+
+func TestResolveValue_CommandSubstitution(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("$(echo hello)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected 'hello', got %q", got)
+	}
+}
+
+func TestResolveValue_MixedCommandAndEnv(t *testing.T) {
+	t.Setenv("SQUAD_TEST_MIXED", "world")
+	got, err := ResolveValue("$(echo hello) $SQUAD_TEST_MIXED")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", got)
+	}
+}
+
+func TestResolveValue_UnsetVar(t *testing.T) {
+	os.Unsetenv("SQUAD_TEST_UNSET_VAR_XYZ")
+	_, err := ResolveValue("$SQUAD_TEST_UNSET_VAR_XYZ")
+	if err == nil {
+		t.Fatal("expected error for unset variable")
+	}
+}
+
+func TestResolveValue_FailedCommand(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveValue("$(exit 1)")
+	if err == nil {
+		t.Fatal("expected error for failed command")
+	}
+}
+
+func TestResolveValue_UnmatchedParen(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveValue("$(echo hello")
+	if err == nil {
+		t.Fatal("expected error for unmatched $(")
+	}
+}
+
+func TestResolveValue_UnmatchedBrace(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveValue("${UNCLOSED")
+	if err == nil {
+		t.Fatal("expected error for unmatched ${")
+	}
+}
+
+func TestResolveValue_LiteralDollar(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("price is $$5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "price is $5" {
+		t.Fatalf("expected 'price is $5', got %q", got)
+	}
+}
+
+func TestResolveValue_NestedCommand(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("$(echo $(echo nested))")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "nested" {
+		t.Fatalf("expected 'nested', got %q", got)
+	}
+}
+
+func TestResolveValue_NoSubstitution(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("no dollars here")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "no dollars here" {
+		t.Fatalf("expected 'no dollars here', got %q", got)
+	}
+}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -127,3 +127,57 @@ func TestResolveValue_NoSubstitution(t *testing.T) {
 		t.Fatalf("expected 'no dollars here', got %q", got)
 	}
 }
+
+func TestResolveValue_LoneDollar(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("price is $")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "price is $" {
+		t.Fatalf("expected 'price is $', got %q", got)
+	}
+}
+
+func TestResolveValue_DollarBeforeNonVarChar(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveValue("cost $! each")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cost $! each" {
+		t.Fatalf("expected 'cost $! each', got %q", got)
+	}
+}
+
+func TestLoadFromPath_TokenResolution(t *testing.T) {
+	t.Setenv("SQUAD_TEST_TOKEN_VAL", "resolved-token-123")
+	dir := t.TempDir()
+	cfgPath := dir + "/config.yaml"
+	if err := os.WriteFile(cfgPath, []byte("provider:\n  token: $SQUAD_TEST_TOKEN_VAL\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _, err := LoadFromPath(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Provider.Token != "resolved-token-123" {
+		t.Fatalf("expected resolved token, got %q", cfg.Provider.Token)
+	}
+}
+
+func TestLoadFromPath_TokenResolutionError(t *testing.T) {
+	t.Setenv("SQUAD_TEST_DUMMY", "")
+	if err := os.Unsetenv("SQUAD_TEST_DUMMY"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
+	dir := t.TempDir()
+	cfgPath := dir + "/config.yaml"
+	if err := os.WriteFile(cfgPath, []byte("provider:\n  token: $SQUAD_TEST_DUMMY\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := LoadFromPath(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for unresolvable token")
+	}
+}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -61,7 +61,10 @@ func TestResolveValue_MixedCommandAndEnv(t *testing.T) {
 }
 
 func TestResolveValue_UnsetVar(t *testing.T) {
-	os.Unsetenv("SQUAD_TEST_UNSET_VAR_XYZ")
+	t.Setenv("SQUAD_TEST_UNSET_VAR_XYZ", "")
+	if err := os.Unsetenv("SQUAD_TEST_UNSET_VAR_XYZ"); err != nil {
+		t.Fatalf("failed to unset env var: %v", err)
+	}
 	_, err := ResolveValue("$SQUAD_TEST_UNSET_VAR_XYZ")
 	if err == nil {
 		t.Fatal("expected error for unset variable")

--- a/csync/map.go
+++ b/csync/map.go
@@ -1,0 +1,96 @@
+package csync
+
+import (
+	"maps"
+	"sync"
+)
+
+// Map is a generic thread-safe map. All operations are guarded by a RWMutex.
+type Map[K comparable, V any] struct {
+	mu sync.RWMutex
+	m  map[K]V
+}
+
+// NewMap creates an empty Map.
+func NewMap[K comparable, V any]() *Map[K, V] {
+	return &Map[K, V]{m: make(map[K]V)}
+}
+
+// NewMapFrom creates a Map pre-populated with entries from src.
+func NewMapFrom[K comparable, V any](src map[K]V) *Map[K, V] {
+	return &Map[K, V]{m: maps.Clone(src)}
+}
+
+// Get returns the value for key and whether it was found.
+func (m *Map[K, V]) Get(key K) (V, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.m[key]
+	return v, ok
+}
+
+// Set stores a key-value pair.
+func (m *Map[K, V]) Set(key K, val V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.m[key] = val
+}
+
+// Del removes a key.
+func (m *Map[K, V]) Del(key K) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.m, key)
+}
+
+// Len returns the number of entries.
+func (m *Map[K, V]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.m)
+}
+
+// GetOrSet returns the existing value for key if present.
+// Otherwise it calls init(), stores and returns the result.
+func (m *Map[K, V]) GetOrSet(key K, init func() V) V {
+	m.mu.RLock()
+	v, ok := m.m[key]
+	m.mu.RUnlock()
+	if ok {
+		return v
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Double-check after acquiring write lock.
+	if v, ok := m.m[key]; ok {
+		return v
+	}
+	v = init()
+	m.m[key] = v
+	return v
+}
+
+// Copy returns a shallow clone of the underlying map.
+func (m *Map[K, V]) Copy() map[K]V {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return maps.Clone(m.m)
+}
+
+// Range calls fn for each entry. If fn returns false, iteration stops.
+// Operates on a snapshot for safety.
+func (m *Map[K, V]) Range(fn func(K, V) bool) {
+	snapshot := m.Copy()
+	for k, v := range snapshot {
+		if !fn(k, v) {
+			return
+		}
+	}
+}
+
+// Reset clears all entries.
+func (m *Map[K, V]) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.m = make(map[K]V)
+}

--- a/csync/map_test.go
+++ b/csync/map_test.go
@@ -1,0 +1,147 @@
+package csync
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMap_BasicOps(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	v, ok := m.Get("a")
+	if !ok || v != 1 {
+		t.Fatalf("expected (1, true), got (%d, %v)", v, ok)
+	}
+
+	if m.Len() != 2 {
+		t.Fatalf("expected len 2, got %d", m.Len())
+	}
+
+	m.Del("a")
+	_, ok = m.Get("a")
+	if ok {
+		t.Fatal("expected key to be deleted")
+	}
+}
+
+func TestMap_GetOrSet(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+
+	v := m.GetOrSet("x", func() int { return 42 })
+	if v != 42 {
+		t.Fatalf("expected 42, got %d", v)
+	}
+
+	// Second call should return cached value.
+	v = m.GetOrSet("x", func() int { return 99 })
+	if v != 42 {
+		t.Fatalf("expected 42 (cached), got %d", v)
+	}
+}
+
+func TestMap_Copy(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	cp := m.Copy()
+	if len(cp) != 2 || cp["a"] != 1 || cp["b"] != 2 {
+		t.Fatalf("unexpected copy: %v", cp)
+	}
+
+	// Modifying copy should not affect original.
+	cp["c"] = 3
+	if m.Len() != 2 {
+		t.Fatal("copy modification affected original")
+	}
+}
+
+func TestMap_Range(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Set("c", 3)
+
+	var count int
+	m.Range(func(_ string, _ int) bool {
+		count++
+		return count < 2 // stop after 2
+	})
+	if count != 2 {
+		t.Fatalf("expected range to stop after 2, got %d", count)
+	}
+}
+
+func TestMap_Reset(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	m.Set("a", 1)
+	m.Reset()
+	if m.Len() != 0 {
+		t.Fatalf("expected empty after reset, got %d", m.Len())
+	}
+}
+
+func TestMap_NewMapFrom(t *testing.T) {
+	t.Parallel()
+	src := map[string]int{"x": 10, "y": 20}
+	m := NewMapFrom(src)
+	if m.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", m.Len())
+	}
+	v, ok := m.Get("x")
+	if !ok || v != 10 {
+		t.Fatalf("expected (10, true), got (%d, %v)", v, ok)
+	}
+}
+
+func TestMap_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	m := NewMap[int, int]()
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(key int) {
+			defer wg.Done()
+			m.Set(key, key*2)
+			m.Get(key)
+		}(i)
+	}
+	wg.Wait()
+	if m.Len() != 100 {
+		t.Fatalf("expected 100 entries, got %d", m.Len())
+	}
+}
+
+func TestMap_GetOrSet_Concurrent(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	var wg sync.WaitGroup
+	var initCount int64
+	var mu sync.Mutex
+
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.GetOrSet("key", func() int {
+				mu.Lock()
+				initCount++
+				mu.Unlock()
+				return 42
+			})
+		}()
+	}
+	wg.Wait()
+
+	v, ok := m.Get("key")
+	if !ok || v != 42 {
+		t.Fatalf("expected (42, true), got (%d, %v)", v, ok)
+	}
+}

--- a/csync/map_test.go
+++ b/csync/map_test.go
@@ -145,3 +145,18 @@ func TestMap_GetOrSet_Concurrent(t *testing.T) {
 		t.Fatalf("expected (42, true), got (%d, %v)", v, ok)
 	}
 }
+
+func TestMap_GetOrSet_ExistingKey(t *testing.T) {
+	t.Parallel()
+	m := NewMap[string, int]()
+	m.Set("preexisting", 99)
+
+	// GetOrSet should return existing value without calling init.
+	v := m.GetOrSet("preexisting", func() int {
+		t.Fatal("init should not be called for existing key")
+		return 0
+	})
+	if v != 99 {
+		t.Fatalf("expected 99, got %d", v)
+	}
+}

--- a/csync/value.go
+++ b/csync/value.go
@@ -1,0 +1,41 @@
+// Package csync provides generic thread-safe containers.
+package csync
+
+import "sync"
+
+// Value is a generic thread-safe scalar wrapper. Use it for values that can
+// be read and written concurrently by multiple goroutines.
+//
+// For pointer, slice, or map types, use Map or Slice instead — those types
+// have reference semantics that a simple mutex guard cannot make safe.
+type Value[T any] struct {
+	mu  sync.RWMutex
+	val T
+}
+
+// NewValue creates a Value with the given initial value.
+func NewValue[T any](initial T) *Value[T] {
+	return &Value[T]{val: initial}
+}
+
+// Get returns the current value under a read lock.
+func (v *Value[T]) Get() T {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.val
+}
+
+// Set updates the value under a write lock.
+func (v *Value[T]) Set(val T) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.val = val
+}
+
+// Update atomically applies fn to the current value and stores the result.
+func (v *Value[T]) Update(fn func(T) T) T {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.val = fn(v.val)
+	return v.val
+}

--- a/csync/value_test.go
+++ b/csync/value_test.go
@@ -1,0 +1,67 @@
+package csync
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestValue_GetSet(t *testing.T) {
+	t.Parallel()
+	v := NewValue(42)
+	if got := v.Get(); got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+	v.Set(100)
+	if got := v.Get(); got != 100 {
+		t.Fatalf("expected 100, got %d", got)
+	}
+}
+
+func TestValue_Update(t *testing.T) {
+	t.Parallel()
+	v := NewValue(10)
+	result := v.Update(func(n int) int { return n * 2 })
+	if result != 20 {
+		t.Fatalf("expected 20, got %d", result)
+	}
+	if got := v.Get(); got != 20 {
+		t.Fatalf("expected 20 after update, got %d", got)
+	}
+}
+
+func TestValue_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	v := NewValue(0)
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v.Update(func(n int) int { return n + 1 })
+		}()
+	}
+	wg.Wait()
+	if got := v.Get(); got != 100 {
+		t.Fatalf("expected 100, got %d", got)
+	}
+}
+
+func TestValue_StringType(t *testing.T) {
+	t.Parallel()
+	v := NewValue("hello")
+	if got := v.Get(); got != "hello" {
+		t.Fatalf("expected 'hello', got %q", got)
+	}
+	v.Set("world")
+	if got := v.Get(); got != "world" {
+		t.Fatalf("expected 'world', got %q", got)
+	}
+}
+
+func TestValue_ZeroValue(t *testing.T) {
+	t.Parallel()
+	v := NewValue(0)
+	if got := v.Get(); got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}

--- a/pipeline/runner.go
+++ b/pipeline/runner.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cowdogmoo/squad/csync"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/telemetry"
@@ -69,8 +70,7 @@ type Runner struct {
 	Prompt     string  // base prompt passed to each agent
 	MaxCost    float64 // total cost budget for the pipeline (0 = unlimited)
 	Findings   *tools.FindingsStore
-	spent      float64 // accumulated cost across all agents
-	spentMu    sync.Mutex
+	spent      *csync.Value[float64]
 }
 
 // Run executes the pipeline and returns a structured report.
@@ -280,10 +280,7 @@ func (r *Runner) runAgentsParallel(ctx context.Context, agents []string, stage S
 
 // addSpent records cost from a completed agent and returns the new total.
 func (r *Runner) addSpent(cost float64) float64 {
-	r.spentMu.Lock()
-	defer r.spentMu.Unlock()
-	r.spent += cost
-	return r.spent
+	return r.getSpent().Update(func(v float64) float64 { return v + cost })
 }
 
 // remainingBudget returns the remaining cost budget, or 0 if unlimited.
@@ -291,13 +288,19 @@ func (r *Runner) remainingBudget() float64 {
 	if r.MaxCost <= 0 {
 		return 0
 	}
-	r.spentMu.Lock()
-	defer r.spentMu.Unlock()
-	remaining := r.MaxCost - r.spent
+	remaining := r.MaxCost - r.getSpent().Get()
 	if remaining < 0 {
 		return 0
 	}
 	return remaining
+}
+
+// getSpent lazily initializes and returns the spent value.
+func (r *Runner) getSpent() *csync.Value[float64] {
+	if r.spent == nil {
+		r.spent = csync.NewValue(0.0)
+	}
+	return r.spent
 }
 
 // runAgent executes a single agent and returns its result.
@@ -322,7 +325,7 @@ func (r *Runner) runAgent(ctx context.Context, agentName string, stage Stage, pr
 			result.Status = StatusFailed
 			result.Duration = time.Since(start).Round(time.Millisecond).String()
 			result.Output = "pipeline cost budget exceeded"
-			logging.InfoContext(ctx, "pipeline: skipping agent %q — budget exhausted ($%.4f spent of $%.4f)", agentName, r.spent, r.MaxCost)
+			logging.InfoContext(ctx, "pipeline: skipping agent %q — budget exhausted ($%.4f spent of $%.4f)", agentName, r.getSpent().Get(), r.MaxCost)
 			return result
 		}
 		logging.InfoContext(ctx, "pipeline: agent %q budget: $%.4f remaining of $%.4f total", agentName, remaining, r.MaxCost)

--- a/tools/bgcmd.go
+++ b/tools/bgcmd.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/cowdogmoo/squad/csync"
+	"github.com/cowdogmoo/squad/executor"
+	"github.com/cowdogmoo/squad/logging"
+	"github.com/tmc/langchaingo/llms"
+)
+
+const (
+	// DefaultAutoBackgroundTimeout is the duration after which a bash command
+	// is automatically moved to the background.
+	DefaultAutoBackgroundTimeout = 120 * time.Second
+)
+
+// BgCommand represents a running background command.
+type BgCommand struct {
+	ID      string
+	Command string
+	Output  string
+	Err     error
+	Done    chan struct{}
+}
+
+// BgCommandRegistry manages background shell commands.
+type BgCommandRegistry struct {
+	commands *csync.Map[string, *BgCommand]
+	counter  uint64
+}
+
+// NewBgCommandRegistry creates a new background command registry.
+func NewBgCommandRegistry() *BgCommandRegistry {
+	return &BgCommandRegistry{
+		commands: csync.NewMap[string, *BgCommand](),
+	}
+}
+
+// Spawn starts a command in the background and returns its ID.
+func (r *BgCommandRegistry) Spawn(ctx context.Context, ex executor.Executor, command string) string {
+	id := fmt.Sprintf("cmd-%d", atomic.AddUint64(&r.counter, 1))
+	bg := &BgCommand{
+		ID:      id,
+		Command: command,
+		Done:    make(chan struct{}),
+	}
+
+	r.commands.Set(id, bg)
+
+	go func() {
+		defer close(bg.Done)
+		output, err := ex.Execute(ctx, command)
+		bg.Output = string(limitOutput(output))
+		bg.Err = err
+	}()
+
+	return id
+}
+
+// Get returns a background command by ID.
+func (r *BgCommandRegistry) Get(id string) (*BgCommand, bool) {
+	return r.commands.Get(id)
+}
+
+// IsDone returns true if the command has finished.
+func (bg *BgCommand) IsDone() bool {
+	select {
+	case <-bg.Done:
+		return true
+	default:
+		return false
+	}
+}
+
+// bgCommandRegistryKeyType is the context key for the BgCommandRegistry.
+type bgCommandRegistryKeyType struct{}
+
+// InitBgCommandRegistry attaches a registry to the context.
+func InitBgCommandRegistry(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bgCommandRegistryKeyType{}, NewBgCommandRegistry())
+}
+
+// GetBgCommandRegistry retrieves the registry from context.
+func GetBgCommandRegistry(ctx context.Context) *BgCommandRegistry {
+	if r, ok := ctx.Value(bgCommandRegistryKeyType{}).(*BgCommandRegistry); ok {
+		return r
+	}
+	return nil
+}
+
+func definitionBashBg() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "BashBackground",
+			Description: "Run a shell command in the background. Returns a command ID immediately. Use BashOutput to check status and collect output. Useful for long-running commands like tests, builds, or servers.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command": map[string]any{"type": "string", "description": "Shell command to run in the background."},
+				},
+				"required": []string{"command"},
+			},
+		},
+	}
+}
+
+func definitionBashOutput() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "BashOutput",
+			Description: "Check on a background command started with BashBackground. Returns the current output and whether the command is still running.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command_id": map[string]any{"type": "string", "description": "The command ID returned by BashBackground."},
+					"wait":       map[string]any{"type": "boolean", "description": "If true, block until the command completes (default: false)."},
+				},
+				"required": []string{"command_id"},
+			},
+		},
+	}
+}
+
+func bashBackgroundTool(ex executor.Executor) func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		Command string `json:"command"`
+	}
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		command := trimCommand(payload.Command)
+		if command == "" {
+			return "", fmt.Errorf("command is required")
+		}
+		if blocked, reason := IsBlockedCommand(command); blocked {
+			return "", fmt.Errorf("%s", reason)
+		}
+
+		registry := GetBgCommandRegistry(ctx)
+		if registry == nil {
+			return "", fmt.Errorf("background commands not available")
+		}
+
+		id := registry.Spawn(ctx, ex, command)
+		logging.InfoContext(ctx, "  → BashBackground %s → %s", TruncateString(command, 120), id)
+		return fmt.Sprintf("Command started in background. ID: %s\nUse BashOutput(command_id=%q) to check status and collect output.", id, id), nil
+	}
+}
+
+func bashOutputTool() func(ctx context.Context, rawArgs []byte) (string, error) {
+	type args struct {
+		CommandID string   `json:"command_id"`
+		Wait      FlexBool `json:"wait"`
+	}
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		var payload args
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		if payload.CommandID == "" {
+			return "", fmt.Errorf("command_id is required")
+		}
+
+		registry := GetBgCommandRegistry(ctx)
+		if registry == nil {
+			return "", fmt.Errorf("background commands not available")
+		}
+
+		bg, ok := registry.Get(payload.CommandID)
+		if !ok {
+			return "", fmt.Errorf("unknown command ID: %s", payload.CommandID)
+		}
+
+		if bool(payload.Wait) {
+			<-bg.Done
+		}
+
+		if bg.IsDone() {
+			status := "completed"
+			if bg.Err != nil {
+				status = fmt.Sprintf("failed: %v", bg.Err)
+			}
+			return TruncateToolOutputHeadTail(
+				fmt.Sprintf("[%s] status: %s\n\n%s", bg.ID, status, bg.Output),
+				maxToolResultBytes,
+			), nil
+		}
+
+		return fmt.Sprintf("[%s] status: running (command: %s)\nOutput so far not available — use wait=true to block until completion.",
+			bg.ID, TruncateString(bg.Command, 80)), nil
+	}
+}
+
+func trimCommand(s string) string {
+	// inline trim to avoid import cycle issues
+	for len(s) > 0 && (s[0] == ' ' || s[0] == '\t' || s[0] == '\n' || s[0] == '\r') {
+		s = s[1:]
+	}
+	for len(s) > 0 && (s[len(s)-1] == ' ' || s[len(s)-1] == '\t' || s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/tools/bgcmd_test.go
+++ b/tools/bgcmd_test.go
@@ -140,3 +140,133 @@ func TestBgCommandRegistryContext(t *testing.T) {
 		t.Fatal("expected nil from bare context")
 	}
 }
+
+func TestBashBackgroundTool_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+
+	bgTool := bashBackgroundTool(ex)
+	_, err := bgTool(ctx, []byte(`{invalid`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestBashBackgroundTool_EmptyCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+
+	bgTool := bashBackgroundTool(ex)
+	args, _ := json.Marshal(map[string]string{"command": "   "})
+	_, err := bgTool(ctx, args)
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+}
+
+func TestBashOutputTool_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	ctx := InitBgCommandRegistry(context.Background())
+	outTool := bashOutputTool()
+	_, err := outTool(ctx, []byte(`{bad`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestBashOutputTool_EmptyCommandID(t *testing.T) {
+	t.Parallel()
+	ctx := InitBgCommandRegistry(context.Background())
+	outTool := bashOutputTool()
+	args, _ := json.Marshal(map[string]string{"command_id": ""})
+	_, err := outTool(ctx, args)
+	if err == nil {
+		t.Fatal("expected error for empty command_id")
+	}
+}
+
+func TestBashOutputTool_NoRegistry(t *testing.T) {
+	t.Parallel()
+	outTool := bashOutputTool()
+	args, _ := json.Marshal(map[string]string{"command_id": "cmd-1"})
+	_, err := outTool(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected error when no registry in context")
+	}
+}
+
+func TestBashOutputTool_FailedCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+	registry := GetBgCommandRegistry(ctx)
+
+	id := registry.Spawn(ctx, ex, "exit 1")
+	bg, _ := registry.Get(id)
+	<-bg.Done
+
+	outTool := bashOutputTool()
+	args, _ := json.Marshal(map[string]string{"command_id": id})
+	result, err := outTool(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "failed") {
+		t.Fatalf("expected 'failed' in result, got: %s", result)
+	}
+}
+
+func TestBashOutputTool_StillRunning(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+	registry := GetBgCommandRegistry(ctx)
+
+	// Start a long-running command.
+	id := registry.Spawn(ctx, ex, "sleep 30")
+
+	outTool := bashOutputTool()
+	args, _ := json.Marshal(map[string]any{"command_id": id, "wait": false})
+	result, err := outTool(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "running") {
+		t.Fatalf("expected 'running' in result, got: %s", result)
+	}
+}
+
+func TestBgCommand_IsDoneBeforeCompletion(t *testing.T) {
+	t.Parallel()
+	bg := &BgCommand{Done: make(chan struct{})}
+	if bg.IsDone() {
+		t.Fatal("expected IsDone=false before closing channel")
+	}
+	close(bg.Done)
+	if !bg.IsDone() {
+		t.Fatal("expected IsDone=true after closing channel")
+	}
+}
+
+func TestTrimCommand(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input, want string
+	}{
+		{"  hello  ", "hello"},
+		{"\t\ntest\r\n", "test"},
+		{"", ""},
+		{"nospace", "nospace"},
+	}
+	for _, tt := range tests {
+		if got := trimCommand(tt.input); got != tt.want {
+			t.Errorf("trimCommand(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/tools/bgcmd_test.go
+++ b/tools/bgcmd_test.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cowdogmoo/squad/executor"
+)
+
+func TestBgCommandRegistry_SpawnAndCollect(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	registry := NewBgCommandRegistry()
+
+	id := registry.Spawn(context.Background(), ex, "echo hello")
+	if id == "" {
+		t.Fatal("expected non-empty ID")
+	}
+
+	bg, ok := registry.Get(id)
+	if !ok {
+		t.Fatal("expected to find command")
+	}
+
+	// Wait for completion.
+	<-bg.Done
+	if !bg.IsDone() {
+		t.Fatal("expected command to be done")
+	}
+	if bg.Err != nil {
+		t.Fatalf("unexpected error: %v", bg.Err)
+	}
+	if !strings.Contains(bg.Output, "hello") {
+		t.Fatalf("expected 'hello' in output, got: %q", bg.Output)
+	}
+}
+
+func TestBgCommandRegistry_UnknownID(t *testing.T) {
+	t.Parallel()
+	registry := NewBgCommandRegistry()
+	_, ok := registry.Get("nonexistent")
+	if ok {
+		t.Fatal("expected false for unknown ID")
+	}
+}
+
+func TestBashBackgroundTool_Integration(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+
+	// Start background command.
+	bgTool := bashBackgroundTool(ex)
+	args, _ := json.Marshal(map[string]string{"command": "echo background_test"})
+	result, err := bgTool(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Command started in background") {
+		t.Fatalf("expected background message, got: %s", result)
+	}
+
+	// Extract the command ID.
+	// Format: "Command started in background. ID: cmd-1\n..."
+	parts := strings.Split(result, "ID: ")
+	if len(parts) < 2 {
+		t.Fatalf("could not extract command ID from: %s", result)
+	}
+	cmdID := strings.Split(parts[1], "\n")[0]
+
+	// Wait a bit for the command to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	// Collect output.
+	outTool := bashOutputTool()
+	outArgs, _ := json.Marshal(map[string]any{"command_id": cmdID, "wait": true})
+	output, err := outTool(ctx, outArgs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, "completed") {
+		t.Fatalf("expected completed status, got: %s", output)
+	}
+	if !strings.Contains(output, "background_test") {
+		t.Fatalf("expected output content, got: %s", output)
+	}
+}
+
+func TestBashBackgroundTool_BlockedCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	ctx := InitBgCommandRegistry(context.Background())
+
+	bgTool := bashBackgroundTool(ex)
+	args, _ := json.Marshal(map[string]string{"command": "sudo rm -rf /"})
+	_, err := bgTool(ctx, args)
+	if err == nil {
+		t.Fatal("expected error for blocked command")
+	}
+}
+
+func TestBashBackgroundTool_NoRegistry(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+
+	bgTool := bashBackgroundTool(ex)
+	args, _ := json.Marshal(map[string]string{"command": "echo test"})
+	_, err := bgTool(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected error when no registry in context")
+	}
+}
+
+func TestBashOutputTool_UnknownID(t *testing.T) {
+	t.Parallel()
+	ctx := InitBgCommandRegistry(context.Background())
+	outTool := bashOutputTool()
+	args, _ := json.Marshal(map[string]string{"command_id": "nonexistent"})
+	_, err := outTool(ctx, args)
+	if err == nil {
+		t.Fatal("expected error for unknown command ID")
+	}
+}
+
+func TestBgCommandRegistryContext(t *testing.T) {
+	t.Parallel()
+	ctx := InitBgCommandRegistry(context.Background())
+	r := GetBgCommandRegistry(ctx)
+	if r == nil {
+		t.Fatal("expected registry from context")
+	}
+	if GetBgCommandRegistry(context.Background()) != nil {
+		t.Fatal("expected nil from bare context")
+	}
+}

--- a/tools/cmdsafety.go
+++ b/tools/cmdsafety.go
@@ -1,0 +1,147 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// safeCommands are read-only commands that do not require extra scrutiny.
+// They are allowed to run without warnings in any context.
+var safeCommands = []string{
+	"cat ", "cat\t",
+	"echo ",
+	"env",
+	"head ",
+	"id",
+	"ls ",
+	"ls\n", "ls\t",
+	"pwd",
+	"tail ",
+	"wc ",
+	"whoami",
+	"which ",
+	"file ",
+	"stat ",
+	"df ",
+	"du ",
+	"date",
+	"uname",
+	"hostname",
+	"printenv",
+	// git read-only
+	"git status",
+	"git log",
+	"git diff",
+	"git show",
+	"git blame",
+	"git branch",
+	"git tag",
+	"git remote",
+	"git rev-parse",
+	"git ls-files",
+	"git ls-tree",
+	"git describe",
+	"git stash list",
+	"git config --get",
+	"git config --list",
+	// go read-only
+	"go version",
+	"go env",
+	"go list",
+	"go doc",
+	"go vet",
+	// python read-only
+	"python --version",
+	"python3 --version",
+	"pip list",
+	"pip3 list",
+	"pip show",
+	"pip3 show",
+	// node read-only
+	"node --version",
+	"npm list",
+	"npm ls",
+	"npm --version",
+}
+
+// blockedCommands are dangerous commands that should never be executed by an
+// agent. The bash tool will refuse to run any command matching these prefixes.
+var blockedCommands = []string{
+	// destructive system commands
+	"rm -rf /",
+	"rm -rf /*",
+	"mkfs",
+	"dd if=",
+	":(){",
+	// privilege escalation
+	"sudo ",
+	"su ",
+	"doas ",
+	// network reconnaissance / exfiltration
+	"nmap ",
+	"masscan ",
+	"zmap ",
+	"curl -X POST",
+	"wget --post",
+	// system modification
+	"shutdown",
+	"reboot",
+	"halt",
+	"init 0",
+	"init 6",
+	"systemctl stop",
+	"systemctl disable",
+	"launchctl unload",
+	// credential access
+	"passwd",
+	"chpasswd",
+	// dangerous git operations
+	"git push --force",
+	"git push -f ",
+	"git reset --hard",
+	"git clean -fd",
+	"git clean -fx",
+	// package manager installs (prevent supply chain)
+	"pip install ",
+	"pip3 install ",
+	"npm install -g",
+	"npm i -g",
+	"gem install ",
+	"cargo install ",
+	"go install ",
+	"apt install",
+	"apt-get install",
+	"yum install",
+	"dnf install",
+	"brew install",
+	"pacman -S",
+}
+
+// IsSafeCommand returns true if the command is known to be read-only.
+func IsSafeCommand(cmd string) bool {
+	trimmed := strings.TrimSpace(cmd)
+	for _, prefix := range safeCommands {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	// Bare "ls" with no arguments.
+	if trimmed == "ls" || trimmed == "env" || trimmed == "pwd" ||
+		trimmed == "whoami" || trimmed == "date" || trimmed == "id" ||
+		trimmed == "uname" || trimmed == "hostname" || trimmed == "printenv" {
+		return true
+	}
+	return false
+}
+
+// IsBlockedCommand returns true and a reason if the command is dangerous
+// and should not be executed by an agent.
+func IsBlockedCommand(cmd string) (bool, string) {
+	trimmed := strings.TrimSpace(cmd)
+	for _, prefix := range blockedCommands {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true, fmt.Sprintf("%v: %s commands are not allowed", ErrBlockedCommand, prefix)
+		}
+	}
+	return false, ""
+}

--- a/tools/cmdsafety_test.go
+++ b/tools/cmdsafety_test.go
@@ -1,0 +1,48 @@
+package tools
+
+import "testing"
+
+func TestIsSafeCommand(t *testing.T) {
+	t.Parallel()
+	safe := []string{
+		"ls", "pwd", "git status", "git log --oneline", "go version",
+		"cat foo.txt", "whoami", "echo hello", "git diff HEAD",
+	}
+	for _, cmd := range safe {
+		if !IsSafeCommand(cmd) {
+			t.Errorf("expected %q to be safe", cmd)
+		}
+	}
+	notSafe := []string{
+		"rm -rf /tmp/foo", "curl http://evil.com", "go run main.go",
+		"make build", "docker run ubuntu",
+	}
+	for _, cmd := range notSafe {
+		if IsSafeCommand(cmd) {
+			t.Errorf("expected %q to NOT be safe", cmd)
+		}
+	}
+}
+
+func TestIsBlockedCommand(t *testing.T) {
+	t.Parallel()
+	blocked := []string{
+		"sudo rm -rf /", "rm -rf /", "nmap 192.168.1.0/24",
+		"git push --force origin main", "pip install requests",
+		"shutdown -h now", "dd if=/dev/zero of=/dev/sda",
+	}
+	for _, cmd := range blocked {
+		if ok, _ := IsBlockedCommand(cmd); !ok {
+			t.Errorf("expected %q to be blocked", cmd)
+		}
+	}
+	allowed := []string{
+		"ls -la", "git status", "go test ./...", "make lint",
+		"echo hello", "git push origin feature-branch",
+	}
+	for _, cmd := range allowed {
+		if ok, reason := IsBlockedCommand(cmd); ok {
+			t.Errorf("expected %q to be allowed, but got: %s", cmd, reason)
+		}
+	}
+}

--- a/tools/efficiency.go
+++ b/tools/efficiency.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cowdogmoo/squad/csync"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/tmc/langchaingo/llms"
 )
@@ -28,13 +29,12 @@ type ReadCacheEntry struct {
 // ReadCache tracks files already read in the current session to avoid
 // wasting tokens on redundant re-reads. Thread-safe.
 type ReadCache struct {
-	mu      sync.RWMutex
-	entries map[string]ReadCacheEntry // key: absolute file path
+	entries *csync.Map[string, ReadCacheEntry]
 }
 
 // NewReadCache creates an empty read cache.
 func NewReadCache() *ReadCache {
-	return &ReadCache{entries: make(map[string]ReadCacheEntry)}
+	return &ReadCache{entries: csync.NewMap[string, ReadCacheEntry]()}
 }
 
 // InitReadCache attaches a ReadCache to the context.
@@ -62,9 +62,7 @@ func (rc *ReadCache) Check(path string, contentHash string) (ReadCacheEntry, boo
 	if rc == nil {
 		return ReadCacheEntry{}, false
 	}
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
-	entry, exists := rc.entries[path]
+	entry, exists := rc.entries.Get(path)
 	if exists && entry.ContentHash == contentHash {
 		return entry, true
 	}
@@ -76,14 +74,12 @@ func (rc *ReadCache) Store(path, contentHash string, lines, bytes, iteration int
 	if rc == nil {
 		return
 	}
-	rc.mu.Lock()
-	defer rc.mu.Unlock()
-	rc.entries[path] = ReadCacheEntry{
+	rc.entries.Set(path, ReadCacheEntry{
 		ContentHash: contentHash,
 		Lines:       lines,
 		Bytes:       bytes,
 		Iteration:   iteration,
-	}
+	})
 }
 
 // Len returns the number of entries in the cache.
@@ -91,9 +87,7 @@ func (rc *ReadCache) Len() int {
 	if rc == nil {
 		return 0
 	}
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
-	return len(rc.entries)
+	return rc.entries.Len()
 }
 
 // --- Iteration Counter (for cache) ---
@@ -152,7 +146,7 @@ func (pe *PhaseEnforcer) ObserveTools(toolNames []string) string {
 		return ""
 	}
 	for _, name := range toolNames {
-		if name == "Edit" || name == "Write" {
+		if name == "Edit" || name == "MultiEdit" || name == "Write" {
 			pe.editSeen = true
 			return ""
 		}
@@ -213,7 +207,7 @@ func classifyToolCall(s *compactionStats, name, args string) {
 		if pat := extractJSONField(args, "pattern"); pat != "" {
 			s.patternsSearched[pat] = true
 		}
-	case "Edit", "Write":
+	case "Edit", "MultiEdit", "Write":
 		if path := extractJSONField(args, "path"); path != "" {
 			s.editsApplied[path]++
 		}
@@ -376,7 +370,8 @@ const ToolEfficiencyPrompt = `## Tool Efficiency
 
 When you need to perform multiple independent operations, invoke ALL relevant tools in a single response:
 - Reading multiple files: call Read for ALL of them in one response, not one at a time.
-- Making multiple edits: call Edit for ALL of them in one response.
+- Making multiple edits to ONE file: use MultiEdit to batch all changes in a single call.
+- Making edits across DIFFERENT files: call Edit or MultiEdit for ALL of them in one response.
 - Multiple searches: call Grep for ALL patterns in one response.
 
 Do NOT read files you have already read unless you need to verify edits you just made.

--- a/tools/efficiency.go
+++ b/tools/efficiency.go
@@ -222,7 +222,7 @@ func classifyToolCall(s *compactionStats, name, args string) {
 func writeCappedList(sb *strings.Builder, label string, items []string, cap int) {
 	sb.WriteString(label)
 	if len(items) > cap {
-		sb.WriteString(fmt.Sprintf("%s ... and %d more", strings.Join(items[:cap], ", "), len(items)-cap))
+		fmt.Fprintf(sb, "%s ... and %d more", strings.Join(items[:cap], ", "), len(items)-cap)
 	} else {
 		sb.WriteString(strings.Join(items, ", "))
 	}

--- a/tools/efficiency_test.go
+++ b/tools/efficiency_test.go
@@ -364,3 +364,15 @@ func TestSortedKeys(t *testing.T) {
 		t.Fatalf("expected [a b c], got %v", keys)
 	}
 }
+
+func TestTokenCalibration_ZeroActual(t *testing.T) {
+	tc := NewTokenCalibration()
+	tc.Record(100, 0)  // actual <= 0, should be ignored
+	tc.Record(100, -5) // negative, should be ignored
+	if tc.Samples() != 0 {
+		t.Fatalf("expected 0 samples for zero/negative actual, got %d", tc.Samples())
+	}
+	if f := tc.CorrectionFactor(); f != 1.0 {
+		t.Fatalf("expected 1.0 with no valid samples, got %f", f)
+	}
+}

--- a/tools/errors.go
+++ b/tools/errors.go
@@ -1,0 +1,28 @@
+package tools
+
+import "errors"
+
+// Sentinel errors for common agent failure modes.
+// Use errors.Is() to check for these in callers.
+var (
+	// ErrToolExecutionFailed indicates a tool handler returned an error.
+	ErrToolExecutionFailed = errors.New("tool execution failed")
+
+	// ErrIterationLimitReached indicates the agent hit its max iteration count.
+	ErrIterationLimitReached = errors.New("iteration limit reached")
+
+	// ErrLoopDetected indicates the agent was stuck repeating identical tool calls.
+	ErrLoopDetected = errors.New("loop detected: agent repeating identical tool calls")
+
+	// ErrEditDeadlineReached indicates the agent failed to make edits within the deadline.
+	ErrEditDeadlineReached = errors.New("edit deadline reached without edits")
+
+	// ErrBlockedCommand indicates a dangerous command was rejected by the safety filter.
+	ErrBlockedCommand = errors.New("blocked command")
+
+	// ErrFileNotRead indicates an edit was attempted on a file that hasn't been read.
+	ErrFileNotRead = errors.New("file not read before edit")
+
+	// ErrStaleRead indicates a file was modified after the agent last read it.
+	ErrStaleRead = errors.New("file modified since last read")
+)

--- a/tools/filetracker.go
+++ b/tools/filetracker.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cowdogmoo/squad/csync"
+)
+
+// fileTrackerKeyType is the context key for the FileTracker.
+type fileTrackerKeyType struct{}
+
+// FileTracker records when files were read by the agent so that edit tools
+// can verify the agent has seen the current content before modifying it.
+type FileTracker struct {
+	reads *csync.Map[string, time.Time]
+}
+
+// NewFileTracker creates an empty file tracker.
+func NewFileTracker() *FileTracker {
+	return &FileTracker{reads: csync.NewMap[string, time.Time]()}
+}
+
+// InitFileTracker attaches a FileTracker to the context.
+func InitFileTracker(ctx context.Context) context.Context {
+	return context.WithValue(ctx, fileTrackerKeyType{}, NewFileTracker())
+}
+
+// GetFileTracker retrieves the FileTracker from context, or nil if not set.
+func GetFileTracker(ctx context.Context) *FileTracker {
+	if ft, ok := ctx.Value(fileTrackerKeyType{}).(*FileTracker); ok {
+		return ft
+	}
+	return nil
+}
+
+// RecordRead records that a file was read at the current time.
+func (ft *FileTracker) RecordRead(path string) {
+	if ft == nil {
+		return
+	}
+	ft.reads.Set(path, time.Now())
+}
+
+// LastReadTime returns when a file was last read, or zero time if never read.
+func (ft *FileTracker) LastReadTime(path string) time.Time {
+	if ft == nil {
+		return time.Time{}
+	}
+	v, _ := ft.reads.Get(path)
+	return v
+}
+
+// ValidateBeforeEdit checks that the file has been read and hasn't been
+// modified since the last read. Returns nil if safe to edit, or an error
+// describing the problem.
+func (ft *FileTracker) ValidateBeforeEdit(path string) error {
+	if ft == nil {
+		return nil // tracker not enabled, allow edit
+	}
+	readTime := ft.LastReadTime(path)
+	if readTime.IsZero() {
+		return fmt.Errorf("%w: %q has not been read yet — read it first before editing", ErrFileNotRead, path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil // file may not exist yet (Write creates), allow
+	}
+	if info.ModTime().After(readTime) {
+		return fmt.Errorf("%w: %q was modified after your last read — re-read it before editing", ErrStaleRead, path)
+	}
+	return nil
+}

--- a/tools/filetracker_test.go
+++ b/tools/filetracker_test.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileTracker_RecordAndValidate(t *testing.T) {
+	t.Parallel()
+	ft := NewFileTracker()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Edit before read should fail.
+	if err := ft.ValidateBeforeEdit(file); err == nil {
+		t.Fatal("expected error editing unread file")
+	}
+
+	// Read, then edit should pass.
+	ft.RecordRead(file)
+	if err := ft.ValidateBeforeEdit(file); err != nil {
+		t.Fatalf("unexpected error after read: %v", err)
+	}
+}
+
+func TestFileTracker_StaleRead(t *testing.T) {
+	t.Parallel()
+	ft := NewFileTracker()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(file, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ft.RecordRead(file)
+	// Wait a tiny bit then modify the file externally.
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(file, []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ft.ValidateBeforeEdit(file); err == nil {
+		t.Fatal("expected error for stale read")
+	}
+}
+
+func TestFileTracker_NilSafe(t *testing.T) {
+	t.Parallel()
+	var ft *FileTracker
+	ft.RecordRead("/some/path")
+	if err := ft.ValidateBeforeEdit("/some/path"); err != nil {
+		t.Fatalf("nil tracker should allow edits: %v", err)
+	}
+	if !ft.LastReadTime("/some/path").IsZero() {
+		t.Fatal("nil tracker should return zero time")
+	}
+}
+
+func TestFileTracker_NonexistentFile(t *testing.T) {
+	t.Parallel()
+	ft := NewFileTracker()
+	// Validate a file that doesn't exist — should pass (Write creates new files).
+	ft.RecordRead("/nonexistent/file.txt")
+	if err := ft.ValidateBeforeEdit("/nonexistent/file.txt"); err != nil {
+		t.Fatalf("should allow edit of non-existent file: %v", err)
+	}
+}
+
+func TestFileTracker_ContextIntegration(t *testing.T) {
+	t.Parallel()
+	ctx := InitFileTracker(context.Background())
+	ft := GetFileTracker(ctx)
+	if ft == nil {
+		t.Fatal("expected file tracker from context")
+	}
+	ft.RecordRead("/test")
+	if ft.LastReadTime("/test").IsZero() {
+		t.Fatal("expected non-zero read time")
+	}
+}
+
+func TestGetFileTracker_MissingContext(t *testing.T) {
+	t.Parallel()
+	ft := GetFileTracker(context.Background())
+	if ft != nil {
+		t.Fatal("expected nil from bare context")
+	}
+}

--- a/tools/golden_test.go
+++ b/tools/golden_test.go
@@ -1,0 +1,133 @@
+package tools
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+// goldenTest compares actual output against a golden file. If -update is set,
+// it writes the actual output as the new golden file.
+func goldenTest(t *testing.T, name, actual string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", name+".golden")
+
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(actual), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("golden file %s not found (run with -update to create): %v", goldenPath, err)
+	}
+	if string(expected) != actual {
+		t.Fatalf("golden mismatch for %s:\n--- expected ---\n%s\n--- actual ---\n%s",
+			goldenPath, string(expected), actual)
+	}
+}
+
+func TestGolden_MultiEditResult(t *testing.T) {
+	t.Parallel()
+	result := formatMultiEditResult("src/main.go", 3, []FailedEdit{
+		{Index: 2, Old: "nonexistent text", Error: "text not found"},
+		{Index: 5, Old: "", Error: "old string is empty"},
+	})
+	goldenTest(t, "multiedit_result", result)
+}
+
+func TestGolden_TruncateToLines(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	for i := 1; i <= 20; i++ {
+		sb.WriteString("line ")
+		sb.WriteString(string(rune('0' + i%10)))
+		sb.WriteString("\n")
+	}
+	result := TruncateToLines(sb.String(), 5, 3)
+	goldenTest(t, "truncate_to_lines", result)
+}
+
+func TestGolden_CompactionSummary(t *testing.T) {
+	t.Parallel()
+	messages := buildCompactionTestMessages()
+	result := CompactionSummary(messages)
+	goldenTest(t, "compaction_summary", result)
+}
+
+func buildCompactionTestMessages() []llms.MessageContent {
+	return []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.ToolCall{ID: "1", FunctionCall: &llms.FunctionCall{Name: "Read", Arguments: `{"path":"main.go"}`}},
+				llms.ToolCall{ID: "2", FunctionCall: &llms.FunctionCall{Name: "Read", Arguments: `{"path":"config.go"}`}},
+			},
+		},
+		{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.ToolCall{ID: "3", FunctionCall: &llms.FunctionCall{Name: "Grep", Arguments: `{"pattern":"TODO"}`}},
+			},
+		},
+		{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.ToolCall{ID: "4", FunctionCall: &llms.FunctionCall{Name: "Edit", Arguments: `{"path":"main.go","old":"foo","new":"bar"}`}},
+				llms.ToolCall{ID: "5", FunctionCall: &llms.FunctionCall{Name: "Edit", Arguments: `{"path":"main.go","old":"baz","new":"qux"}`}},
+			},
+		},
+		{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.ToolCall{ID: "6", FunctionCall: &llms.FunctionCall{Name: "Bash", Arguments: `{"command":"go test ./..."}`}},
+			},
+		},
+	}
+}
+
+func TestGolden_CommandSafety(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	testCmds := []string{
+		"ls -la",
+		"git status",
+		"sudo rm -rf /",
+		"go test ./...",
+		"nmap 192.168.1.0/24",
+		"echo hello",
+		"pip install requests",
+	}
+	for _, cmd := range testCmds {
+		safe := IsSafeCommand(cmd)
+		blocked, reason := IsBlockedCommand(cmd)
+		sb.WriteString(cmd)
+		sb.WriteString(" → safe=")
+		if safe {
+			sb.WriteString("true")
+		} else {
+			sb.WriteString("false")
+		}
+		sb.WriteString(" blocked=")
+		if blocked {
+			sb.WriteString("true (")
+			sb.WriteString(reason)
+			sb.WriteString(")")
+		} else {
+			sb.WriteString("false")
+		}
+		sb.WriteString("\n")
+	}
+	goldenTest(t, "cmd_safety", sb.String())
+}

--- a/tools/golden_test.go
+++ b/tools/golden_test.go
@@ -32,7 +32,7 @@ func goldenTest(t *testing.T, name, actual string) {
 	if err != nil {
 		t.Fatalf("golden file %s not found (run with -update to create): %v", goldenPath, err)
 	}
-	if string(expected) != actual {
+	if strings.TrimRight(string(expected), "\n") != strings.TrimRight(actual, "\n") {
 		t.Fatalf("golden mismatch for %s:\n--- expected ---\n%s\n--- actual ---\n%s",
 			goldenPath, string(expected), actual)
 	}

--- a/tools/loopdetect.go
+++ b/tools/loopdetect.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+const (
+	// loopWindowSize is the number of recent steps to examine for loops.
+	loopWindowSize = 10
+	// loopMaxRepeats is how many times a step signature can repeat before
+	// we consider the agent stuck in a loop.
+	loopMaxRepeats = 3
+)
+
+// LoopDetector watches for repetitive tool-call patterns by hashing recent
+// (tool-calls + tool-results) steps and detecting when the same signature
+// appears too many times within a sliding window.
+type LoopDetector struct {
+	signatures []string
+}
+
+// stepSignature computes a SHA-256 hash of all tool calls in a step paired
+// with their results. The hash covers tool name, arguments, and output so
+// that identical calls producing different results are treated as distinct.
+func stepSignature(calls []llms.ToolCall, results map[string]string) string {
+	if len(calls) == 0 {
+		return ""
+	}
+	h := sha256.New()
+	// Sort calls by ID for deterministic ordering.
+	sorted := make([]llms.ToolCall, len(calls))
+	copy(sorted, calls)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].ID < sorted[j].ID
+	})
+	for _, tc := range sorted {
+		if tc.FunctionCall == nil {
+			continue
+		}
+		fmt.Fprintf(h, "%s\x00%s\x00%s\x00",
+			tc.FunctionCall.Name,
+			tc.FunctionCall.Arguments,
+			results[tc.ID],
+		)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Record adds a step (tool calls + their results) to the detector's history.
+func (ld *LoopDetector) Record(calls []llms.ToolCall, results map[string]string) {
+	sig := stepSignature(calls, results)
+	if sig == "" {
+		return
+	}
+	ld.signatures = append(ld.signatures, sig)
+}
+
+// Stuck returns true if any step signature appears more than loopMaxRepeats
+// times within the last loopWindowSize steps.
+func (ld *LoopDetector) Stuck() bool {
+	n := len(ld.signatures)
+	start := 0
+	if n > loopWindowSize {
+		start = n - loopWindowSize
+	}
+	window := ld.signatures[start:]
+
+	counts := make(map[string]int, len(window))
+	for _, sig := range window {
+		counts[sig]++
+		if counts[sig] >= loopMaxRepeats {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/loopdetect.go
+++ b/tools/loopdetect.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"sort"
 
 	"github.com/tmc/langchaingo/llms"
@@ -42,11 +41,12 @@ func stepSignature(calls []llms.ToolCall, results map[string]string) string {
 		if tc.FunctionCall == nil {
 			continue
 		}
-		fmt.Fprintf(h, "%s\x00%s\x00%s\x00",
-			tc.FunctionCall.Name,
-			tc.FunctionCall.Arguments,
-			results[tc.ID],
-		)
+		h.Write([]byte(tc.FunctionCall.Name))
+		h.Write([]byte{0})
+		h.Write([]byte(tc.FunctionCall.Arguments))
+		h.Write([]byte{0})
+		h.Write([]byte(results[tc.ID]))
+		h.Write([]byte{0})
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/tools/loopdetect_test.go
+++ b/tools/loopdetect_test.go
@@ -1,0 +1,113 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+func makeToolCall(id, name, args string) llms.ToolCall {
+	return llms.ToolCall{
+		ID: id,
+		FunctionCall: &llms.FunctionCall{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func TestLoopDetector_NotStuckOnVariedCalls(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	for i := 0; i < 10; i++ {
+		calls := []llms.ToolCall{makeToolCall("1", "Read", `{"path":"file`+string(rune('a'+i))+`.go"}`)}
+		results := map[string]string{"1": "content " + string(rune('a'+i))}
+		ld.Record(calls, results)
+		if ld.Stuck() {
+			t.Fatalf("should not be stuck after %d varied calls", i+1)
+		}
+	}
+}
+
+func TestLoopDetector_StuckOnIdenticalCalls(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	calls := []llms.ToolCall{makeToolCall("1", "Grep", `{"pattern":"foo"}`)}
+	results := map[string]string{"1": "no matches"}
+
+	for i := 0; i < loopMaxRepeats-1; i++ {
+		ld.Record(calls, results)
+		if ld.Stuck() {
+			t.Fatalf("should not be stuck after only %d repeats", i+1)
+		}
+	}
+	ld.Record(calls, results)
+	if !ld.Stuck() {
+		t.Fatal("should be stuck after loopMaxRepeats identical calls")
+	}
+}
+
+func TestLoopDetector_SlidingWindow(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+
+	// Fill window with identical calls.
+	calls := []llms.ToolCall{makeToolCall("1", "Read", `{"path":"a.go"}`)}
+	results := map[string]string{"1": "content a"}
+	for i := 0; i < loopMaxRepeats-1; i++ {
+		ld.Record(calls, results)
+	}
+
+	// Push the old repeats out of the window with varied calls.
+	for i := 0; i < loopWindowSize; i++ {
+		varied := []llms.ToolCall{makeToolCall("1", "Bash", `{"command":"echo `+string(rune('a'+i))+`"}`)}
+		variedResults := map[string]string{"1": "output " + string(rune('a'+i))}
+		ld.Record(varied, variedResults)
+	}
+
+	if ld.Stuck() {
+		t.Fatal("old repeats should have slid out of the window")
+	}
+}
+
+func TestLoopDetector_SameCallDifferentResult(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	calls := []llms.ToolCall{makeToolCall("1", "Grep", `{"pattern":"foo"}`)}
+
+	for i := 0; i < loopMaxRepeats+2; i++ {
+		results := map[string]string{"1": "result " + string(rune('a'+i))}
+		ld.Record(calls, results)
+	}
+
+	if ld.Stuck() {
+		t.Fatal("same call with different results should not trigger loop detection")
+	}
+}
+
+func TestLoopDetector_EmptyCallsIgnored(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	ld.Record(nil, nil)
+	ld.Record([]llms.ToolCall{}, nil)
+	if ld.Stuck() {
+		t.Fatal("empty calls should not trigger loop detection")
+	}
+}
+
+func TestLoopDetector_MultipleToolCalls(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	calls := []llms.ToolCall{
+		makeToolCall("1", "Read", `{"path":"a.go"}`),
+		makeToolCall("2", "Read", `{"path":"b.go"}`),
+	}
+	results := map[string]string{"1": "content a", "2": "content b"}
+
+	for i := 0; i < loopMaxRepeats; i++ {
+		ld.Record(calls, results)
+	}
+	if !ld.Stuck() {
+		t.Fatal("identical multi-tool steps should trigger loop detection")
+	}
+}

--- a/tools/loopdetect_test.go
+++ b/tools/loopdetect_test.go
@@ -111,3 +111,35 @@ func TestLoopDetector_MultipleToolCalls(t *testing.T) {
 		t.Fatal("identical multi-tool steps should trigger loop detection")
 	}
 }
+
+func TestLoopDetector_NilFunctionCall(t *testing.T) {
+	t.Parallel()
+	ld := &LoopDetector{}
+	// Tool call with nil FunctionCall should be skipped gracefully.
+	calls := []llms.ToolCall{
+		{ID: "1", FunctionCall: nil},
+		makeToolCall("2", "Read", `{"path":"a.go"}`),
+	}
+	results := map[string]string{"2": "content"}
+	ld.Record(calls, results)
+	if ld.Stuck() {
+		t.Fatal("single step should not be stuck")
+	}
+}
+
+func TestStepSignature_Deterministic(t *testing.T) {
+	t.Parallel()
+	calls := []llms.ToolCall{
+		makeToolCall("2", "Read", `{"path":"b.go"}`),
+		makeToolCall("1", "Read", `{"path":"a.go"}`),
+	}
+	results := map[string]string{"1": "a", "2": "b"}
+	sig1 := stepSignature(calls, results)
+	sig2 := stepSignature(calls, results)
+	if sig1 != sig2 {
+		t.Fatal("signatures should be deterministic")
+	}
+	if sig1 == "" {
+		t.Fatal("signature should not be empty for valid calls")
+	}
+}

--- a/tools/multiedit.go
+++ b/tools/multiedit.go
@@ -1,0 +1,140 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// MultiEditOperation describes a single find-and-replace within a file.
+type MultiEditOperation struct {
+	Old        string   `json:"old"`
+	New        string   `json:"new"`
+	ReplaceAll FlexBool `json:"replace_all"`
+}
+
+// MultiEditArgs are the arguments for the MultiEdit tool.
+type MultiEditArgs struct {
+	Path  string               `json:"path"`
+	Edits []MultiEditOperation `json:"edits"`
+}
+
+// FailedEdit records an edit operation that could not be applied.
+type FailedEdit struct {
+	Index int    `json:"index"`
+	Old   string `json:"old"`
+	Error string `json:"error"`
+}
+
+func definitionMultiEdit() llms.Tool {
+	return llms.Tool{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name: "MultiEdit",
+			Description: "Apply multiple find-and-replace operations to a single file in one call. " +
+				"More efficient than calling Edit repeatedly. Edits are applied sequentially " +
+				"so later edits see the result of earlier ones. Supports partial success.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{"type": "string", "description": "Path to the file."},
+					"edits": map[string]any{
+						"type":        "array",
+						"description": "List of edit operations to apply in order.",
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"old":         map[string]any{"type": "string", "description": "Text to find."},
+								"new":         map[string]any{"type": "string", "description": "Replacement text."},
+								"replace_all": map[string]any{"type": "boolean", "description": "Replace all occurrences (default: false)."},
+							},
+							"required": []string{"old", "new"},
+						},
+					},
+				},
+				"required": []string{"path", "edits"},
+			},
+		},
+	}
+}
+
+func multiEditTool(workingDir string) func(ctx context.Context, rawArgs []byte) (string, error) {
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
+		var payload MultiEditArgs
+		if err := json.Unmarshal(rawArgs, &payload); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+		if len(payload.Edits) == 0 {
+			return "", fmt.Errorf("edits array is empty")
+		}
+		path, err := ResolvePath(workingDir, payload.Path)
+		if err != nil {
+			return "", err
+		}
+		if ft := GetFileTracker(ctx); ft != nil {
+			if err := ft.ValidateBeforeEdit(path); err != nil {
+				return "", err
+			}
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		content := string(data)
+
+		var applied int
+		var failed []FailedEdit
+
+		for i, edit := range payload.Edits {
+			if edit.Old == "" {
+				failed = append(failed, FailedEdit{
+					Index: i,
+					Old:   edit.Old,
+					Error: "old string is empty",
+				})
+				continue
+			}
+			if !strings.Contains(content, edit.Old) {
+				failed = append(failed, FailedEdit{
+					Index: i,
+					Old:   edit.Old,
+					Error: "text not found",
+				})
+				continue
+			}
+			if bool(edit.ReplaceAll) {
+				content = strings.ReplaceAll(content, edit.Old, edit.New)
+			} else {
+				content = strings.Replace(content, edit.Old, edit.New, 1)
+			}
+			applied++
+		}
+
+		if applied == 0 {
+			return formatMultiEditResult(payload.Path, 0, failed), fmt.Errorf("all %d edits failed", len(failed))
+		}
+
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return "", err
+		}
+
+		return formatMultiEditResult(payload.Path, applied, failed), nil
+	}
+}
+
+func formatMultiEditResult(path string, applied int, failed []FailedEdit) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "updated %s: %d edit(s) applied", filepath.ToSlash(path), applied)
+	if len(failed) > 0 {
+		fmt.Fprintf(&sb, ", %d failed", len(failed))
+		for _, f := range failed {
+			fmt.Fprintf(&sb, "\n  edit[%d]: %s (old=%q)", f.Index, f.Error, TruncateString(f.Old, 80))
+		}
+	}
+	return sb.String()
+}

--- a/tools/multiedit_test.go
+++ b/tools/multiedit_test.go
@@ -1,0 +1,204 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	file := filepath.Join(dir, name)
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeTestFile: %v", err)
+	}
+	return file
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readTestFile: %v", err)
+	}
+	return string(data)
+}
+
+func TestMultiEdit_BasicReplacements(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "test.go", "foo bar baz\nfoo qux\n")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.go",
+		Edits: []MultiEditOperation{
+			{Old: "foo bar", New: "hello"},
+			{Old: "foo qux", New: "world"},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	result, err := tool(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "2 edit(s) applied") {
+		t.Fatalf("expected 2 edits applied, got: %s", result)
+	}
+	if got := readTestFile(t, file); got != "hello baz\nworld\n" {
+		t.Fatalf("unexpected file content: %q", got)
+	}
+}
+
+func TestMultiEdit_PartialFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "test.txt", "alpha beta gamma")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.txt",
+		Edits: []MultiEditOperation{
+			{Old: "alpha", New: "ALPHA"},
+			{Old: "nonexistent", New: "X"},
+			{Old: "gamma", New: "GAMMA"},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	result, err := tool(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error on partial success: %v", err)
+	}
+	if !strings.Contains(result, "2 edit(s) applied") {
+		t.Fatalf("expected 2 applied, got: %s", result)
+	}
+	if !strings.Contains(result, "1 failed") {
+		t.Fatalf("expected 1 failed, got: %s", result)
+	}
+	if got := readTestFile(t, file); got != "ALPHA beta GAMMA" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestMultiEdit_AllFail(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "test.txt", "hello world")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.txt",
+		Edits: []MultiEditOperation{
+			{Old: "xxx", New: "Y"},
+			{Old: "yyy", New: "Z"},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool(context.Background(), raw)
+	if err == nil {
+		t.Fatal("expected error when all edits fail")
+	}
+	if got := readTestFile(t, file); got != "hello world" {
+		t.Fatalf("file should not be modified when all edits fail: %q", got)
+	}
+}
+
+func TestMultiEdit_ReplaceAll(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "test.txt", "aaa bbb aaa ccc aaa")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.txt",
+		Edits: []MultiEditOperation{
+			{Old: "aaa", New: "XXX", ReplaceAll: true},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	result, err := tool(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "1 edit(s) applied") {
+		t.Fatalf("expected 1 applied, got: %s", result)
+	}
+	if got := readTestFile(t, file); got != "XXX bbb XXX ccc XXX" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestMultiEdit_SequentialEdits(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := writeTestFile(t, dir, "test.txt", "foo")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.txt",
+		Edits: []MultiEditOperation{
+			{Old: "foo", New: "bar"},
+			{Old: "bar", New: "baz"},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	result, err := tool(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "2 edit(s) applied") {
+		t.Fatalf("expected 2 applied, got: %s", result)
+	}
+	if got := readTestFile(t, file); got != "baz" {
+		t.Fatalf("expected sequential application, got: %q", got)
+	}
+}
+
+func TestMultiEdit_EmptyEdits(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{Path: "test.txt", Edits: []MultiEditOperation{}}
+	raw, _ := json.Marshal(args)
+	_, err := tool(context.Background(), raw)
+	if err == nil {
+		t.Fatal("expected error for empty edits")
+	}
+}
+
+func TestMultiEdit_EmptyOldString(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "test.txt", "hello")
+
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path: "test.txt",
+		Edits: []MultiEditOperation{
+			{Old: "", New: "X"},
+		},
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool(context.Background(), raw)
+	if err == nil {
+		t.Fatal("expected error when old string is empty")
+	}
+}
+
+func TestMultiEdit_PathTraversal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path:  "../etc/passwd",
+		Edits: []MultiEditOperation{{Old: "root", New: "hacked"}},
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool(context.Background(), raw)
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+}

--- a/tools/multiedit_test.go
+++ b/tools/multiedit_test.go
@@ -202,3 +202,47 @@ func TestMultiEdit_PathTraversal(t *testing.T) {
 		t.Fatal("expected error for path traversal")
 	}
 }
+
+func TestMultiEdit_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tool := multiEditTool(dir)
+	_, err := tool(context.Background(), []byte(`{bad`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestMultiEdit_NonexistentFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path:  "nonexistent.go",
+		Edits: []MultiEditOperation{{Old: "x", New: "y"}},
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool(context.Background(), raw)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestMultiEdit_FileTrackerValidation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "test.go", "hello world")
+
+	ctx := InitFileTracker(context.Background())
+	// Don't record a read — edit should fail validation.
+	tool := multiEditTool(dir)
+	args := MultiEditArgs{
+		Path:  "test.go",
+		Edits: []MultiEditOperation{{Old: "hello", New: "goodbye"}},
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool(ctx, raw)
+	if err == nil {
+		t.Fatal("expected error when file not read before edit")
+	}
+}

--- a/tools/task.go
+++ b/tools/task.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"sync/atomic"
 
+	"github.com/cowdogmoo/squad/csync"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/telemetry"
@@ -35,8 +35,7 @@ type BackgroundTaskResult struct {
 
 // BackgroundTaskRegistry manages background task spawning and results.
 type BackgroundTaskRegistry struct {
-	mu        sync.RWMutex
-	tasks     map[string]*BackgroundTaskResult
+	tasks     *csync.Map[string, *BackgroundTaskResult]
 	counter   uint64
 	semaphore chan struct{}
 }
@@ -48,7 +47,7 @@ func NewBackgroundTaskRegistry(concurrency int) *BackgroundTaskRegistry {
 		concurrency = DefaultConcurrentTasks
 	}
 	return &BackgroundTaskRegistry{
-		tasks:     make(map[string]*BackgroundTaskResult),
+		tasks:     csync.NewMap[string, *BackgroundTaskResult](),
 		semaphore: make(chan struct{}, concurrency),
 	}
 }
@@ -60,9 +59,7 @@ func (r *BackgroundTaskRegistry) SpawnTask(ctx context.Context, cfg TaskConfig, 
 		Done: make(chan struct{}),
 	}
 
-	r.mu.Lock()
-	r.tasks[id] = result
-	r.mu.Unlock()
+	r.tasks.Set(id, result)
 
 	// Capture the parent span context for linking.
 	parentSpanCtx := trace.SpanContextFromContext(ctx)
@@ -143,10 +140,7 @@ func (r *BackgroundTaskRegistry) SpawnTask(ctx context.Context, cfg TaskConfig, 
 
 // GetResult returns the result for a task ID, blocking until complete if wait is true.
 func (r *BackgroundTaskRegistry) GetResult(taskID string, wait bool) (*BackgroundTaskResult, bool) {
-	r.mu.RLock()
-	result, ok := r.tasks[taskID]
-	r.mu.RUnlock()
-
+	result, ok := r.tasks.Get(taskID)
 	if !ok {
 		return nil, false
 	}

--- a/tools/testdata/cmd_safety.golden
+++ b/tools/testdata/cmd_safety.golden
@@ -1,0 +1,7 @@
+ls -la → safe=true blocked=false
+git status → safe=true blocked=false
+sudo rm -rf / → safe=false blocked=true (blocked command: sudo  commands are not allowed)
+go test ./... → safe=false blocked=false
+nmap 192.168.1.0/24 → safe=false blocked=true (blocked command: nmap  commands are not allowed)
+echo hello → safe=true blocked=false
+pip install requests → safe=false blocked=true (blocked command: pip install  commands are not allowed)

--- a/tools/testdata/compaction_summary.golden
+++ b/tools/testdata/compaction_summary.golden
@@ -1,0 +1,6 @@
+[SESSION STATE after context compaction]
+Files read: config.go, main.go
+Patterns searched: TODO
+Edits applied: main.go (2)
+Commands run: go test ./...
+Do NOT re-read files listed above unless you need to verify your edits.

--- a/tools/testdata/multiedit_result.golden
+++ b/tools/testdata/multiedit_result.golden
@@ -1,0 +1,3 @@
+updated src/main.go: 3 edit(s) applied, 2 failed
+  edit[2]: text not found (old="nonexistent text")
+  edit[5]: old string is empty (old="")

--- a/tools/testdata/truncate_to_lines.golden
+++ b/tools/testdata/truncate_to_lines.golden
@@ -1,0 +1,11 @@
+line 1
+line 2
+line 3
+line 4
+line 5
+
+... [12 lines omitted — use Read with offset/limit] ...
+
+line 8
+line 9
+line 0

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -58,8 +58,9 @@ type editDeadlineKeyType struct{}
 
 // mutatingTools are tools that legitimately chain in long sequences.
 var mutatingTools = map[string]bool{
-	"Edit":  true,
-	"Write": true,
+	"Edit":      true,
+	"MultiEdit": true,
+	"Write":     true,
 }
 
 var highRepeatTools = map[string]bool{
@@ -196,7 +197,7 @@ func (e *EditEnforcer) CheckNames(names []string) bool {
 		return false
 	}
 	for _, name := range names {
-		if name == "Edit" {
+		if name == "Edit" || name == "MultiEdit" {
 			e.editSeen = true
 			return false
 		}
@@ -217,6 +218,8 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	ctx = InitReadCache(ctx)
 	ctx = InitIterationCounter(ctx)
 	ctx = InitTokenCalibration(ctx)
+	ctx = InitFileTracker(ctx)
+	ctx = InitBgCommandRegistry(ctx)
 
 	handlers, toolDefs := BuildHandlers(workingDir, taskCfg, ex)
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
@@ -230,7 +233,10 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	if done {
 		return lastContent, nil
 	}
-	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) {
+	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) &&
+		!errors.Is(loopErr, ErrIterationLimitReached) &&
+		!errors.Is(loopErr, ErrLoopDetected) &&
+		!errors.Is(loopErr, ErrEditDeadlineReached) {
 		span.RecordError(loopErr)
 		span.SetStatus(codes.Error, loopErr.Error())
 		return lastContent, loopErr
@@ -339,6 +345,7 @@ func budgetWarningMessage(pctInt int, remaining float64) string {
 func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter, editDeadline int, m *metrics.Metrics, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
 	var lastContent string
 	var repeat RepeatTracker
+	var loopDetector LoopDetector
 	editEnforcer := NewEditEnforcer(editDeadline)
 	phaseEnforcer := NewPhaseEnforcer(defaultPhaseNudgeIters)
 	budgetWarned := make([]bool, len(budgetWarningThresholds))
@@ -381,11 +388,18 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		}
 
 		if checkEditDeadline(ctx, editEnforcer, mergedToolCalls) {
-			break
+			return lastContent, messages, ErrEditDeadlineReached, false
 		}
 
 		messages = appendToolCallMessage(messages, mergedContent, mergedToolCalls, ctx)
 		messages = executeToolCalls(ctx, messages, mergedToolCalls, handlers)
+
+		// Feed tool results into loop detector.
+		loopDetector.Record(mergedToolCalls, extractToolResults(messages))
+		if loopDetector.Stuck() {
+			logging.InfoContext(ctx, "loop detected: agent repeating identical tool calls with same results, stopping")
+			return lastContent, messages, ErrLoopDetected, false
+		}
 
 		if m != nil && m.BudgetExceeded() {
 			logging.InfoContext(ctx, "budget exceeded ($%.4f >= $%.4f max), stopping tool loop", m.TotalCostWithChildren(), m.MaxCost)
@@ -397,7 +411,23 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		messages = injectBudgetWarnings(ctx, m, budgetWarned, messages)
 		messages = compactMessages(ctx, messages)
 	}
-	return lastContent, messages, nil, false
+	return lastContent, messages, ErrIterationLimitReached, false
+}
+
+// extractToolResults pulls tool call IDs and their result content from the
+// last message in the conversation (which should be the tool-result message).
+func extractToolResults(messages []llms.MessageContent) map[string]string {
+	results := make(map[string]string)
+	if len(messages) == 0 {
+		return results
+	}
+	last := messages[len(messages)-1]
+	for _, part := range last.Parts {
+		if tcr, ok := part.(llms.ToolCallResponse); ok {
+			results[tcr.ToolCallID] = tcr.Content
+		}
+	}
+	return results
 }
 
 func extractTokenUsage(gi map[string]any, m *metrics.Metrics, ctx ...context.Context) {
@@ -596,10 +626,12 @@ func appendToolCallMessage(messages []llms.MessageContent, textContent string, t
 // serialTools are tools that must not run concurrently because they
 // mutate shared state (filesystem, executor) in order-dependent ways.
 var serialTools = map[string]bool{
-	"Bash":  true,
-	"Edit":  true,
-	"Write": true,
-	"Task":  true,
+	"Bash":           true,
+	"BashBackground": true,
+	"Edit":           true,
+	"MultiEdit":      true,
+	"Write":          true,
+	"Task":           true,
 }
 
 func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]Handler) []llms.MessageContent {
@@ -708,10 +740,11 @@ func argString(args map[string]interface{}, keys ...string) string {
 
 // simpleArgKeys maps tool names to the single arg key that summarizes them.
 var simpleArgKeys = map[string]string{
-	"Read":  "path",
-	"Write": "path",
-	"Edit":  "path",
-	"Glob":  "pattern",
+	"Read":      "path",
+	"Write":     "path",
+	"Edit":      "path",
+	"MultiEdit": "path",
+	"Glob":      "pattern",
 }
 
 func toolArgsSummary(toolName, argsJSON string) string {
@@ -763,6 +796,9 @@ func BuildHandlers(workingDir string, taskCfg *TaskConfig, ex executor.Executor)
 	add(Handler{Def: definitionGlob(), Call: globTool(workingDir)})
 	add(Handler{Def: definitionGrep(), Call: grepTool(workingDir)})
 	add(Handler{Def: definitionBash(), Call: bashTool(ex)})
+	add(Handler{Def: definitionBashBg(), Call: bashBackgroundTool(ex)})
+	add(Handler{Def: definitionBashOutput(), Call: bashOutputTool()})
+	add(Handler{Def: definitionMultiEdit(), Call: trackEdits(multiEditTool(workingDir))})
 	add(Handler{Def: definitionSystemInfo(), Call: systemInfoTool(ex)})
 	add(Handler{Def: definitionRepoMap(), Call: repoMapTool(workingDir)})
 
@@ -938,6 +974,11 @@ func readTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 			return "", err
 		}
 
+		// Record that this file was read (for edit safety checks).
+		if ft := GetFileTracker(ctx); ft != nil {
+			ft.RecordRead(path)
+		}
+
 		// If using offset/limit, skip cache and smart truncation — targeted read.
 		if payload.Offset > 0 || payload.Limit > 0 {
 			return sliceLines(data, payload.Offset, payload.Limit), nil
@@ -1064,7 +1105,7 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		New        string   `json:"new"`
 		ReplaceAll FlexBool `json:"replace_all"`
 	}
-	return func(_ context.Context, rawArgs []byte) (string, error) {
+	return func(ctx context.Context, rawArgs []byte) (string, error) {
 		var payload args
 		if err := json.Unmarshal(rawArgs, &payload); err != nil {
 			return "", fmt.Errorf("invalid args: %w", err)
@@ -1072,6 +1113,11 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		path, err := ResolvePath(workingDir, payload.Path)
 		if err != nil {
 			return "", err
+		}
+		if ft := GetFileTracker(ctx); ft != nil {
+			if err := ft.ValidateBeforeEdit(path); err != nil {
+				return "", err
+			}
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -1272,6 +1318,10 @@ func bashTool(ex executor.Executor) func(ctx context.Context, rawArgs []byte) (s
 		command := strings.TrimSpace(payload.Command)
 		if command == "" {
 			return "", fmt.Errorf("command is required")
+		}
+
+		if blocked, reason := IsBlockedCommand(command); blocked {
+			return "", fmt.Errorf("%s", reason)
 		}
 
 		// Add executor metadata to the current span so traces show

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2284,3 +2284,92 @@ func TestToolLoopNoBudgetWarningsWithoutMaxCost(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractToolResults(t *testing.T) {
+	t.Parallel()
+	// Empty messages.
+	r := extractToolResults(nil)
+	if len(r) != 0 {
+		t.Fatal("expected empty map for nil messages")
+	}
+
+	// Messages with tool call responses.
+	messages := []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeTool,
+			Parts: []llms.ContentPart{
+				llms.ToolCallResponse{ToolCallID: "1", Content: "output1"},
+				llms.ToolCallResponse{ToolCallID: "2", Content: "output2"},
+			},
+		},
+	}
+	r = extractToolResults(messages)
+	if len(r) != 2 || r["1"] != "output1" || r["2"] != "output2" {
+		t.Fatalf("unexpected results: %v", r)
+	}
+
+	// Non-tool-call-response parts are ignored.
+	messages = []llms.MessageContent{
+		{
+			Role: llms.ChatMessageTypeAI,
+			Parts: []llms.ContentPart{
+				llms.TextContent{Text: "hello"},
+			},
+		},
+	}
+	r = extractToolResults(messages)
+	if len(r) != 0 {
+		t.Fatal("expected empty map for non-tool messages")
+	}
+}
+
+func TestBashTool_BlockedCommand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ex := &executor.LocalExecutor{WorkingDir: dir}
+	tool := bashTool(ex)
+	args, _ := json.Marshal(map[string]string{"command": "sudo rm -rf /"})
+	_, err := tool(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected error for blocked command")
+	}
+}
+
+func TestReadTool_FileTracker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := InitFileTracker(context.Background())
+	ft := GetFileTracker(ctx)
+
+	tool := readTool(dir)
+	args, _ := json.Marshal(map[string]string{"path": "test.go"})
+	_, err := tool(ctx, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the file was recorded as read.
+	if ft.LastReadTime(filepath.Join(dir, "test.go")).IsZero() {
+		t.Fatal("expected file to be recorded as read")
+	}
+}
+
+func TestEditTool_FileTrackerValidation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.go"), []byte("hello world\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := InitFileTracker(context.Background())
+
+	// Try to edit without reading first — should fail.
+	tool := editTool(dir)
+	args, _ := json.Marshal(map[string]any{"path": "test.go", "old": "hello", "new": "goodbye"})
+	_, err := tool(ctx, args)
+	if err == nil {
+		t.Fatal("expected error when editing without reading first")
+	}
+}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -200,8 +200,8 @@ func TestBuildHandlers(t *testing.T) {
 		extra    []Handler
 		wantDefs int
 	}{
-		{"without TaskConfig", false, nil, 8},
-		{"with TaskConfig", true, nil, 9},
+		{"without TaskConfig", false, nil, 11},
+		{"with TaskConfig", true, nil, 12},
 		{"with ExtraTools", true, []Handler{
 			{
 				Def: llms.Tool{
@@ -215,7 +215,7 @@ func TestBuildHandlers(t *testing.T) {
 					return "ok", nil
 				},
 			},
-		}, 10},
+		}, 13},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1641,9 +1641,7 @@ func TestTaskResultToolWithParentMetrics(t *testing.T) {
 	}
 	close(result.Done)
 
-	registry.mu.Lock()
-	registry.tasks["bg-test"] = result
-	registry.mu.Unlock()
+	registry.tasks.Set("bg-test", result)
 
 	cfg := TaskConfig{
 		AgentsDir:     "agents",
@@ -1692,8 +1690,8 @@ func TestBuildHandlersWithRegistry(t *testing.T) {
 	if _, ok := handlers["TaskResult"]; !ok {
 		t.Fatalf("expected TaskResult handler when registry is set")
 	}
-	if len(defs) != 10 {
-		t.Fatalf("tool defs = %d, want 10 (8 base + Task + TaskResult)", len(defs))
+	if len(defs) != 13 {
+		t.Fatalf("tool defs = %d, want 13 (11 base + Task + TaskResult)", len(defs))
 	}
 }
 
@@ -1797,9 +1795,9 @@ func TestBuildHandlersWithFindings(t *testing.T) {
 	if _, ok := handlers["ReportFinding"]; !ok {
 		t.Fatalf("expected ReportFinding handler when Findings store is set")
 	}
-	// 8 base + Task + TaskResult + ReportFinding = 11
-	if len(defs) != 11 {
-		t.Fatalf("tool defs = %d, want 11", len(defs))
+	// 11 base + Task + TaskResult + ReportFinding = 14
+	if len(defs) != 14 {
+		t.Fatalf("tool defs = %d, want 14", len(defs))
 	}
 
 	// Verify the handler actually works and attributes to the agent


### PR DESCRIPTION
**Key Changes:**

- Introduced generic thread-safe `Map` and `Value` containers in a new `csync` package
- Added background shell command support with the BashBackground/BashOutput tools
- Implemented command safety filtering and file tracking for safe concurrent edits
- Enhanced agent loop detection and improved tool efficiency logic

**Added:**

- Generic thread-safe containers - Added `csync.Map` and `csync.Value` types for safe concurrent access to maps and scalars, with full test coverage
- Background command execution - Implemented `tools/bgcmd.go` with BashBackground and BashOutput tools for managing and querying background shell commands, with registry and context integration
- Command safety enforcement - Added `tools/cmdsafety.go` to filter unsafe or destructive shell commands; provided safe/blocked command lists and test coverage
- File read tracking - Introduced `tools/filetracker.go` for tracking when files are read and preventing edits on stale or unread files
- Multi-edit tool - Added `tools/multiedit.go` to allow batching multiple find-and-replace edits in a single tool call, supporting partial success
- Agent loop detection - Implemented `tools/loopdetect.go` to monitor and prevent agents from repeating identical tool calls and results
- Sentinel errors - Defined common agent/tool errors in `tools/errors.go` for consistent error handling
- Golden file tests - Added `tools/golden_test.go` for output consistency across formatting and safety logic

**Changed:**

- Pipeline cost tracking - Refactored `pipeline/runner.go` to use `csync.Value` for thread-safe budget accounting
- Read cache concurrency - Updated `tools/efficiency.go` to use `csync.Map` for safe concurrent file read caching
- Background task registry - Modified `tools/task.go` to replace mutex-protected maps with `csync.Map`
- Tool orchestration and safety - Updated `tools/tools.go` to:
  - Register new tools (BashBackground, BashOutput, MultiEdit) and support for file tracking and background commands
  - Integrate command safety checks before executing Bash tools
  - Track file reads and validate edits using the file tracker
  - Support multi-edit batching and improved edit enforcement logic
  - Integrate loop detection into the tool loop to halt on repeated tool call/result patterns
- Test suites - Added or updated comprehensive tests for all new features and concurrency primitives, including edge cases and golden file validation

**Removed:**

- Manual mutex and map management for caches and registries in favor of the new csync containers across pipeline, tools, and task registry code