### PR TITLE
feat: unify squad run for composed (pipeline) and leaf agents

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,151 @@
+# Composed Agents: Unified `squad run` Entry Point
+
+## Goal
+
+Unify `squad run` and `squad pipeline run` so users don't need to know
+whether an agent is a single leaf or a composed pipeline. The agent's
+`agent.yaml` declares its own topology.
+
+```
+squad run --agent go-security-audit "Audit this repo"   # works for both
+```
+
+## Design
+
+### Manifest discrimination
+
+If `agent.yaml` has `stages` → composed agent (pipeline orchestrator).
+If `agent.yaml` has `entrypoint` → leaf agent (single model call).
+These are mutually exclusive; validation enforces this.
+
+**Leaf agent (unchanged):**
+
+```yaml
+name: go-security-resources
+version: 0.1.0
+models:
+  - model: claude-sonnet-4-6
+    provider: anthropic
+entrypoint: system.md
+wrapper: agent.md
+```
+
+**Composed agent (new):**
+
+```yaml
+name: go-security-audit
+version: 0.1.0
+description: Parallel security audit
+
+stages:
+  - name: audit
+    agents:
+      - go-security-injection
+      - go-security-resources
+
+gates:
+  - after: audit
+    command: "go build ./..."
+    on_failure: stop
+```
+
+### No synthesis stage (for now)
+
+A composed agent is purely an orchestrator — no entrypoint, no models,
+no wrapper. If synthesis is needed, add a final stage with a dedicated
+synthesis agent. This keeps the model simple and is additive later.
+
+### Architecture
+
+```
+cmd/squad/run.go RunE
+  ├─ findAgentDir() + LoadManifest()
+  ├─ leaf?     → runner.ExecuteRun() [unchanged]
+  └─ composed? → runComposedAgent()
+                    ├─ validateComposedFlags()
+                    ├─ manifestToPipeline()
+                    ├─ pl.Runner.Run()
+                    └─ outputReport()
+```
+
+### Package layout (no circular imports)
+
+- `agent/composed.go` — ComposedStage, ComposedGate types + Manifest
+  validation. No pipeline import.
+- `runner/composed.go` — manifestToPipeline() conversion + FindAgentDir
+  export. Imports both agent and pipeline.
+- `cmd/squad/run.go` — fork point + runComposedAgent(). Reuses
+  buildRunAgentFunc pattern from pipeline.go.
+
+### Incompatible flags (composed agents)
+
+These flags error with a clear message when used with composed agents:
+
+| Flag | Why incompatible |
+|------|-----------------|
+| `--system` | No single system prompt |
+| `--print-bundle` | No single bundle |
+| `--bundle-out` | No single bundle |
+| `--apply` | Pipeline manages output |
+| `--apply-fallback` | Pipeline manages output |
+| `--require-actionable` | Reports, not raw responses |
+| `--stream` | Multiple agents, ambiguous |
+
+Flags that DO work: `--model`/`--provider` (defaults for sub-agents
+without their own), `--max-cost`, `--max-iterations`, `--out`, `--json`,
+`--dry-run`, `--var`, `--working-dir`.
+
+### --dry-run for composed agents
+
+Validates pipeline structure, checks all sub-agents exist and parse,
+prints stage topology. No API calls.
+
+## Implementation
+
+### Phase 1: Manifest extension (`agent/composed.go`) ✅
+
+- [x] Define ComposedStage, ComposedGate, ComposedPreGate,
+      ComposedPartition types
+- [x] Add Stages, Gates, Description fields to Manifest
+- [x] Add IsComposed() bool method
+- [x] Add Validate() error method (stages XOR entrypoint)
+- [x] Call Validate() from LoadManifest()
+- [x] Tests in agent/composed_test.go
+
+### Phase 2: Conversion + FindAgentDir export (`runner/composed.go`) ✅
+
+- [x] Export FindAgentDir (rename from findAgentDir)
+- [x] Add ManifestToPipeline() conversion function
+- [x] Tests in runner/composed_test.go
+
+### Phase 3: Fork in run command (`cmd/squad/run.go`) ✅
+
+- [x] Load manifest before deciding path
+- [x] If composed → runComposedAgent()
+- [x] runComposedAgent(): validate flags, convert manifest, build
+      runner, execute, output report
+- [x] Reuse buildRunAgentFunc pattern from pipeline.go
+- [x] Handle --dry-run for composed agents
+
+### Phase 4: Tests + validation ✅
+
+- [x] Unit tests for manifest validation
+- [x] Unit tests for conversion
+- [x] Unit tests for flag validation
+- [x] Verify existing tests still pass
+
+### Phase 5: Remove `squad pipeline run` ✅
+
+- [x] Remove `newPipelineCmd()` and `newPipelineRunCmd()` — never released
+- [x] Remove pipeline command registration from root.go
+- [x] Keep reusable functions in pipeline.go (buildRunAgentFunc,
+      buildComposedRunOpts, outputReport, flagOrViper, mergeVars)
+- [x] Update pipeline_test.go for renamed functions
+- [x] Update docs (pipelines.md, observability.md) to use `squad run --agent`
+
+### What stays unchanged
+
+- `pipeline/runner.go` — all orchestration logic untouched
+- `pipeline/pipeline.go` — Pipeline type, validation, topo sort
+- Leaf agent manifests — fully backwards compatible
+- Agent resolution — source.Manager.FindAgent() unchanged

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ squad run --agent go-review --provider openai --model gpt-4.1-mini
 # Run with local Ollama
 squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
 
-# Run a multi-agent pipeline
-squad pipeline run security-audit.yaml "Review this codebase"
+# Run a composed (multi-agent) pipeline
+squad run --agent security-audit "Review this codebase"
 ```
 
 ## Documentation

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -659,3 +659,93 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		EditDeadline:  manifest.EditDeadline,
 	}, nil
 }
+
+// InlineAgentConfig holds the configuration for an agent defined inline
+// within a composed agent's stage.
+type InlineAgentConfig struct {
+	Name       string            // stage name, used as the agent identity
+	EntryPoint string            // path to system prompt, relative to base dir
+	Wrapper    string            // path to wrapper prompt, relative to base dir
+	Task       string            // path to task prompt, relative to base dir
+	Models     []ModelPreference // model preferences
+	References []string          // paths to reference files, relative to base dir
+}
+
+// resolveInlinePromptDir returns the directory containing the inline agent's
+// prompt files. It checks stages/<name>/ first (for stage-specific prompts),
+// then falls back to baseDir.
+func resolveInlinePromptDir(baseDir, name, entryPoint string) string {
+	stageDir := filepath.Join(baseDir, "stages", name)
+	if _, err := os.Stat(filepath.Join(stageDir, entryPoint)); err == nil {
+		return stageDir
+	}
+	return baseDir
+}
+
+// BuildBundleInline assembles a bundle from inline agent config.
+// baseDir is the composed agent's directory where prompt files live.
+// Files are resolved with progressive lookup: stages/<name>/ first, then baseDir.
+func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDir, mode string, vars map[string]string) (*Bundle, error) {
+	// Resolve the prompt directory: check stages/<name>/ first, then baseDir.
+	promptDir := resolveInlinePromptDir(baseDir, cfg.Name, cfg.EntryPoint)
+
+	manifest := &Manifest{
+		Name:       cfg.Name,
+		Version:    "inline",
+		EntryPoint: cfg.EntryPoint,
+		Wrapper:    cfg.Wrapper,
+		Task:       cfg.Task,
+		Models:     cfg.Models,
+		References: cfg.References,
+	}
+
+	displayMode := mode
+	if displayMode == "" {
+		displayMode = "edit"
+	}
+
+	data := TemplateData{Mode: mode, Vars: vars}
+	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(promptDir, baseDir, manifest, data)
+	if err != nil {
+		return nil, err
+	}
+
+	// References are resolved from baseDir (shared) or promptDir (stage-specific).
+	refs, err := loadReferences(promptDir, manifest.References)
+	if err != nil {
+		// Fall back to baseDir for shared references.
+		refs, err = loadReferences(baseDir, manifest.References)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sys := buildSystemMessage(manifest, displayMode, workingDir, wrapperContent, systemContent, taskContent, refs)
+
+	userMessage := prompt
+	if userMessage == "" {
+		userMessage = "Begin."
+	}
+
+	var combined bytes.Buffer
+	combined.Write(sys.Bytes())
+	combined.WriteString("\n\n## User Message\n\n")
+	combined.WriteString(userMessage)
+	combined.WriteString("\n")
+
+	var primaryModel, primaryProvider string
+	if len(manifest.Models) > 0 {
+		primaryModel = manifest.Models[0].Model
+		primaryProvider = manifest.Models[0].Provider
+	}
+
+	return &Bundle{
+		System:   sys.String(),
+		User:     userMessage,
+		Combined: combined.Bytes(),
+		WorkDir:  workingDir,
+		Model:    primaryModel,
+		Provider: primaryProvider,
+		Models:   manifest.Models,
+	}, nil
+}

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -27,14 +27,25 @@ type ModelPreference struct {
 }
 
 // Manifest represents the structure of an agent's manifest file.
+// A manifest is either a leaf agent (has entrypoint/wrapper) or a composed
+// agent (has stages). These are mutually exclusive; Validate() enforces this.
 type Manifest struct {
-	Name          string             `yaml:"name"`
-	Version       string             `yaml:"version"`
-	Models        []ModelPreference  `yaml:"models,omitempty"` // ranked model preferences
-	EntryPoint    string             `yaml:"entrypoint"`
-	Wrapper       string             `yaml:"wrapper"`
-	References    []string           `yaml:"references"`
-	Task          string             `yaml:"task,omitempty"`
+	Name        string `yaml:"name"`
+	Version     string `yaml:"version"`
+	Description string `yaml:"description,omitempty"`
+
+	// Leaf agent fields.
+	Models     []ModelPreference `yaml:"models,omitempty"` // ranked model preferences
+	EntryPoint string            `yaml:"entrypoint,omitempty"`
+	Wrapper    string            `yaml:"wrapper,omitempty"`
+	References []string          `yaml:"references,omitempty"`
+	Task       string            `yaml:"task,omitempty"`
+
+	// Composed agent fields.
+	Stages []ComposedStage `yaml:"stages,omitempty"`
+	Gates  []ComposedGate  `yaml:"gates,omitempty"`
+
+	// Shared fields.
 	Environment   *executor.Config   `yaml:"environment,omitempty"`
 	DependsOn     []string           `yaml:"depends_on,omitempty"`
 	Output        *OutputConfig      `yaml:"output,omitempty"`
@@ -262,6 +273,8 @@ func loadTask(agentPath, taskFile string) (string, error) {
 }
 
 // LoadManifest reads and parses the agent manifest from the given agent directory.
+// It validates the manifest structure, ensuring composed and leaf fields are
+// mutually exclusive.
 func LoadManifest(agentPath string) (*Manifest, error) {
 	manifestPath := filepath.Join(agentPath, "agent.yaml")
 	manifestData, err := os.ReadFile(manifestPath)
@@ -271,6 +284,9 @@ func LoadManifest(agentPath string) (*Manifest, error) {
 	var manifest Manifest
 	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse agent manifest: %w", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid agent manifest: %w", err)
 	}
 	return &manifest, nil
 }
@@ -461,7 +477,10 @@ func compactRepoSummary(workingDir string) string {
 	dirs := make(map[string]*dirInfo)
 	totalFiles := 0
 
-	_ = filepath.WalkDir(workingDir, repoSummaryVisitor(workingDir, dirs, &totalFiles))
+	if err := filepath.WalkDir(workingDir, repoSummaryVisitor(workingDir, dirs, &totalFiles)); err != nil {
+		logging.Warn("failed to walk working directory for repo summary: %v", err)
+		return ""
+	}
 
 	if totalFiles == 0 {
 		return ""

--- a/agent/bundle_internal_test.go
+++ b/agent/bundle_internal_test.go
@@ -454,6 +454,32 @@ func TestBuildBundleInline_WithVars(t *testing.T) {
 	}
 }
 
+func TestBuildBundleInline_ReferenceFallbackToBaseDir(t *testing.T) {
+	t.Parallel()
+	// Put prompts in a stage subdir but references only in baseDir.
+	// This exercises the reference fallback path (lines 715-720).
+	baseDir := setupInlineDir(t, map[string]string{
+		"stages/fallback-stage/system.md": "stage system",
+		"stages/fallback-stage/agent.md":  "stage wrapper",
+		"shared-ref.md":                   "shared reference content",
+	})
+
+	cfg := &InlineAgentConfig{
+		Name:       "fallback-stage",
+		EntryPoint: "system.md",
+		Wrapper:    "agent.md",
+		References: []string{"shared-ref.md"},
+	}
+
+	bundle, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "shared reference content") {
+		t.Error("expected shared reference content from baseDir fallback")
+	}
+}
+
 func TestBuildBundleInline_MissingEntrypoint(t *testing.T) {
 	t.Parallel()
 	baseDir := t.TempDir()

--- a/agent/bundle_internal_test.go
+++ b/agent/bundle_internal_test.go
@@ -281,6 +281,190 @@ func TestCompactRepoSummary(t *testing.T) {
 	})
 }
 
+func TestResolveInlinePromptDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stage dir exists with entrypoint", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		stageDir := filepath.Join(baseDir, "stages", "my-stage")
+		if err := os.MkdirAll(stageDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(stageDir, "system.md"), []byte("stage system"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := resolveInlinePromptDir(baseDir, "my-stage", "system.md")
+		if got != stageDir {
+			t.Fatalf("expected %q, got %q", stageDir, got)
+		}
+	})
+
+	t.Run("stage dir missing falls back to baseDir", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+
+		got := resolveInlinePromptDir(baseDir, "no-stage", "system.md")
+		if got != baseDir {
+			t.Fatalf("expected %q, got %q", baseDir, got)
+		}
+	})
+
+	t.Run("stage dir exists but no entrypoint falls back", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		stageDir := filepath.Join(baseDir, "stages", "my-stage")
+		if err := os.MkdirAll(stageDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got := resolveInlinePromptDir(baseDir, "my-stage", "system.md")
+		if got != baseDir {
+			t.Fatalf("expected fallback to %q, got %q", baseDir, got)
+		}
+	})
+}
+
+// setupInlineDir creates a temp dir with the given files for inline agent tests.
+func setupInlineDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	baseDir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(baseDir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return baseDir
+}
+
+func TestBuildBundleInline_Basic(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{
+		"system.md": "inline system prompt",
+		"agent.md":  "inline wrapper",
+	})
+
+	cfg := &InlineAgentConfig{Name: "test-inline", EntryPoint: "system.md", Wrapper: "agent.md"}
+	bundle, err := BuildBundleInline(baseDir, cfg, "review this", "/tmp/work", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "inline system prompt") {
+		t.Error("expected system prompt content")
+	}
+	if !strings.Contains(bundle.System, "inline wrapper") {
+		t.Error("expected wrapper content")
+	}
+	if bundle.User != "review this" {
+		t.Errorf("User = %q, want 'review this'", bundle.User)
+	}
+	if bundle.WorkDir != "/tmp/work" {
+		t.Errorf("WorkDir = %q, want '/tmp/work'", bundle.WorkDir)
+	}
+}
+
+func TestBuildBundleInline_EmptyPrompt(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{"system.md": "sys", "agent.md": "wrap"})
+
+	cfg := &InlineAgentConfig{Name: "test-inline", EntryPoint: "system.md", Wrapper: "agent.md"}
+	bundle, err := BuildBundleInline(baseDir, cfg, "", "/tmp", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.User != "Begin." {
+		t.Errorf("User = %q, want 'Begin.'", bundle.User)
+	}
+}
+
+func TestBuildBundleInline_WithModels(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{"system.md": "sys", "agent.md": "wrap"})
+
+	cfg := &InlineAgentConfig{
+		Name: "test-inline", EntryPoint: "system.md", Wrapper: "agent.md",
+		Models: []ModelPreference{{Model: "gpt-4", Provider: "openai"}},
+	}
+	bundle, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.Model != "gpt-4" {
+		t.Errorf("Model = %q, want gpt-4", bundle.Model)
+	}
+	if bundle.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai", bundle.Provider)
+	}
+}
+
+func TestBuildBundleInline_WithReferences(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{
+		"system.md": "sys", "agent.md": "wrap", "ref.md": "reference content",
+	})
+
+	cfg := &InlineAgentConfig{
+		Name: "test-inline", EntryPoint: "system.md", Wrapper: "agent.md",
+		References: []string{"ref.md"},
+	}
+	bundle, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "reference content") {
+		t.Error("expected reference content in system prompt")
+	}
+}
+
+func TestBuildBundleInline_StageSpecificPrompts(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{
+		"stages/my-stage/system.md": "stage-specific system",
+		"stages/my-stage/agent.md":  "stage-specific wrapper",
+	})
+
+	cfg := &InlineAgentConfig{Name: "my-stage", EntryPoint: "system.md", Wrapper: "agent.md"}
+	bundle, err := BuildBundleInline(baseDir, cfg, "test", "/tmp", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "stage-specific system") {
+		t.Error("expected stage-specific system content")
+	}
+}
+
+func TestBuildBundleInline_WithVars(t *testing.T) {
+	t.Parallel()
+	baseDir := setupInlineDir(t, map[string]string{
+		"system.md": "target: {{.Vars.TARGET}}", "agent.md": "wrap",
+	})
+
+	cfg := &InlineAgentConfig{Name: "test-inline", EntryPoint: "system.md", Wrapper: "agent.md"}
+	bundle, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", map[string]string{"TARGET": "85"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "target: 85") {
+		t.Error("expected vars to be expanded in system prompt")
+	}
+}
+
+func TestBuildBundleInline_MissingEntrypoint(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+
+	cfg := &InlineAgentConfig{Name: "test-inline", EntryPoint: "missing.md", Wrapper: "agent.md"}
+	_, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", nil)
+	if err == nil {
+		t.Fatal("expected error for missing entrypoint")
+	}
+}
+
 // fakeDirEntry implements fs.DirEntry for testing.
 type fakeDirEntry struct {
 	fname string

--- a/agent/composed.go
+++ b/agent/composed.go
@@ -5,6 +5,9 @@ import "fmt"
 // ComposedStage defines a unit of work in a composed agent.
 // It mirrors pipeline.Stage but lives in the agent package to avoid
 // circular imports between agent and pipeline.
+//
+// A stage can either reference external agents (agent/agents fields) or define
+// an inline agent (entrypoint/wrapper/models fields). These are mutually exclusive.
 type ComposedStage struct {
 	Name            string             `yaml:"name"`
 	Agent           string             `yaml:"agent,omitempty"`
@@ -18,10 +21,27 @@ type ComposedStage struct {
 	Partition       *ComposedPartition `yaml:"partition,omitempty"`
 	Summarize       string             `yaml:"summarize,omitempty"`
 	SummarizePrompt string             `yaml:"summarize_prompt,omitempty"`
+
+	// Inline agent fields — define the agent directly in the stage.
+	// When set, agent/agents must be empty.
+	EntryPoint string            `yaml:"entrypoint,omitempty"`
+	Wrapper    string            `yaml:"wrapper,omitempty"`
+	Task       string            `yaml:"task,omitempty"`
+	Models     []ModelPreference `yaml:"models,omitempty"`
+	References []string          `yaml:"references,omitempty"`
+}
+
+// IsInline returns true if the stage defines an inline agent.
+func (s ComposedStage) IsInline() bool {
+	return s.EntryPoint != ""
 }
 
 // AgentList returns all agents in the stage (normalizing single vs parallel).
+// For inline stages, the stage name is used as the agent name.
 func (s ComposedStage) AgentList() []string {
+	if s.IsInline() {
+		return []string{s.Name}
+	}
 	if s.Agent != "" {
 		return []string{s.Agent}
 	}
@@ -104,28 +124,52 @@ func (m *Manifest) validateComposedStages() (map[string]bool, error) {
 		}
 		stageNames[s.Name] = true
 
-		if len(s.AgentList()) == 0 {
-			return nil, fmt.Errorf("composed agent %q: stage %q: must specify agent or agents", m.Name, s.Name)
+		if err := m.validateStageAgents(s); err != nil {
+			return nil, err
 		}
-		if s.Agent != "" && len(s.Agents) > 0 {
-			return nil, fmt.Errorf("composed agent %q: stage %q: cannot specify both agent and agents", m.Name, s.Name)
-		}
-		if s.Partition != nil {
-			if s.Agent == "" {
-				return nil, fmt.Errorf("composed agent %q: stage %q: partition requires a single agent", m.Name, s.Name)
-			}
-			if s.Partition.By != "files" {
-				return nil, fmt.Errorf("composed agent %q: stage %q: partition.by must be \"files\"", m.Name, s.Name)
-			}
-			if s.Partition.Glob == "" {
-				return nil, fmt.Errorf("composed agent %q: stage %q: partition.glob is required", m.Name, s.Name)
-			}
+		if err := m.validateStagePartition(s); err != nil {
+			return nil, err
 		}
 		if s.Summarize != "" && s.Summarize != "auto" && s.Summarize != "always" && s.Summarize != "never" {
 			return nil, fmt.Errorf("composed agent %q: stage %q: summarize must be auto, always, or never", m.Name, s.Name)
 		}
 	}
 	return stageNames, nil
+}
+
+func (m *Manifest) validateStageAgents(s ComposedStage) error {
+	hasExternal := s.Agent != "" || len(s.Agents) > 0
+	hasInline := s.IsInline()
+
+	if !hasExternal && !hasInline {
+		return fmt.Errorf("composed agent %q: stage %q: must specify agent, agents, or inline entrypoint", m.Name, s.Name)
+	}
+	if hasExternal && hasInline {
+		return fmt.Errorf("composed agent %q: stage %q: cannot specify both agent/agents and inline entrypoint", m.Name, s.Name)
+	}
+	if s.Agent != "" && len(s.Agents) > 0 {
+		return fmt.Errorf("composed agent %q: stage %q: cannot specify both agent and agents", m.Name, s.Name)
+	}
+	if hasInline && s.Wrapper == "" {
+		return fmt.Errorf("composed agent %q: stage %q: inline agent requires wrapper", m.Name, s.Name)
+	}
+	return nil
+}
+
+func (m *Manifest) validateStagePartition(s ComposedStage) error {
+	if s.Partition == nil {
+		return nil
+	}
+	if s.Agent == "" {
+		return fmt.Errorf("composed agent %q: stage %q: partition requires a single agent", m.Name, s.Name)
+	}
+	if s.Partition.By != "files" {
+		return fmt.Errorf("composed agent %q: stage %q: partition.by must be \"files\"", m.Name, s.Name)
+	}
+	if s.Partition.Glob == "" {
+		return fmt.Errorf("composed agent %q: stage %q: partition.glob is required", m.Name, s.Name)
+	}
+	return nil
 }
 
 func (m *Manifest) validateComposedDeps(stageNames map[string]bool) error {

--- a/agent/composed.go
+++ b/agent/composed.go
@@ -1,0 +1,205 @@
+package agent
+
+import "fmt"
+
+// ComposedStage defines a unit of work in a composed agent.
+// It mirrors pipeline.Stage but lives in the agent package to avoid
+// circular imports between agent and pipeline.
+type ComposedStage struct {
+	Name            string             `yaml:"name"`
+	Agent           string             `yaml:"agent,omitempty"`
+	Agents          []string           `yaml:"agents,omitempty"`
+	DependsOn       []string           `yaml:"depends_on,omitempty"`
+	Mode            string             `yaml:"mode,omitempty"`
+	Vars            map[string]string  `yaml:"vars,omitempty"`
+	Condition       string             `yaml:"condition,omitempty"`
+	PreGates        []ComposedPreGate  `yaml:"pre_gates,omitempty"`
+	MaxCost         float64            `yaml:"max_cost,omitempty"`
+	Partition       *ComposedPartition `yaml:"partition,omitempty"`
+	Summarize       string             `yaml:"summarize,omitempty"`
+	SummarizePrompt string             `yaml:"summarize_prompt,omitempty"`
+}
+
+// AgentList returns all agents in the stage (normalizing single vs parallel).
+func (s ComposedStage) AgentList() []string {
+	if s.Agent != "" {
+		return []string{s.Agent}
+	}
+	return s.Agents
+}
+
+// ComposedGate defines a regression check between composed agent stages.
+type ComposedGate struct {
+	After     string `yaml:"after"`
+	Command   string `yaml:"command"`
+	OnFailure string `yaml:"on_failure,omitempty"`
+}
+
+// ComposedPreGate runs a command before an agent and injects output into the prompt.
+type ComposedPreGate struct {
+	Command string `yaml:"command"`
+	Label   string `yaml:"label,omitempty"`
+	OnError string `yaml:"on_error,omitempty"`
+}
+
+// ComposedPartition configures automatic work splitting for a composed stage.
+type ComposedPartition struct {
+	By              string `yaml:"by"`
+	Glob            string `yaml:"glob"`
+	MaxPerPartition int    `yaml:"max_per_partition"`
+}
+
+// IsComposed returns true if the manifest declares a composed agent
+// (has stages rather than an entrypoint).
+func (m *Manifest) IsComposed() bool {
+	return len(m.Stages) > 0
+}
+
+// Validate checks the manifest for structural errors.
+// Composed manifests (with stages) must not have entrypoint/wrapper.
+// Leaf manifests (with entrypoint) must not have stages.
+func (m *Manifest) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("manifest name is required")
+	}
+
+	if m.IsComposed() {
+		return m.validateComposed()
+	}
+	return m.validateLeaf()
+}
+
+func (m *Manifest) validateComposed() error {
+	if m.EntryPoint != "" {
+		return fmt.Errorf("composed agent %q: cannot have entrypoint (has stages)", m.Name)
+	}
+	if m.Wrapper != "" {
+		return fmt.Errorf("composed agent %q: cannot have wrapper (has stages)", m.Name)
+	}
+	if len(m.Models) > 0 {
+		return fmt.Errorf("composed agent %q: cannot have models (sub-agents declare their own)", m.Name)
+	}
+	if m.Task != "" {
+		return fmt.Errorf("composed agent %q: cannot have task (has stages)", m.Name)
+	}
+
+	stageNames, err := m.validateComposedStages()
+	if err != nil {
+		return err
+	}
+	if err := m.validateComposedDeps(stageNames); err != nil {
+		return err
+	}
+	return m.validateComposedGates(stageNames)
+}
+
+func (m *Manifest) validateComposedStages() (map[string]bool, error) {
+	stageNames := make(map[string]bool, len(m.Stages))
+	for i, s := range m.Stages {
+		if s.Name == "" {
+			return nil, fmt.Errorf("composed agent %q: stage %d: name is required", m.Name, i)
+		}
+		if stageNames[s.Name] {
+			return nil, fmt.Errorf("composed agent %q: duplicate stage name: %q", m.Name, s.Name)
+		}
+		stageNames[s.Name] = true
+
+		if len(s.AgentList()) == 0 {
+			return nil, fmt.Errorf("composed agent %q: stage %q: must specify agent or agents", m.Name, s.Name)
+		}
+		if s.Agent != "" && len(s.Agents) > 0 {
+			return nil, fmt.Errorf("composed agent %q: stage %q: cannot specify both agent and agents", m.Name, s.Name)
+		}
+		if s.Partition != nil {
+			if s.Agent == "" {
+				return nil, fmt.Errorf("composed agent %q: stage %q: partition requires a single agent", m.Name, s.Name)
+			}
+			if s.Partition.By != "files" {
+				return nil, fmt.Errorf("composed agent %q: stage %q: partition.by must be \"files\"", m.Name, s.Name)
+			}
+			if s.Partition.Glob == "" {
+				return nil, fmt.Errorf("composed agent %q: stage %q: partition.glob is required", m.Name, s.Name)
+			}
+		}
+		if s.Summarize != "" && s.Summarize != "auto" && s.Summarize != "always" && s.Summarize != "never" {
+			return nil, fmt.Errorf("composed agent %q: stage %q: summarize must be auto, always, or never", m.Name, s.Name)
+		}
+	}
+	return stageNames, nil
+}
+
+func (m *Manifest) validateComposedDeps(stageNames map[string]bool) error {
+	for _, s := range m.Stages {
+		for _, dep := range s.DependsOn {
+			if !stageNames[dep] {
+				return fmt.Errorf("composed agent %q: stage %q depends on unknown stage %q", m.Name, s.Name, dep)
+			}
+			if dep == s.Name {
+				return fmt.Errorf("composed agent %q: stage %q depends on itself", m.Name, s.Name)
+			}
+		}
+	}
+	return m.detectComposedCycle()
+}
+
+func (m *Manifest) detectComposedCycle() error {
+	adj := make(map[string][]string, len(m.Stages))
+	for _, s := range m.Stages {
+		adj[s.Name] = s.DependsOn
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(m.Stages))
+
+	var visit func(string) error
+	visit = func(name string) error {
+		color[name] = gray
+		for _, dep := range adj[name] {
+			switch color[dep] {
+			case gray:
+				return fmt.Errorf("composed agent %q: cycle detected: %s -> %s", m.Name, name, dep)
+			case white:
+				if err := visit(dep); err != nil {
+					return err
+				}
+			}
+		}
+		color[name] = black
+		return nil
+	}
+
+	for _, s := range m.Stages {
+		if color[s.Name] == white {
+			if err := visit(s.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manifest) validateComposedGates(stageNames map[string]bool) error {
+	for _, g := range m.Gates {
+		if !stageNames[g.After] {
+			return fmt.Errorf("composed agent %q: gate references unknown stage %q", m.Name, g.After)
+		}
+		if g.Command == "" {
+			return fmt.Errorf("composed agent %q: gate after %q: command is required", m.Name, g.After)
+		}
+	}
+	return nil
+}
+
+func (m *Manifest) validateLeaf() error {
+	if m.EntryPoint == "" {
+		return fmt.Errorf("agent %q: entrypoint is required", m.Name)
+	}
+	if m.Wrapper == "" {
+		return fmt.Errorf("agent %q: wrapper is required", m.Name)
+	}
+	return nil
+}

--- a/agent/composed_test.go
+++ b/agent/composed_test.go
@@ -347,6 +347,62 @@ func TestValidate_ComposedPartitionRequiresSingleAgent(t *testing.T) {
 	}
 }
 
+func TestValidate_ComposedPartitionInvalidBy(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{
+				Name:      "s1",
+				Agent:     "a1",
+				Partition: &ComposedPartition{By: "lines", Glob: "*.go"},
+			},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid partition.by")
+	}
+	if !strings.Contains(err.Error(), "partition.by must be") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedPartitionMissingGlob(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{
+				Name:      "s1",
+				Agent:     "a1",
+				Partition: &ComposedPartition{By: "files"},
+			},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing partition.glob")
+	}
+	if !strings.Contains(err.Error(), "partition.glob is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedStageNameRequired(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Agent: "a1"},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for stage without name")
+	}
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidate_LeafValid(t *testing.T) {
 	m := &Manifest{
 		Name:       "leaf",

--- a/agent/composed_test.go
+++ b/agent/composed_test.go
@@ -1,0 +1,430 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsComposed_WithStages(t *testing.T) {
+	m := &Manifest{
+		Name: "composed",
+		Stages: []ComposedStage{
+			{Name: "audit", Agents: []string{"a1", "a2"}},
+		},
+	}
+	if !m.IsComposed() {
+		t.Fatal("expected IsComposed() == true for manifest with stages")
+	}
+}
+
+func TestIsComposed_WithoutStages(t *testing.T) {
+	m := &Manifest{
+		Name:       "leaf",
+		EntryPoint: "system.md",
+		Wrapper:    "agent.md",
+	}
+	if m.IsComposed() {
+		t.Fatal("expected IsComposed() == false for leaf manifest")
+	}
+}
+
+func TestValidate_ComposedValid(t *testing.T) {
+	m := &Manifest{
+		Name:    "composed",
+		Version: "1.0",
+		Stages: []ComposedStage{
+			{Name: "analyze", Agents: []string{"a1", "a2"}},
+			{Name: "fix", Agent: "fixer", DependsOn: []string{"analyze"}},
+		},
+		Gates: []ComposedGate{
+			{After: "fix", Command: "go build ./..."},
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid composed manifest, got: %v", err)
+	}
+}
+
+func TestValidate_ComposedRejectsEntrypoint(t *testing.T) {
+	m := &Manifest{
+		Name:       "bad",
+		EntryPoint: "system.md",
+		Stages:     []ComposedStage{{Name: "s1", Agent: "a1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for composed manifest with entrypoint")
+	}
+	if !strings.Contains(err.Error(), "cannot have entrypoint") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedRejectsWrapper(t *testing.T) {
+	m := &Manifest{
+		Name:    "bad",
+		Wrapper: "agent.md",
+		Stages:  []ComposedStage{{Name: "s1", Agent: "a1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for composed manifest with wrapper")
+	}
+	if !strings.Contains(err.Error(), "cannot have wrapper") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedRejectsModels(t *testing.T) {
+	m := &Manifest{
+		Name:   "bad",
+		Models: []ModelPreference{{Model: "gpt-4", Provider: "openai"}},
+		Stages: []ComposedStage{{Name: "s1", Agent: "a1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for composed manifest with models")
+	}
+	if !strings.Contains(err.Error(), "cannot have models") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedRejectsTask(t *testing.T) {
+	m := &Manifest{
+		Name:   "bad",
+		Task:   "task.md",
+		Stages: []ComposedStage{{Name: "s1", Agent: "a1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for composed manifest with task")
+	}
+	if !strings.Contains(err.Error(), "cannot have task") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedDuplicateStage(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1"},
+			{Name: "s1", Agent: "a2"},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for duplicate stage names")
+	}
+	if !strings.Contains(err.Error(), "duplicate stage name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedNoAgents(t *testing.T) {
+	m := &Manifest{
+		Name:   "bad",
+		Stages: []ComposedStage{{Name: "s1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for stage with no agents")
+	}
+	if !strings.Contains(err.Error(), "must specify agent or agents") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedBothAgentAndAgents(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1", Agents: []string{"a2"}},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for stage with both agent and agents")
+	}
+	if !strings.Contains(err.Error(), "cannot specify both") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedUnknownDep(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1", DependsOn: []string{"nonexistent"}},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown dependency")
+	}
+	if !strings.Contains(err.Error(), "unknown stage") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedSelfDep(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1", DependsOn: []string{"s1"}},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for self-dependency")
+	}
+	if !strings.Contains(err.Error(), "depends on itself") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedCycleDetection(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{Name: "a", Agent: "a1", DependsOn: []string{"b"}},
+			{Name: "b", Agent: "a2", DependsOn: []string{"a"}},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for cycle")
+	}
+	if !strings.Contains(err.Error(), "cycle detected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedGateUnknownStage(t *testing.T) {
+	m := &Manifest{
+		Name:   "bad",
+		Stages: []ComposedStage{{Name: "s1", Agent: "a1"}},
+		Gates:  []ComposedGate{{After: "nonexistent", Command: "echo ok"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for gate referencing unknown stage")
+	}
+	if !strings.Contains(err.Error(), "unknown stage") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedGateNoCommand(t *testing.T) {
+	m := &Manifest{
+		Name:   "bad",
+		Stages: []ComposedStage{{Name: "s1", Agent: "a1"}},
+		Gates:  []ComposedGate{{After: "s1"}},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for gate with no command")
+	}
+	if !strings.Contains(err.Error(), "command is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedPartition(t *testing.T) {
+	m := &Manifest{
+		Name: "valid",
+		Stages: []ComposedStage{
+			{
+				Name:  "s1",
+				Agent: "a1",
+				Partition: &ComposedPartition{
+					By:              "files",
+					Glob:            "**/*.go",
+					MaxPerPartition: 20,
+				},
+			},
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid, got: %v", err)
+	}
+}
+
+func TestValidate_ComposedPartitionRequiresSingleAgent(t *testing.T) {
+	m := &Manifest{
+		Name: "bad",
+		Stages: []ComposedStage{
+			{
+				Name:      "s1",
+				Agents:    []string{"a1", "a2"},
+				Partition: &ComposedPartition{By: "files", Glob: "*.go"},
+			},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for partition with multiple agents")
+	}
+	if !strings.Contains(err.Error(), "partition requires a single agent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_LeafValid(t *testing.T) {
+	m := &Manifest{
+		Name:       "leaf",
+		Version:    "1.0",
+		EntryPoint: "system.md",
+		Wrapper:    "agent.md",
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected valid leaf manifest, got: %v", err)
+	}
+}
+
+func TestValidate_LeafMissingEntrypoint(t *testing.T) {
+	m := &Manifest{
+		Name:    "bad",
+		Wrapper: "agent.md",
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for leaf without entrypoint")
+	}
+	if !strings.Contains(err.Error(), "entrypoint is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_LeafMissingWrapper(t *testing.T) {
+	m := &Manifest{
+		Name:       "bad",
+		EntryPoint: "system.md",
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for leaf without wrapper")
+	}
+	if !strings.Contains(err.Error(), "wrapper is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_MissingName(t *testing.T) {
+	m := &Manifest{EntryPoint: "system.md", Wrapper: "agent.md"}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadManifest_ComposedFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "composed-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	yaml := `name: security-audit
+version: "1.0"
+description: Parallel security audit
+
+stages:
+  - name: scan
+    agents:
+      - injection-scanner
+      - resource-scanner
+  - name: fix
+    agent: auto-fixer
+    depends_on: [scan]
+    mode: edit
+
+gates:
+  - after: fix
+    command: "go build ./..."
+    on_failure: stop
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m, err := LoadManifest(agentDir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+
+	if !m.IsComposed() {
+		t.Fatal("expected IsComposed() == true")
+	}
+	if m.Name != "security-audit" {
+		t.Fatalf("expected name 'security-audit', got %q", m.Name)
+	}
+	if m.Description != "Parallel security audit" {
+		t.Fatalf("expected description, got %q", m.Description)
+	}
+	if len(m.Stages) != 2 {
+		t.Fatalf("expected 2 stages, got %d", len(m.Stages))
+	}
+	if len(m.Gates) != 1 {
+		t.Fatalf("expected 1 gate, got %d", len(m.Gates))
+	}
+
+	// Verify stage details.
+	if m.Stages[0].Name != "scan" {
+		t.Fatalf("expected stage 0 name 'scan', got %q", m.Stages[0].Name)
+	}
+	if len(m.Stages[0].Agents) != 2 {
+		t.Fatalf("expected 2 agents in scan stage, got %d", len(m.Stages[0].Agents))
+	}
+	if m.Stages[1].Agent != "auto-fixer" {
+		t.Fatalf("expected stage 1 agent 'auto-fixer', got %q", m.Stages[1].Agent)
+	}
+	if m.Stages[1].Mode != "edit" {
+		t.Fatalf("expected stage 1 mode 'edit', got %q", m.Stages[1].Mode)
+	}
+}
+
+func TestLoadManifest_ComposedInvalid(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "bad-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Composed agent with entrypoint — should fail validation.
+	yaml := `name: bad
+entrypoint: system.md
+stages:
+  - name: s1
+    agent: a1
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := LoadManifest(agentDir)
+	if err == nil {
+		t.Fatal("expected LoadManifest to fail for invalid composed manifest")
+	}
+	if !strings.Contains(err.Error(), "cannot have entrypoint") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestComposedStage_AgentList(t *testing.T) {
+	single := ComposedStage{Agent: "a1"}
+	if got := single.AgentList(); len(got) != 1 || got[0] != "a1" {
+		t.Fatalf("single agent: expected [a1], got %v", got)
+	}
+
+	multi := ComposedStage{Agents: []string{"a1", "a2", "a3"}}
+	if got := multi.AgentList(); len(got) != 3 {
+		t.Fatalf("multi agent: expected 3, got %d", len(got))
+	}
+}

--- a/agent/composed_test.go
+++ b/agent/composed_test.go
@@ -133,7 +133,7 @@ func TestValidate_ComposedNoAgents(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for stage with no agents")
 	}
-	if !strings.Contains(err.Error(), "must specify agent or agents") {
+	if !strings.Contains(err.Error(), "must specify agent, agents, or inline entrypoint") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -151,6 +151,80 @@ func TestValidate_ComposedBothAgentAndAgents(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot specify both") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedInlineValid(t *testing.T) {
+	m := &Manifest{
+		Name: "inline-ok",
+		Stages: []ComposedStage{
+			{Name: "s1", EntryPoint: "system.md", Wrapper: "agent.md"},
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedInlineMissingWrapper(t *testing.T) {
+	m := &Manifest{
+		Name: "inline-bad",
+		Stages: []ComposedStage{
+			{Name: "s1", EntryPoint: "system.md"},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for inline without wrapper")
+	}
+	if !strings.Contains(err.Error(), "requires wrapper") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedInlineWithExternalAgent(t *testing.T) {
+	m := &Manifest{
+		Name: "conflict",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1", EntryPoint: "system.md", Wrapper: "agent.md"},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for inline with external agent")
+	}
+	if !strings.Contains(err.Error(), "cannot specify both agent/agents and inline entrypoint") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedInvalidSummarize(t *testing.T) {
+	m := &Manifest{
+		Name: "bad-summarize",
+		Stages: []ComposedStage{
+			{Name: "s1", Agent: "a1", Summarize: "invalid"},
+		},
+	}
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid summarize value")
+	}
+	if !strings.Contains(err.Error(), "summarize must be auto, always, or never") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ComposedValidSummarize(t *testing.T) {
+	for _, val := range []string{"auto", "always", "never", ""} {
+		m := &Manifest{
+			Name: "ok",
+			Stages: []ComposedStage{
+				{Name: "s1", Agent: "a1", Summarize: val},
+			},
+		}
+		if err := m.Validate(); err != nil {
+			t.Fatalf("summarize=%q: unexpected error: %v", val, err)
+		}
 	}
 }
 
@@ -426,5 +500,32 @@ func TestComposedStage_AgentList(t *testing.T) {
 	multi := ComposedStage{Agents: []string{"a1", "a2", "a3"}}
 	if got := multi.AgentList(); len(got) != 3 {
 		t.Fatalf("multi agent: expected 3, got %d", len(got))
+	}
+
+	// Inline stage uses the stage name as the agent name.
+	inline := ComposedStage{Name: "my-inline", EntryPoint: "system.md"}
+	if got := inline.AgentList(); len(got) != 1 || got[0] != "my-inline" {
+		t.Fatalf("inline agent: expected [my-inline], got %v", got)
+	}
+}
+
+func TestComposedStage_IsInline(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stage ComposedStage
+		want  bool
+	}{
+		{"not inline", ComposedStage{Agent: "a1"}, false},
+		{"inline with entrypoint", ComposedStage{Name: "s1", EntryPoint: "system.md"}, true},
+		{"empty entrypoint", ComposedStage{Name: "s1"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.stage.IsInline(); got != tt.want {
+				t.Fatalf("IsInline() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/config"
@@ -39,152 +38,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPipelineCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "pipeline",
-		Short: "Run multi-agent pipelines",
-		Long:  "Execute declarative multi-agent pipelines defined in YAML.",
-	}
-
-	cmd.AddCommand(newPipelineRunCmd())
-	return cmd
-}
-
-func newPipelineRunCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "run <pipeline.yaml> [prompt]",
-		Short: "Execute a pipeline",
-		Long: `Execute a multi-agent pipeline defined in a YAML file.
-
-The pipeline file declares stages with agents, dependencies, gates, and
-output format. Agents within a stage run in parallel; stages execute in
-dependency order.
-
-Examples:
-  # Run a pipeline
-  squad pipeline run recon.yaml "Assess the target system"
-
-  # Run with cost limit and output file
-  squad pipeline run security-audit.yaml --max-cost 5.00 --out report.md
-
-  # Dry run to validate the pipeline
-  squad pipeline run recon.yaml --dry-run`,
-		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.SilenceUsage = true
-			return runPipeline(cmd, args)
-		},
-	}
-
-	cmd.Flags().String("agents-dir", "", "Agents directory (default: ./agents, then ~/.config/squad/agents)")
-	cmd.Flags().String("working-dir", "", "Working directory (default: current working directory)")
-	cmd.Flags().String("api-key", "", "API key (overrides env/config)")
-	cmd.Flags().String("base-url", "", "Base URL override for provider")
-	cmd.Flags().String("organization", "", "Organization ID")
-	cmd.Flags().String("api-version", "", "API version")
-	cmd.Flags().String("api-type", "", "API type (openai or azure)")
-	cmd.Flags().Bool("openai-compat-max-tokens", false, "Use max_tokens for OpenAI-compatible endpoints")
-	cmd.Flags().String("provider", "", "Model provider")
-	cmd.Flags().String("model", "", "Model name")
-	cmd.Flags().Float64("temperature", -1, "Sampling temperature")
-	cmd.Flags().Int("max-tokens", -1, "Max output tokens")
-	cmd.Flags().Int("max-iterations", 100, "Max tool-calling iterations per agent (10-1000)")
-	cmd.Flags().Float64("max-cost", 10, "Max total cost budget in USD for entire pipeline (0 = unlimited)")
-	cmd.Flags().String("out", "", "Write report to file")
-	cmd.Flags().Bool("print", true, "Print report to stdout")
-	cmd.Flags().Bool("dry-run", false, "Validate pipeline and exit without running")
-	cmd.Flags().Bool("json", false, "Force JSON output format")
-	cmd.Flags().Int("num-ctx", 32768, "Context window size for Ollama models")
-	cmd.Flags().StringArray("var", nil, "Template variable in KEY=VALUE format (can be repeated)")
-
-	return cmd
-}
-
-func runPipeline(cmd *cobra.Command, args []string) error {
-	pipelinePath := args[0]
-	prompt := ""
-	if len(args) > 1 {
-		prompt = strings.Join(args[1:], " ")
-	}
-
-	// Load and validate the pipeline.
-	p, err := pl.Load(pipelinePath)
-	if err != nil {
-		return fmt.Errorf("failed to load pipeline: %w", err)
-	}
-
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	if dryRun {
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Pipeline %q (%s) validated: %d stages\n", p.Name, p.Version, len(p.Stages))
-		return err
-	}
-
-	cfg := configFromContext(cmd)
-	if cfg == nil {
-		return fmt.Errorf("config not available")
-	}
-
-	workingDir, err := resolveWorkingDir(cmd)
-	if err != nil {
-		return err
-	}
-
-	maxCost, _ := cmd.Flags().GetFloat64("max-cost")
-	if maxCost < 0 {
-		maxCost = 0
-	}
-
-	opts := buildPipelineRunOpts(cmd, cfg)
-
-	agentsDir, err := resolveAgentsDir(cmd, cfg)
-	if err != nil {
-		return err
-	}
-
-	varStrings, _ := cmd.Flags().GetStringArray("var")
-	vars := parseVars(varStrings)
-
-	logging.InfoContext(cmd.Context(), "pipeline: starting %q with %d stages (max_cost=$%.2f)", p.Name, len(p.Stages), maxCost)
-
-	pipelineRunner := &pl.Runner{
-		Pipeline:   p,
-		WorkingDir: workingDir,
-		Prompt:     prompt,
-		MaxCost:    maxCost,
-	}
-	pipelineRunner.RunAgent = buildRunAgentFunc(opts, agentsDir, cfg, vars, pipelineRunner)
-
-	report, err := pipelineRunner.Run(cmd.Context())
-
-	// Always try to output the report, even on error.
-	if report != nil {
-		outputReport(cmd, p, pipelineRunner, report)
-	}
-
-	return err
-}
-
-func resolveWorkingDir(cmd *cobra.Command) (string, error) {
-	workingDir, _ := cmd.Flags().GetString("working-dir")
-	if workingDir == "" {
-		return os.Getwd()
-	}
-	return filepath.Abs(workingDir)
-}
-
-func resolveAgentsDir(cmd *cobra.Command, cfg *config.Config) (string, error) {
-	agentsDir, _ := cmd.Flags().GetString("agents-dir")
-	if agentsDir == "" {
-		return resolveAgentsDirForPipeline(cfg)
-	}
-	return filepath.Abs(agentsDir)
-}
-
+// buildRunAgentFunc creates the callback used by the pipeline runner to execute
+// individual agents. It handles agent resolution, bundle building, budget
+// propagation, and model invocation.
 func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, cfg *config.Config, vars map[string]string, pipelineRunner *pl.Runner) func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 	return func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 		mergedVars := mergeVars(vars, stageVars)
 
-		resolvedAgentsDir, agentErr := findAgentDirForPipeline(agentName, agentsDir, cfg)
+		resolvedAgentsDir, agentErr := findAgentDirForComposed(agentName, agentsDir, cfg)
 		if agentErr != nil {
 			return "", nil, agentErr
 		}
@@ -219,6 +80,7 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, cfg *config.Co
 	}
 }
 
+// outputReport formats and writes the pipeline report to stdout and/or a file.
 func outputReport(cmd *cobra.Command, p *pl.Pipeline, pipelineRunner *pl.Runner, report *pl.Report) {
 	forceJSON, _ := cmd.Flags().GetBool("json")
 	if forceJSON && (p.Output == nil || p.Output.Format != "json") {
@@ -238,18 +100,22 @@ func outputReport(cmd *cobra.Command, p *pl.Pipeline, pipelineRunner *pl.Runner,
 	outFile, _ := cmd.Flags().GetString("out")
 
 	if printOut || outFile == "" {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), formatted)
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), formatted); err != nil {
+			logging.Warn("failed to print report: %v", err)
+		}
 	}
 	if outFile != "" {
 		if writeErr := os.WriteFile(outFile, []byte(formatted), 0o644); writeErr != nil {
 			logging.Warn("failed to write report: %v", writeErr)
 		} else {
-			logging.InfoContext(cmd.Context(), "pipeline report written to %s", outFile)
+			logging.InfoContext(cmd.Context(), "report written to %s", outFile)
 		}
 	}
 }
 
-func buildPipelineRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOptions {
+// buildComposedRunOpts creates RunOptions for composed agent execution from
+// CLI flags and Viper config.
+func buildComposedRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOptions {
 	v := viperFromContext(cmd)
 
 	provider := flagOrViper(cmd, "provider", v, "provider.default")
@@ -308,6 +174,7 @@ func flagOrViper(cmd *cobra.Command, flagName string, v interface{ GetString(str
 	return ""
 }
 
+// mergeVars combines base and override variable maps, with override taking precedence.
 func mergeVars(base, override map[string]string) map[string]string {
 	if len(base) == 0 && len(override) == 0 {
 		return nil
@@ -322,8 +189,8 @@ func mergeVars(base, override map[string]string) map[string]string {
 	return merged
 }
 
-// resolveAgentsDirForPipeline resolves the agents directory from config sources.
-func resolveAgentsDirForPipeline(cfg *config.Config) (string, error) {
+// resolveAgentsDirFromConfig resolves the agents directory from config sources.
+func resolveAgentsDirFromConfig(cfg *config.Config) (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("no config provided and no explicit agents directory specified")
 	}
@@ -341,8 +208,8 @@ func resolveAgentsDirForPipeline(cfg *config.Config) (string, error) {
 	return paths[0], nil
 }
 
-// findAgentDirForPipeline locates an agent's parent directory.
-func findAgentDirForPipeline(agentName, defaultDir string, cfg *config.Config) (string, error) {
+// findAgentDirForComposed locates an agent's parent directory for composed agent execution.
+func findAgentDirForComposed(agentName, defaultDir string, cfg *config.Config) (string, error) {
 	if cfg != nil {
 		manager, err := source.NewManager(cfg)
 		if err == nil {

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -41,23 +41,47 @@ import (
 // buildRunAgentFunc creates the callback used by the pipeline runner to execute
 // individual agents. It handles agent resolution, bundle building, budget
 // propagation, and model invocation.
-func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, cfg *config.Config, vars map[string]string, pipelineRunner *pl.Runner) func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
+func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentDir string, cfg *config.Config, vars map[string]string, pipelineRunner *pl.Runner) func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 	return func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 		mergedVars := mergeVars(vars, stageVars)
 
-		resolvedAgentsDir, agentErr := findAgentDirForComposed(agentName, agentsDir, cfg)
-		if agentErr != nil {
-			return "", nil, agentErr
-		}
+		var bundle *agent.Bundle
 
-		bundle, agentErr := agent.BuildBundle(resolvedAgentsDir, agentName, agentPrompt, wd, mode, mergedVars)
-		if agentErr != nil {
-			return "", nil, fmt.Errorf("failed to build agent %s: %w", agentName, agentErr)
+		// Check if this is an inline agent defined in the composed manifest.
+		if inlineCfg, ok := pipelineRunner.InlineAgents[agentName]; ok && inlineCfg != nil {
+			inlineAgent := &agent.InlineAgentConfig{
+				Name:       agentName,
+				EntryPoint: inlineCfg.EntryPoint,
+				Wrapper:    inlineCfg.Wrapper,
+				Task:       inlineCfg.Task,
+				References: inlineCfg.References,
+			}
+			for _, m := range inlineCfg.Models {
+				inlineAgent.Models = append(inlineAgent.Models, agent.ModelPreference{
+					Model:    m.Model,
+					Provider: m.Provider,
+				})
+			}
+			var buildErr error
+			bundle, buildErr = agent.BuildBundleInline(pipelineRunner.ComposedDir, inlineAgent, agentPrompt, wd, mode, mergedVars)
+			if buildErr != nil {
+				return "", nil, fmt.Errorf("failed to build inline agent %s: %w", agentName, buildErr)
+			}
+		} else {
+			resolvedAgentsDir, agentErr := findAgentDirForComposed(agentName, agentsDir, composedAgentDir, cfg)
+			if agentErr != nil {
+				return "", nil, agentErr
+			}
+
+			var buildErr error
+			bundle, buildErr = agent.BuildBundle(resolvedAgentsDir, agentName, agentPrompt, wd, mode, mergedVars)
+			if buildErr != nil {
+				return "", nil, fmt.Errorf("failed to build agent %s: %w", agentName, buildErr)
+			}
 		}
 
 		agentOpts := *opts
 		agentOpts.Agent = agentName
-		agentOpts.AgentsDir = resolvedAgentsDir
 		agentOpts.WorkingDir = wd
 		agentOpts.Mode = mode
 		agentOpts.Vars = mergedVars
@@ -209,7 +233,18 @@ func resolveAgentsDirFromConfig(cfg *config.Config) (string, error) {
 }
 
 // findAgentDirForComposed locates an agent's parent directory for composed agent execution.
-func findAgentDirForComposed(agentName, defaultDir string, cfg *config.Config) (string, error) {
+// It checks for nested sub-agents inside composedDir/agents/ first, then falls back to
+// global search paths and the default directory.
+func findAgentDirForComposed(agentName, defaultDir, composedDir string, cfg *config.Config) (string, error) {
+	// Check for nested sub-agents inside the composed agent's directory.
+	if composedDir != "" {
+		nestedDir := filepath.Join(composedDir, "agents")
+		manifestPath := filepath.Join(nestedDir, agentName, "agent.yaml")
+		if _, err := os.Stat(manifestPath); err == nil {
+			return nestedDir, nil
+		}
+	}
+
 	if cfg != nil {
 		manager, err := source.NewManager(cfg)
 		if err == nil {

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -513,6 +513,72 @@ func TestBuildRunAgentFunc_AgentNotFound(t *testing.T) {
 	}
 }
 
+func TestBuildRunAgentFunc_InlineAgent(t *testing.T) {
+	t.Parallel()
+
+	// Create a composed agent directory with inline prompt files.
+	composedDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(composedDir, "system.md"), []byte("inline system"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(composedDir, "agent.md"), []byte("inline wrapper"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &runner.RunOptions{Provider: "test", Model: "test-model"}
+	pRunner := &pl.Runner{
+		ComposedDir: composedDir,
+		InlineAgents: map[string]*pl.InlineConfig{
+			"my-inline": {
+				EntryPoint: "system.md",
+				Wrapper:    "agent.md",
+				Models: []pl.ModelPreference{
+					{Model: "gpt-4", Provider: "openai"},
+				},
+			},
+		},
+	}
+
+	fn := buildRunAgentFunc(opts, t.TempDir(), composedDir, &config.Config{}, nil, pRunner)
+
+	// The inline path resolves successfully and fails at model invocation.
+	_, _, err := fn(context.Background(), "my-inline", "test prompt", t.TempDir(), "edit", nil)
+	if err == nil {
+		t.Fatal("expected error from InvokeModel (no real provider)")
+	}
+	// Should NOT fail at inline build.
+	if strings.Contains(err.Error(), "failed to build inline agent") {
+		t.Fatalf("inline agent build failed: %v", err)
+	}
+}
+
+func TestBuildRunAgentFunc_InlineBuildError(t *testing.T) {
+	t.Parallel()
+
+	// composedDir has no prompt files — BuildBundleInline will fail.
+	composedDir := t.TempDir()
+	opts := &runner.RunOptions{}
+	pRunner := &pl.Runner{
+		ComposedDir: composedDir,
+		InlineAgents: map[string]*pl.InlineConfig{
+			"bad-inline": {
+				EntryPoint: "missing.md",
+				Wrapper:    "also-missing.md",
+			},
+		},
+	}
+
+	fn := buildRunAgentFunc(opts, t.TempDir(), composedDir, nil, nil, pRunner)
+
+	_, _, err := fn(context.Background(), "bad-inline", "test", t.TempDir(), "edit", nil)
+	if err == nil {
+		t.Fatal("expected error for missing inline prompts")
+	}
+	if !strings.Contains(err.Error(), "failed to build inline agent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestOutputReport_FormatError(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -289,6 +289,23 @@ func TestResolveAgentsDirFromConfig(t *testing.T) {
 			t.Fatal("expected error with empty config, got nil")
 		}
 	})
+
+	t.Run("config with local path returns path", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := t.TempDir()
+		cfg := &config.Config{
+			Agents: config.AgentsConfig{
+				LocalPaths: []string{agentsDir},
+			},
+		}
+		result, err := resolveAgentsDirFromConfig(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == "" {
+			t.Fatal("expected non-empty path")
+		}
+	})
 }
 
 func TestFindAgentDirForComposed(t *testing.T) {

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -14,11 +14,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-// newTestPipelineRunCmd creates a pipeline run command with a context that
-// includes a Viper instance and an optional config, mirroring what the
-// real root command sets up.
-func newTestPipelineRunCmd(cfg *config.Config) *cobra.Command {
-	cmd := newPipelineRunCmd()
+// newTestRunCmdWithContext creates a run command with a context that
+// includes a Viper instance and an optional config.
+func newTestRunCmdWithContext(cfg *config.Config) *cobra.Command {
+	cmd := newRunCmd()
 	ctx := context.Background()
 	ctx = withViper(ctx, viper.New())
 	if cfg != nil {
@@ -60,7 +59,7 @@ func TestMergeVars(t *testing.T) {
 
 func TestFlagOrViper(t *testing.T) {
 	t.Parallel()
-	cmd := newPipelineRunCmd()
+	cmd := newRunCmd()
 	// Without changing flags, flagOrViper should return empty string.
 	val := flagOrViper(cmd, "provider", nil, "provider.default")
 	if val != "" {
@@ -68,108 +67,22 @@ func TestFlagOrViper(t *testing.T) {
 	}
 }
 
-func TestPipelineRunDryRun(t *testing.T) {
-	// Create a minimal pipeline file.
-	dir := t.TempDir()
-	pipelinePath := filepath.Join(dir, "test.yaml")
-	content := `
-name: test-pipeline
-version: v1
-stages:
-  - name: review
-    agent: go-review
-`
-	if err := os.WriteFile(pipelinePath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	rootCmd := NewRootCmd()
-	rootCmd.SetArgs([]string{"pipeline", "run", pipelinePath, "--dry-run"})
-
-	var out strings.Builder
-	rootCmd.SetOut(&out)
-
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-
-	if !strings.Contains(out.String(), "validated") {
-		t.Fatalf("expected validation message, got: %s", out.String())
-	}
-}
-
-func TestResolveWorkingDir(t *testing.T) {
-	t.Parallel()
-
-	t.Run("default uses cwd", func(t *testing.T) {
-		t.Parallel()
-		cmd := newPipelineRunCmd()
-		dir, err := resolveWorkingDir(cmd)
-		if err != nil {
-			// os.Getwd can fail when parallel tests chdir to
-			// temp dirs that are later removed; not our bug.
-			t.Skipf("os.Getwd unavailable in parallel test env: %v", err)
-		}
-		if !filepath.IsAbs(dir) {
-			t.Fatalf("expected absolute path, got %q", dir)
-		}
-	})
-
-	t.Run("flag set returns absolute path", func(t *testing.T) {
-		t.Parallel()
-		tmp := t.TempDir()
-		cmd := newPipelineRunCmd()
-		if err := cmd.Flags().Set("working-dir", tmp); err != nil {
-			t.Fatalf("set flag: %v", err)
-		}
-		dir, err := resolveWorkingDir(cmd)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		abs, _ := filepath.Abs(tmp)
-		if dir != abs {
-			t.Fatalf("expected %q, got %q", abs, dir)
-		}
-	})
-}
-
-func TestResolveAgentsDir(t *testing.T) {
-	t.Parallel()
-
-	t.Run("flag set returns absolute path", func(t *testing.T) {
-		t.Parallel()
-		tmp := t.TempDir()
-		cmd := newPipelineRunCmd()
-		if err := cmd.Flags().Set("agents-dir", tmp); err != nil {
-			t.Fatalf("set flag: %v", err)
-		}
-		dir, err := resolveAgentsDir(cmd, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		abs, _ := filepath.Abs(tmp)
-		if dir != abs {
-			t.Fatalf("expected %q, got %q", abs, dir)
-		}
-	})
-}
-
-func TestBuildPipelineRunOpts(t *testing.T) {
+func TestBuildComposedRunOpts(t *testing.T) {
 	t.Parallel()
 
 	t.Run("defaults", func(t *testing.T) {
 		t.Parallel()
 		cfg := &config.Config{}
-		cmd := newTestPipelineRunCmd(cfg)
-		opts := buildPipelineRunOpts(cmd, cfg)
+		cmd := newTestRunCmdWithContext(cfg)
+		opts := buildComposedRunOpts(cmd, cfg)
 		if opts == nil {
 			t.Fatal("expected non-nil opts")
 		}
 		if opts.MaxIterations != 100 {
 			t.Fatalf("expected MaxIterations=100, got %d", opts.MaxIterations)
 		}
-		if opts.MaxCost != 10 {
-			t.Fatalf("expected MaxCost=10, got %f", opts.MaxCost)
+		if opts.MaxCost != 5 {
+			t.Fatalf("expected MaxCost=5, got %f", opts.MaxCost)
 		}
 		if opts.NumCtx != 32768 {
 			t.Fatalf("expected NumCtx=32768, got %d", opts.NumCtx)
@@ -181,8 +94,8 @@ func TestBuildPipelineRunOpts(t *testing.T) {
 
 	t.Run("nil config", func(t *testing.T) {
 		t.Parallel()
-		cmd := newTestPipelineRunCmd(nil)
-		opts := buildPipelineRunOpts(cmd, nil)
+		cmd := newTestRunCmdWithContext(nil)
+		opts := buildComposedRunOpts(cmd, nil)
 		if opts.ConfigAvailable {
 			t.Fatal("expected ConfigAvailable=false")
 		}
@@ -190,9 +103,9 @@ func TestBuildPipelineRunOpts(t *testing.T) {
 
 	t.Run("max-iterations clamped low", func(t *testing.T) {
 		t.Parallel()
-		cmd := newTestPipelineRunCmd(nil)
+		cmd := newTestRunCmdWithContext(nil)
 		_ = cmd.Flags().Set("max-iterations", "3")
-		opts := buildPipelineRunOpts(cmd, nil)
+		opts := buildComposedRunOpts(cmd, nil)
 		if opts.MaxIterations != 10 {
 			t.Fatalf("expected MaxIterations=10, got %d", opts.MaxIterations)
 		}
@@ -200,9 +113,9 @@ func TestBuildPipelineRunOpts(t *testing.T) {
 
 	t.Run("max-iterations clamped high", func(t *testing.T) {
 		t.Parallel()
-		cmd := newTestPipelineRunCmd(nil)
+		cmd := newTestRunCmdWithContext(nil)
 		_ = cmd.Flags().Set("max-iterations", "5000")
-		opts := buildPipelineRunOpts(cmd, nil)
+		opts := buildComposedRunOpts(cmd, nil)
 		if opts.MaxIterations != 1000 {
 			t.Fatalf("expected MaxIterations=1000, got %d", opts.MaxIterations)
 		}
@@ -210,9 +123,9 @@ func TestBuildPipelineRunOpts(t *testing.T) {
 
 	t.Run("negative max-cost becomes zero", func(t *testing.T) {
 		t.Parallel()
-		cmd := newTestPipelineRunCmd(nil)
+		cmd := newTestRunCmdWithContext(nil)
 		_ = cmd.Flags().Set("max-cost", "-5")
-		opts := buildPipelineRunOpts(cmd, nil)
+		opts := buildComposedRunOpts(cmd, nil)
 		if opts.MaxCost != 0 {
 			t.Fatalf("expected MaxCost=0, got %f", opts.MaxCost)
 		}
@@ -220,13 +133,13 @@ func TestBuildPipelineRunOpts(t *testing.T) {
 
 	t.Run("flag values propagate", func(t *testing.T) {
 		t.Parallel()
-		cmd := newTestPipelineRunCmd(nil)
+		cmd := newTestRunCmdWithContext(nil)
 		_ = cmd.Flags().Set("provider", "openai")
 		_ = cmd.Flags().Set("model", "gpt-4")
 		_ = cmd.Flags().Set("api-key", "sk-test")
 		_ = cmd.Flags().Set("temperature", "0.7")
 		_ = cmd.Flags().Set("max-tokens", "2048")
-		opts := buildPipelineRunOpts(cmd, nil)
+		opts := buildComposedRunOpts(cmd, nil)
 		if opts.Provider != "openai" {
 			t.Fatalf("expected Provider=openai, got %q", opts.Provider)
 		}
@@ -260,7 +173,7 @@ func TestOutputReport(t *testing.T) {
 
 	t.Run("print to stdout markdown", func(t *testing.T) {
 		t.Parallel()
-		cmd := newPipelineRunCmd()
+		cmd := newRunCmd()
 		var out strings.Builder
 		cmd.SetOut(&out)
 
@@ -276,7 +189,7 @@ func TestOutputReport(t *testing.T) {
 
 	t.Run("json output", func(t *testing.T) {
 		t.Parallel()
-		cmd := newPipelineRunCmd()
+		cmd := newRunCmd()
 		_ = cmd.Flags().Set("json", "true")
 		var out strings.Builder
 		cmd.SetOut(&out)
@@ -298,7 +211,7 @@ func TestOutputReport(t *testing.T) {
 
 	t.Run("json sets output format on nil Output", func(t *testing.T) {
 		t.Parallel()
-		cmd := newPipelineRunCmd()
+		cmd := newRunCmd()
 		_ = cmd.Flags().Set("json", "true")
 		var out strings.Builder
 		cmd.SetOut(&out)
@@ -317,7 +230,7 @@ func TestOutputReport(t *testing.T) {
 		t.Parallel()
 		tmp := t.TempDir()
 		outFile := filepath.Join(tmp, "report.md")
-		cmd := newPipelineRunCmd()
+		cmd := newRunCmd()
 		_ = cmd.Flags().Set("out", outFile)
 		_ = cmd.Flags().Set("print", "false")
 		var out strings.Builder
@@ -340,7 +253,7 @@ func TestOutputReport(t *testing.T) {
 
 	t.Run("print false and no out still prints", func(t *testing.T) {
 		t.Parallel()
-		cmd := newPipelineRunCmd()
+		cmd := newRunCmd()
 		_ = cmd.Flags().Set("print", "false")
 		var out strings.Builder
 		cmd.SetOut(&out)
@@ -350,20 +263,18 @@ func TestOutputReport(t *testing.T) {
 		report := makeReport()
 
 		outputReport(cmd, p, pRunner, report)
-		// When print=false but out="" the condition (printOut || outFile == "") is true
-		// because outFile is empty, so it still prints.
 		if out.Len() == 0 {
 			t.Fatal("expected output when no out file is specified")
 		}
 	})
 }
 
-func TestResolveAgentsDirForPipeline(t *testing.T) {
+func TestResolveAgentsDirFromConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil config returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := resolveAgentsDirForPipeline(nil)
+		_, err := resolveAgentsDirFromConfig(nil)
 		if err == nil {
 			t.Fatal("expected error with nil config, got nil")
 		}
@@ -372,20 +283,20 @@ func TestResolveAgentsDirForPipeline(t *testing.T) {
 	t.Run("empty config returns error", func(t *testing.T) {
 		t.Parallel()
 		cfg := &config.Config{}
-		_, err := resolveAgentsDirForPipeline(cfg)
+		_, err := resolveAgentsDirFromConfig(cfg)
 		if err == nil {
 			t.Fatal("expected error with empty config, got nil")
 		}
 	})
 }
 
-func TestFindAgentDirForPipeline(t *testing.T) {
+func TestFindAgentDirForComposed(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil config returns default dir", func(t *testing.T) {
 		t.Parallel()
 		defaultDir := "/some/default/agents"
-		dir, err := findAgentDirForPipeline("my-agent", defaultDir, nil)
+		dir, err := findAgentDirForComposed("my-agent", defaultDir, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -398,7 +309,7 @@ func TestFindAgentDirForPipeline(t *testing.T) {
 		t.Parallel()
 		defaultDir := "/fallback/agents"
 		cfg := &config.Config{}
-		dir, err := findAgentDirForPipeline("nonexistent-agent", defaultDir, cfg)
+		dir, err := findAgentDirForComposed("nonexistent-agent", defaultDir, cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -406,49 +317,6 @@ func TestFindAgentDirForPipeline(t *testing.T) {
 			t.Fatalf("expected %q, got %q", defaultDir, dir)
 		}
 	})
-}
-
-func TestNewPipelineCmd(t *testing.T) {
-	t.Parallel()
-	cmd := newPipelineCmd()
-	if cmd.Use != "pipeline" {
-		t.Fatalf("expected Use=pipeline, got %q", cmd.Use)
-	}
-	if !cmd.HasSubCommands() {
-		t.Fatal("expected pipeline cmd to have subcommands")
-	}
-	// Verify 'run' subcommand exists.
-	found := false
-	for _, sub := range cmd.Commands() {
-		if sub.Use == "run <pipeline.yaml> [prompt]" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("expected 'run' subcommand")
-	}
-}
-
-func TestNewPipelineRunCmd(t *testing.T) {
-	t.Parallel()
-	cmd := newPipelineRunCmd()
-	if cmd.Use != "run <pipeline.yaml> [prompt]" {
-		t.Fatalf("expected Use='run <pipeline.yaml> [prompt]', got %q", cmd.Use)
-	}
-
-	// Verify key flags exist.
-	expectedFlags := []string{
-		"agents-dir", "working-dir", "api-key", "base-url",
-		"provider", "model", "temperature", "max-tokens",
-		"max-iterations", "max-cost", "out", "print",
-		"dry-run", "json", "num-ctx", "var",
-	}
-	for _, name := range expectedFlags {
-		if cmd.Flags().Lookup(name) == nil {
-			t.Fatalf("expected flag %q to exist", name)
-		}
-	}
 }
 
 func TestFlagOrViperWithMockViper(t *testing.T) {

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cowdogmoo/squad/config"
 	pl "github.com/cowdogmoo/squad/pipeline"
+	"github.com/cowdogmoo/squad/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -296,7 +297,7 @@ func TestFindAgentDirForComposed(t *testing.T) {
 	t.Run("nil config returns default dir", func(t *testing.T) {
 		t.Parallel()
 		defaultDir := "/some/default/agents"
-		dir, err := findAgentDirForComposed("my-agent", defaultDir, nil)
+		dir, err := findAgentDirForComposed("my-agent", defaultDir, "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -309,12 +310,46 @@ func TestFindAgentDirForComposed(t *testing.T) {
 		t.Parallel()
 		defaultDir := "/fallback/agents"
 		cfg := &config.Config{}
-		dir, err := findAgentDirForComposed("nonexistent-agent", defaultDir, cfg)
+		dir, err := findAgentDirForComposed("nonexistent-agent", defaultDir, "", cfg)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if dir != defaultDir {
 			t.Fatalf("expected %q, got %q", defaultDir, dir)
+		}
+	})
+
+	t.Run("nested sub-agent found inside composed dir", func(t *testing.T) {
+		t.Parallel()
+		composedDir := t.TempDir()
+		subAgentDir := filepath.Join(composedDir, "agents", "my-sub-agent")
+		if err := os.MkdirAll(subAgentDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(subAgentDir, "agent.yaml"), []byte("name: my-sub-agent\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		dir, err := findAgentDirForComposed("my-sub-agent", "/fallback", composedDir, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := filepath.Join(composedDir, "agents")
+		if dir != expected {
+			t.Fatalf("expected %q, got %q", expected, dir)
+		}
+	})
+
+	t.Run("nested dir checked before global fallback", func(t *testing.T) {
+		t.Parallel()
+		composedDir := t.TempDir()
+		// No sub-agent exists — should fall back to default
+		dir, err := findAgentDirForComposed("missing-agent", "/fallback", composedDir, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dir != "/fallback" {
+			t.Fatalf("expected /fallback, got %q", dir)
 		}
 	})
 }
@@ -347,6 +382,160 @@ func TestFlagOrViperWithMockViper(t *testing.T) {
 			t.Fatalf("expected viper value 'openai', got %q", val)
 		}
 	})
+}
+
+func TestBuildRunAgentFunc_ResolvesAgent(t *testing.T) {
+	t.Parallel()
+
+	// Create a real agent on disk that buildRunAgentFunc can resolve.
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "test-leaf")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifestYAML := "name: test-leaf\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\n"
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifestYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("system prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("agent wrapper"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &runner.RunOptions{
+		Provider: "test",
+		Model:    "test-model",
+	}
+	pRunner := &pl.Runner{
+		InlineAgents: make(map[string]*pl.InlineConfig),
+	}
+
+	fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+
+	// The callback should resolve the agent and build its bundle. It will fail
+	// at InvokeModel (no real provider), but that confirms the agent resolution
+	// and bundle building paths are exercised.
+	_, _, err := fn(context.Background(), "test-leaf", "review this", t.TempDir(), "edit", nil)
+	if err == nil {
+		t.Fatal("expected error from InvokeModel (no real provider)")
+	}
+	// The error should come from the model invocation, not agent resolution.
+	if strings.Contains(err.Error(), "failed to build agent") {
+		t.Fatalf("agent resolution failed: %v", err)
+	}
+}
+
+func TestBuildRunAgentFunc_BudgetPropagation(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "budgeted")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"),
+		[]byte("name: budgeted\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &runner.RunOptions{MaxCost: 10.0}
+	pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+	fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+
+	// Inject pipeline budget var.
+	stageVars := map[string]string{pl.PipelineMaxCostVar: "3.50"}
+	_, _, err := fn(context.Background(), "budgeted", "prompt", t.TempDir(), "edit", stageVars)
+	// Will fail at InvokeModel but confirms budget parsing path runs.
+	if err == nil {
+		t.Fatal("expected error from InvokeModel")
+	}
+}
+
+func TestBuildRunAgentFunc_ExhaustedBudget(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "cheapo")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"),
+		[]byte("name: cheapo\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &runner.RunOptions{}
+	pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+	fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+
+	// Budget var with invalid (non-positive) value triggers exhaustion error.
+	stageVars := map[string]string{pl.PipelineMaxCostVar: "0.00"}
+	_, _, err := fn(context.Background(), "cheapo", "prompt", t.TempDir(), "edit", stageVars)
+	if err == nil {
+		t.Fatal("expected error for exhausted budget")
+	}
+	if !strings.Contains(err.Error(), "budget exhausted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildRunAgentFunc_AgentNotFound(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	opts := &runner.RunOptions{}
+	pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+	fn := buildRunAgentFunc(opts, agentsDir, "", nil, nil, pRunner)
+
+	_, _, err := fn(context.Background(), "nonexistent", "prompt", t.TempDir(), "edit", nil)
+	if err == nil {
+		t.Fatal("expected error for missing agent")
+	}
+	if !strings.Contains(err.Error(), "failed to build agent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOutputReport_FormatError(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRunCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	// Pipeline with nil Output causes FormatReport to use markdown.
+	p := &pl.Pipeline{Name: "test", Version: "v1"}
+	pRunner := &pl.Runner{Pipeline: p}
+
+	// Report with nil internals — FormatReport will still produce output.
+	report := &pl.Report{
+		Pipeline: "test",
+		Version:  "v1",
+		Status:   pl.StatusPassed,
+		Duration: "1s",
+	}
+
+	outputReport(cmd, p, pRunner, report)
+	if out.Len() == 0 {
+		t.Fatal("expected output")
+	}
 }
 
 // mockViper implements the interface { GetString(string) string } for testing.

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -66,7 +66,6 @@ Define an agent in markdown and YAML, point it at any LLM, and turn it loose on 
 	})
 
 	rootCmd.AddCommand(newRunCmd())
-	rootCmd.AddCommand(newPipelineCmd())
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(newGradeCmd())

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -383,13 +383,23 @@ func runComposedAgent(cmd *cobra.Command, args []string, opts *runner.RunOptions
 	logging.InfoContext(cmd.Context(), "composed agent: starting %q with %d stages (max_cost=$%.2f)",
 		manifest.Name, len(p.Stages), opts.MaxCost)
 
-	pipelineRunner := &pl.Runner{
-		Pipeline:   p,
-		WorkingDir: workingDir,
-		Prompt:     prompt,
-		MaxCost:    opts.MaxCost,
+	// Collect inline agent configs from stages.
+	inlineAgents := make(map[string]*pl.InlineConfig)
+	for _, stage := range p.Stages {
+		if stage.InlineConfig != nil {
+			inlineAgents[stage.Name] = stage.InlineConfig
+		}
 	}
-	pipelineRunner.RunAgent = buildRunAgentFunc(pipelineOpts, agentsDir, cfg, vars, pipelineRunner)
+
+	pipelineRunner := &pl.Runner{
+		Pipeline:     p,
+		WorkingDir:   workingDir,
+		Prompt:       prompt,
+		MaxCost:      opts.MaxCost,
+		InlineAgents: inlineAgents,
+		ComposedDir:  agentDir,
+	}
+	pipelineRunner.RunAgent = buildRunAgentFunc(pipelineOpts, agentsDir, agentDir, cfg, vars, pipelineRunner)
 
 	report, runErr := pipelineRunner.Run(cmd.Context())
 

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -30,7 +30,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/mcp"
+	pl "github.com/cowdogmoo/squad/pipeline"
 	"github.com/cowdogmoo/squad/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -222,6 +225,19 @@ user_prompt will be used (if configured in the agent's manifest).`,
 			if opts == nil {
 				return fmt.Errorf("run configuration not initialized")
 			}
+
+			// Check if the agent is a composed agent (has stages).
+			// If so, fork to the composed agent execution path.
+			if opts.Agent != "" {
+				agentDir, err := runner.FindAgentDir(opts.Agent, opts.AgentsDir, opts.Config)
+				if err == nil {
+					manifest, mErr := agent.LoadManifest(agentDir)
+					if mErr == nil && manifest.IsComposed() {
+						return runComposedAgent(cmd, args, opts, manifest, agentDir)
+					}
+				}
+			}
+
 			return runner.ExecuteRun(cmd, args, opts)
 		},
 	}
@@ -256,6 +272,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	cmd.Flags().StringArray("mcp-server", nil, "MCP server: stdio NAME:COMMAND[:ARG1,ARG2,...] or SSE NAME:sse:URL (can be repeated)")
 	cmd.Flags().Bool("stream", false, "Stream model output tokens to stderr as they arrive")
 	cmd.Flags().Int("max-concurrent-tasks", 0, "Max concurrent background child tasks (default: 4)")
+	cmd.Flags().Bool("json", false, "Force JSON output format (composed agents only)")
 
 	cmd.MarkFlagsMutuallyExclusive("dry-run", "apply")
 
@@ -309,6 +326,135 @@ func completeAgentNames(_ *cobra.Command, _ []string, toComplete string) ([]stri
 		}
 	}
 	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// runComposedAgent executes a composed agent (one with stages) by converting
+// its manifest to a pipeline and running it through the pipeline runner.
+func runComposedAgent(cmd *cobra.Command, args []string, opts *runner.RunOptions, manifest *agent.Manifest, agentDir string) error {
+	if err := validateComposedFlags(cmd); err != nil {
+		return err
+	}
+
+	p, err := runner.ManifestToPipeline(manifest)
+	if err != nil {
+		return err
+	}
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		return composedDryRun(cmd, manifest, p)
+	}
+
+	cfg := configFromContext(cmd)
+	if cfg == nil {
+		return fmt.Errorf("config not available")
+	}
+
+	prompt := ""
+	if len(args) > 0 {
+		prompt = strings.Join(args, " ")
+	} else if hasPipedInput(cmd.InOrStdin()) {
+		input, readErr := io.ReadAll(cmd.InOrStdin())
+		if readErr != nil {
+			return fmt.Errorf("failed to read stdin: %w", readErr)
+		}
+		prompt = strings.TrimSpace(string(input))
+	}
+
+	workingDir := opts.WorkingDir
+	if workingDir == "" {
+		workingDir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	} else {
+		workingDir, err = filepath.Abs(workingDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	agentsDir := filepath.Dir(agentDir)
+	varStrings, _ := cmd.Flags().GetStringArray("var")
+	vars := parseVars(varStrings)
+
+	pipelineOpts := buildComposedRunOpts(cmd, cfg)
+
+	logging.InfoContext(cmd.Context(), "composed agent: starting %q with %d stages (max_cost=$%.2f)",
+		manifest.Name, len(p.Stages), opts.MaxCost)
+
+	pipelineRunner := &pl.Runner{
+		Pipeline:   p,
+		WorkingDir: workingDir,
+		Prompt:     prompt,
+		MaxCost:    opts.MaxCost,
+	}
+	pipelineRunner.RunAgent = buildRunAgentFunc(pipelineOpts, agentsDir, cfg, vars, pipelineRunner)
+
+	report, runErr := pipelineRunner.Run(cmd.Context())
+
+	if report != nil {
+		outputReport(cmd, p, pipelineRunner, report)
+	}
+
+	return runErr
+}
+
+// validateComposedFlags checks that no incompatible flags are set for composed agents.
+func validateComposedFlags(cmd *cobra.Command) error {
+	for _, flag := range runner.ComposedFlags {
+		if cmd.Flags().Changed(flag) {
+			return fmt.Errorf("--%s is not applicable to composed agents (sub-agents declare their own configuration)", flag)
+		}
+	}
+	return nil
+}
+
+// composedDryRun validates and prints the composed agent's pipeline structure.
+func composedDryRun(cmd *cobra.Command, manifest *agent.Manifest, p *pl.Pipeline) error {
+	w := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(w, "Composed agent %q (%s) validated: %d stages\n\n", manifest.Name, manifest.Version, len(p.Stages)); err != nil {
+		return fmt.Errorf("failed to write dry-run output: %w", err)
+	}
+
+	tiers := p.TopologicalOrder()
+	for i, tier := range tiers {
+		if _, err := fmt.Fprintf(w, "Tier %d:\n", i+1); err != nil {
+			return fmt.Errorf("failed to write dry-run output: %w", err)
+		}
+		for _, stage := range tier {
+			agents := stage.AgentList()
+			mode := stage.Mode
+			if mode == "" {
+				mode = "edit"
+			}
+			if _, err := fmt.Fprintf(w, "  Stage %q [mode=%s]: %s\n", stage.Name, mode, strings.Join(agents, ", ")); err != nil {
+				return fmt.Errorf("failed to write dry-run output: %w", err)
+			}
+			if len(stage.DependsOn) > 0 {
+				if _, err := fmt.Fprintf(w, "    depends_on: %s\n", strings.Join(stage.DependsOn, ", ")); err != nil {
+					return fmt.Errorf("failed to write dry-run output: %w", err)
+				}
+			}
+		}
+	}
+
+	if len(p.Gates) > 0 {
+		if _, err := fmt.Fprintf(w, "\nGates:\n"); err != nil {
+			return fmt.Errorf("failed to write dry-run output: %w", err)
+		}
+		for _, g := range p.Gates {
+			onFailure := g.OnFailure
+			if onFailure == "" {
+				onFailure = "stop"
+			}
+			if _, err := fmt.Fprintf(w, "  after %q: %s (on_failure=%s)\n", g.After, g.Command, onFailure); err != nil {
+				return fmt.Errorf("failed to write dry-run output: %w", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // parseMCPServers parses MCP server specs into ServerConfig.

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/config"
+	"github.com/cowdogmoo/squad/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -829,6 +830,192 @@ func TestParseMCPServers(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateComposedFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		value   string
+		wantErr bool
+	}{
+		{"system", "system", "override", true},
+		{"print-bundle", "print-bundle", "true", true},
+		{"bundle-out", "bundle-out", "/tmp/b", true},
+		{"apply", "apply", "true", true},
+		{"apply-fallback", "apply-fallback", "true", true},
+		{"require-actionable", "require-actionable", "true", true},
+		{"stream", "stream", "true", true},
+		{"max-cost allowed", "max-cost", "5.00", false},
+		{"json allowed", "json", "true", false},
+		{"out allowed", "out", "/tmp/report.md", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRunCmd()
+			if err := cmd.Flags().Set(tt.flag, tt.value); err != nil {
+				t.Fatalf("Set %s: %v", tt.flag, err)
+			}
+			err := validateComposedFlags(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateComposedFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil {
+				if !strings.Contains(err.Error(), "not applicable to composed agents") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestComposedDryRun(t *testing.T) {
+	manifest := &agent.Manifest{
+		Name:    "test-composed",
+		Version: "1.0",
+		Stages: []agent.ComposedStage{
+			{Name: "analyze", Agents: []string{"scanner-a", "scanner-b"}},
+			{Name: "fix", Agent: "fixer", DependsOn: []string{"analyze"}, Mode: "edit"},
+		},
+		Gates: []agent.ComposedGate{
+			{After: "fix", Command: "go test ./...", OnFailure: "stop"},
+		},
+	}
+
+	p, err := runner.ManifestToPipeline(manifest)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := composedDryRun(cmd, manifest, p); err != nil {
+		t.Fatalf("composedDryRun: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-composed") {
+		t.Error("expected agent name in output")
+	}
+	if !strings.Contains(output, "2 stages") {
+		t.Error("expected stage count in output")
+	}
+	if !strings.Contains(output, "scanner-a, scanner-b") {
+		t.Error("expected parallel agents in output")
+	}
+	if !strings.Contains(output, "fixer") {
+		t.Error("expected fix agent in output")
+	}
+	if !strings.Contains(output, "depends_on: analyze") {
+		t.Error("expected dependency info in output")
+	}
+	if !strings.Contains(output, "go test ./...") {
+		t.Error("expected gate command in output")
+	}
+}
+
+func TestRunComposedAgent_DryRun(t *testing.T) {
+	manifest := `
+name: test-composed
+version: "1.0"
+description: Test composed agent
+
+stages:
+  - name: analyze
+    agents:
+      - scanner-a
+      - scanner-b
+  - name: fix
+    agent: fixer
+    depends_on: [analyze]
+    mode: edit
+
+gates:
+  - after: fix
+    command: "go test ./..."
+    on_failure: stop
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+	v.Set("run.dry_run", true)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("Set dry-run: %v", err)
+	}
+
+	// Execute RunE directly.
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-composed") {
+		t.Errorf("expected agent name in output, got: %s", output)
+	}
+	if !strings.Contains(output, "2 stages") {
+		t.Errorf("expected stage count in output, got: %s", output)
+	}
+}
+
+func TestRunComposedAgent_RejectsIncompatibleFlags(t *testing.T) {
+	manifest := `
+name: test-composed
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+	v.Set("run.dry_run", true)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("system", "override"); err != nil {
+		t.Fatalf("Set system: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for --system with composed agent")
+	}
+	if !strings.Contains(err.Error(), "not applicable to composed agents") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -1019,6 +1019,128 @@ stages:
 	}
 }
 
+func TestRunComposedAgent_ExecutionPath(t *testing.T) {
+	t.Parallel()
+
+	// Create a composed agent whose sub-agent exists on disk.
+	// Execution will fail at model invocation but exercises the full
+	// setup path: config, prompt, workingDir, vars, runner construction.
+	baseDir := t.TempDir()
+
+	// Create the sub-agent.
+	subDir := filepath.Join(baseDir, "agents", "leaf-agent")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "agent.yaml"),
+		[]byte("name: leaf-agent\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "system.md"), []byte("sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the composed agent.
+	composedDir := filepath.Join(baseDir, "agents", "composed-exec")
+	if err := os.MkdirAll(composedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	composedManifest := `
+name: composed-exec
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: leaf-agent
+`
+	if err := os.WriteFile(filepath.Join(composedDir, "agent.yaml"), []byte(composedManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agentsDir := filepath.Join(baseDir, "agents")
+
+	v := viper.New()
+	v.Set("run.agent", "composed-exec")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	if err := cmd.Flags().Set("agent", "composed-exec"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("working-dir", t.TempDir()); err != nil {
+		t.Fatalf("Set working-dir: %v", err)
+	}
+
+	// Run will fail at model invocation (no real provider) — that's expected.
+	// We're testing the setup path, not the model call.
+	err := cmd.RunE(cmd, []string{"test prompt"})
+	if err == nil {
+		t.Fatal("expected error from model invocation")
+	}
+	// Should NOT fail at config/setup level.
+	if strings.Contains(err.Error(), "config not available") {
+		t.Fatalf("setup failed unexpectedly: %v", err)
+	}
+}
+
+func TestRunComposedAgent_StdinPrompt(t *testing.T) {
+	t.Parallel()
+	manifest := `
+name: test-stdin
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-stdin", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-stdin")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	// Provide piped input via a buffer.
+	cmd.SetIn(bytes.NewBufferString("piped prompt content"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Flags().Set("agent", "test-stdin"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("Set dry-run: %v", err)
+	}
+
+	// dry-run with stdin — exercises the prompt reading path.
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+}
+
 func TestInitConfigMissingConfigFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -1029,5 +1151,210 @@ func TestInitConfigMissingConfigFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to read config flag") {
 		t.Fatalf("error = %q, want config flag error", err.Error())
+	}
+}
+
+func TestParseVars(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   []string
+		wantNil bool
+		wantLen int
+		wantKey string
+		wantVal string
+	}{
+		{"nil", nil, true, 0, "", ""},
+		{"empty", []string{}, true, 0, "", ""},
+		{"single", []string{"FOO=bar"}, false, 1, "FOO", "bar"},
+		{"multiple", []string{"A=1", "B=2"}, false, 2, "A", "1"},
+		{"value with equals", []string{"CMD=echo a=b"}, false, 1, "CMD", "echo a=b"},
+		{"no equals skipped", []string{"INVALID"}, false, 0, "", ""},
+		{"empty key skipped", []string{"=value"}, false, 0, "", ""},
+		{"mixed valid and invalid", []string{"GOOD=val", "BAD"}, false, 1, "GOOD", "val"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseVars(tt.input)
+			if tt.wantNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %v", result)
+				}
+				return
+			}
+			if len(result) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(result), tt.wantLen)
+			}
+			if tt.wantKey != "" {
+				if result[tt.wantKey] != tt.wantVal {
+					t.Fatalf("result[%q] = %q, want %q", tt.wantKey, result[tt.wantKey], tt.wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestRunComposedAgent_NoConfig(t *testing.T) {
+	t.Parallel()
+	manifest := `
+name: test-composed
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	// Do NOT set config — this should trigger "config not available" error.
+	cmd.SetContext(ctx)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+	if !strings.Contains(err.Error(), "config not available") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunComposedAgent_WithPromptArgs(t *testing.T) {
+	t.Parallel()
+	manifest := `
+name: test-composed
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("Set dry-run: %v", err)
+	}
+
+	// Pass args (prompt) through to the composed agent dry-run.
+	err := cmd.RunE(cmd, []string{"audit", "this", "repo"})
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if !strings.Contains(buf.String(), "test-composed") {
+		t.Error("expected agent name in output")
+	}
+}
+
+func TestRunComposedAgent_WithWorkingDir(t *testing.T) {
+	t.Parallel()
+	manifest := `
+name: test-composed
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("working-dir", t.TempDir()); err != nil {
+		t.Fatalf("Set working-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("Set dry-run: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+}
+
+func TestRunComposedAgent_WithVars(t *testing.T) {
+	t.Parallel()
+	manifest := `
+name: test-composed
+version: "1.0"
+
+stages:
+  - name: s1
+    agent: a1
+`
+	agentsDir := setupTestAgent(t, "test-composed", manifest, nil)
+
+	v := viper.New()
+	v.Set("run.agent", "test-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.Flags().Set("agent", "test-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("Set dry-run: %v", err)
+	}
+
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
 	}
 }

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -879,7 +879,8 @@ func TestComposedDryRun(t *testing.T) {
 			{Name: "fix", Agent: "fixer", DependsOn: []string{"analyze"}, Mode: "edit"},
 		},
 		Gates: []agent.ComposedGate{
-			{After: "fix", Command: "go test ./...", OnFailure: "stop"},
+			{After: "analyze", Command: "go vet ./..."},
+			{After: "fix", Command: "go test ./...", OnFailure: "revert"},
 		},
 	}
 
@@ -912,8 +913,68 @@ func TestComposedDryRun(t *testing.T) {
 	if !strings.Contains(output, "depends_on: analyze") {
 		t.Error("expected dependency info in output")
 	}
-	if !strings.Contains(output, "go test ./...") {
-		t.Error("expected gate command in output")
+	if !strings.Contains(output, "go vet ./...") {
+		t.Error("expected first gate command in output")
+	}
+	if !strings.Contains(output, "on_failure=stop") {
+		t.Error("expected default on_failure=stop for gate without OnFailure")
+	}
+	if !strings.Contains(output, "on_failure=revert") {
+		t.Error("expected on_failure=revert for second gate")
+	}
+}
+
+func TestComposedDryRun_NoGates(t *testing.T) {
+	manifest := &agent.Manifest{
+		Name:    "no-gates",
+		Version: "1.0",
+		Stages:  []agent.ComposedStage{{Name: "s1", Agent: "a1"}},
+	}
+
+	p, err := runner.ManifestToPipeline(manifest)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := composedDryRun(cmd, manifest, p); err != nil {
+		t.Fatalf("composedDryRun: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "Gates:") {
+		t.Error("should not print Gates section when there are none")
+	}
+}
+
+func TestComposedDryRun_ExplicitMode(t *testing.T) {
+	// Stage with explicit mode set (not default "edit").
+	manifest := &agent.Manifest{
+		Name:    "mode-test",
+		Version: "1.0",
+		Stages: []agent.ComposedStage{
+			{Name: "s1", Agent: "a1", Mode: "readonly"},
+		},
+	}
+
+	p, err := runner.ManifestToPipeline(manifest)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := composedDryRun(cmd, manifest, p); err != nil {
+		t.Fatalf("composedDryRun: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "mode=readonly") {
+		t.Error("expected mode=readonly in output")
 	}
 }
 

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -1266,6 +1266,73 @@ stages:
 	}
 }
 
+func TestRunComposedAgent_StdinAndDefaultWorkDir(t *testing.T) {
+	t.Parallel()
+
+	// Create a composed agent with a real sub-agent so the non-dry-run path
+	// proceeds through stdin reading and default workingDir resolution.
+	baseDir := t.TempDir()
+
+	subDir := filepath.Join(baseDir, "agents", "leaf")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "agent.yaml"),
+		[]byte("name: leaf\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "system.md"), []byte("sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	composedDir := filepath.Join(baseDir, "agents", "stdin-composed")
+	if err := os.MkdirAll(composedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	composedManifest := "name: stdin-composed\nversion: \"1.0\"\nstages:\n  - name: s1\n    agent: leaf\n"
+	if err := os.WriteFile(filepath.Join(composedDir, "agent.yaml"), []byte(composedManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agentsDir := filepath.Join(baseDir, "agents")
+
+	v := viper.New()
+	v.Set("run.agent", "stdin-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	// Piped stdin with NO args — exercises lines 356-362 (stdin reading path).
+	cmd.SetIn(bytes.NewBufferString("piped prompt"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	if err := cmd.Flags().Set("agent", "stdin-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	// Deliberately NOT setting --working-dir to exercise os.Getwd default (lines 365-366).
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error from model invocation")
+	}
+	// Should NOT fail at setup level.
+	if strings.Contains(err.Error(), "config not available") {
+		t.Fatalf("setup failed: %v", err)
+	}
+}
+
 func TestInitConfigMissingConfigFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -1141,6 +1141,70 @@ stages:
 	}
 }
 
+func TestRunComposedAgent_WithInlineStage(t *testing.T) {
+	t.Parallel()
+
+	// Create a composed agent with an inline stage that has prompt files.
+	baseDir := t.TempDir()
+	composedDir := filepath.Join(baseDir, "agents", "inline-composed")
+	if err := os.MkdirAll(composedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(composedDir, "system.md"), []byte("inline sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(composedDir, "agent.md"), []byte("inline wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	composedManifest := `
+name: inline-composed
+version: "1.0"
+
+stages:
+  - name: review
+    entrypoint: system.md
+    wrapper: agent.md
+`
+	if err := os.WriteFile(filepath.Join(composedDir, "agent.yaml"), []byte(composedManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agentsDir := filepath.Join(baseDir, "agents")
+	v := viper.New()
+	v.Set("run.agent", "inline-composed")
+	v.Set("run.agents_dir", agentsDir)
+
+	cmd := newRunCmd()
+	ctx := withViper(context.Background(), v)
+	ctx = withConfig(ctx, config.Defaults())
+	cmd.SetContext(ctx)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	if err := cmd.Flags().Set("agent", "inline-composed"); err != nil {
+		t.Fatalf("Set agent: %v", err)
+	}
+	if err := cmd.Flags().Set("agents-dir", agentsDir); err != nil {
+		t.Fatalf("Set agents-dir: %v", err)
+	}
+	if err := cmd.Flags().Set("working-dir", t.TempDir()); err != nil {
+		t.Fatalf("Set working-dir: %v", err)
+	}
+
+	// Execution will fail at model invocation but exercises inline agent
+	// collection in runComposedAgent (lines 387-392).
+	err := cmd.RunE(cmd, []string{"audit"})
+	if err == nil {
+		t.Fatal("expected error from model invocation")
+	}
+	if strings.Contains(err.Error(), "config not available") {
+		t.Fatalf("setup failed: %v", err)
+	}
+}
+
 func TestInitConfigMissingConfigFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,8 +42,8 @@ exhausted.
 # Single agent with $2 budget
 squad run --agent go-review --max-cost 2.00
 
-# Pipeline with $10 total budget
-squad pipeline run audit.yaml --max-cost 10.00
+# Composed agent with $10 total budget
+squad run --agent security-audit --max-cost 10.00
 ```
 
 Agents can declare cost estimation hints in `agent.yaml`:

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,26 +1,30 @@
-# Pipelines
+# Composed Agents (Pipelines)
 
-Declarative multi-agent pipelines run multiple agents across stages with
-dependency ordering, parallel execution, regression gates, and structured
-output.
+Composed agents run multiple sub-agents across stages with dependency
+ordering, parallel execution, regression gates, and structured output.
+A composed agent declares its pipeline topology in `agent.yaml` — users
+run it with `squad run` like any other agent.
 
-## Running Pipelines
+## Running Composed Agents
 
 ```bash
-# Run a pipeline
-squad pipeline run security-audit.yaml "Assess the target system"
+# Run a composed agent
+squad run --agent security-audit "Assess the target system"
 
 # Run with cost limit and output file
-squad pipeline run recon.yaml --max-cost 5.00 --out report.md
+squad run --agent security-audit --max-cost 5.00 --out report.md
 
-# Validate without running
-squad pipeline run recon.yaml --dry-run
+# Validate without running (shows stages and gates)
+squad run --agent security-audit --dry-run
 
 # Force JSON output
-squad pipeline run recon.yaml --json
+squad run --agent security-audit --json
 ```
 
-## Pipeline YAML Format
+## Composed Agent Manifest
+
+A composed agent's `agent.yaml` uses `stages` instead of `entrypoint`.
+Squad detects this automatically.
 
 ```yaml
 name: security-audit
@@ -53,10 +57,6 @@ gates:
   - after: testing
     command: "go test ./..."
     on_failure: stop
-
-# Output format for the pipeline report
-output:
-  format: json  # json | markdown (default: markdown)
 ```
 
 ## Features
@@ -68,9 +68,14 @@ output:
   the pipeline
 - **Cost budgeting**: `--max-cost` limits total spend across all agents
 - **Structured output**: JSON or Markdown reports with per-stage results
+- **Unified entry point**: `squad run --agent <name>` works for both leaf
+  and composed agents
 
-## Scaffold a Pipeline
+## Leaf vs Composed Manifests
 
-```bash
-squad init pipeline my-pipeline
-```
+| | Leaf Agent | Composed Agent |
+|---|---|---|
+| Has `entrypoint` | Yes | No |
+| Has `stages` | No | Yes |
+| Has `models` | Yes | No (sub-agents declare their own) |
+| Run with | `squad run --agent` | `squad run --agent` |

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -22,6 +22,8 @@ type Pipeline struct {
 
 // Stage is a unit of work in a pipeline. A stage runs one agent or
 // multiple agents in parallel, and may depend on prior stages.
+// A stage can reference external agents (Agent/Agents) or define an
+// inline agent (InlineConfig). These are mutually exclusive.
 type Stage struct {
 	Name            string            `yaml:"name"`
 	Agent           string            `yaml:"agent,omitempty"`  // single agent
@@ -35,6 +37,28 @@ type Stage struct {
 	Partition       *Partition        `yaml:"partition,omitempty"`        // automatic work partitioning
 	Summarize       string            `yaml:"summarize,omitempty"`        // auto | always | never — controls stage output summarization
 	SummarizePrompt string            `yaml:"summarize_prompt,omitempty"` // custom summarization instruction
+	InlineConfig    *InlineConfig     `yaml:"-"`                          // inline agent config (set programmatically, not from YAML)
+}
+
+// InlineConfig holds inline agent configuration set by ManifestToPipeline
+// for stages that define their agent inline rather than referencing an external one.
+type InlineConfig struct {
+	EntryPoint string
+	Wrapper    string
+	Task       string
+	Models     []ModelPreference
+	References []string
+}
+
+// ModelPreference mirrors agent.ModelPreference to avoid circular imports.
+type ModelPreference struct {
+	Model    string
+	Provider string
+}
+
+// IsInline returns true if the stage defines an inline agent.
+func (s Stage) IsInline() bool {
+	return s.InlineConfig != nil
 }
 
 // Partition configures automatic work splitting for a stage.

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1392,3 +1392,52 @@ func TestRunnerAttachFindings(t *testing.T) {
 		t.Fatalf("expected nil findings for nil store, got %v", nilReport.Findings)
 	}
 }
+
+func TestStageIsInline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil InlineConfig", func(t *testing.T) {
+		t.Parallel()
+		s := Stage{Name: "s1", Agent: "a1"}
+		if s.IsInline() {
+			t.Fatal("expected IsInline() = false for stage without InlineConfig")
+		}
+	})
+
+	t.Run("with InlineConfig", func(t *testing.T) {
+		t.Parallel()
+		s := Stage{
+			Name:  "s1",
+			Agent: "s1",
+			InlineConfig: &InlineConfig{
+				EntryPoint: "system.md",
+				Wrapper:    "agent.md",
+			},
+		}
+		if !s.IsInline() {
+			t.Fatal("expected IsInline() = true for stage with InlineConfig")
+		}
+	})
+}
+
+func TestStageAgentList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single agent", func(t *testing.T) {
+		t.Parallel()
+		s := Stage{Name: "s1", Agent: "a1"}
+		got := s.AgentList()
+		if len(got) != 1 || got[0] != "a1" {
+			t.Fatalf("expected [a1], got %v", got)
+		}
+	})
+
+	t.Run("multiple agents", func(t *testing.T) {
+		t.Parallel()
+		s := Stage{Name: "s1", Agents: []string{"a1", "a2"}}
+		got := s.AgentList()
+		if len(got) != 2 {
+			t.Fatalf("expected 2 agents, got %d", len(got))
+		}
+	})
+}

--- a/pipeline/runner.go
+++ b/pipeline/runner.go
@@ -68,15 +68,17 @@ type RunAgentFunc func(ctx context.Context, agentName, prompt, workingDir, mode 
 
 // Runner executes a pipeline configuration.
 type Runner struct {
-	Pipeline   *Pipeline
-	WorkingDir string
-	RunAgent   RunAgentFunc
-	Prompt     string  // base prompt passed to each agent
-	MaxCost    float64 // total cost budget for the pipeline (0 = unlimited)
-	Findings   *tools.FindingsStore
-	Summarize  SummarizeFunc // optional LLM summarization for stage handoffs
-	spent      *csync.Value[float64]
-	sumCache   *summaryCache
+	Pipeline     *Pipeline
+	WorkingDir   string
+	RunAgent     RunAgentFunc
+	Prompt       string  // base prompt passed to each agent
+	MaxCost      float64 // total cost budget for the pipeline (0 = unlimited)
+	Findings     *tools.FindingsStore
+	Summarize    SummarizeFunc            // optional LLM summarization for stage handoffs
+	InlineAgents map[string]*InlineConfig // inline agent configs keyed by stage name
+	ComposedDir  string                   // directory of the composed agent (for resolving inline prompt files)
+	spent        *csync.Value[float64]
+	sumCache     *summaryCache
 }
 
 // Run executes the pipeline and returns a structured report.

--- a/runner/composed.go
+++ b/runner/composed.go
@@ -46,6 +46,25 @@ func ManifestToPipeline(m *agent.Manifest) (*pl.Pipeline, error) {
 			SummarizePrompt: s.SummarizePrompt,
 		}
 
+		// Carry inline agent config through to the pipeline stage.
+		// Use the stage name as the agent identifier so the pipeline
+		// validator sees a valid agent reference.
+		if s.IsInline() {
+			ps.Agent = s.Name
+			ps.InlineConfig = &pl.InlineConfig{
+				EntryPoint: s.EntryPoint,
+				Wrapper:    s.Wrapper,
+				Task:       s.Task,
+				References: s.References,
+			}
+			for _, model := range s.Models {
+				ps.InlineConfig.Models = append(ps.InlineConfig.Models, pl.ModelPreference{
+					Model:    model.Model,
+					Provider: model.Provider,
+				})
+			}
+		}
+
 		for _, pg := range s.PreGates {
 			ps.PreGates = append(ps.PreGates, pl.PreGate{
 				Command: pg.Command,

--- a/runner/composed.go
+++ b/runner/composed.go
@@ -1,0 +1,81 @@
+package runner
+
+import (
+	"fmt"
+
+	"github.com/cowdogmoo/squad/agent"
+	pl "github.com/cowdogmoo/squad/pipeline"
+)
+
+// ComposedFlags lists flags that are incompatible with composed agents.
+// Used by the run command to validate flag usage.
+var ComposedFlags = []string{
+	"system",
+	"print-bundle",
+	"bundle-out",
+	"apply",
+	"apply-fallback",
+	"require-actionable",
+	"stream",
+}
+
+// ManifestToPipeline converts a composed agent manifest into a Pipeline.
+// The manifest's stages and gates are mapped to their pipeline equivalents.
+func ManifestToPipeline(m *agent.Manifest) (*pl.Pipeline, error) {
+	if !m.IsComposed() {
+		return nil, fmt.Errorf("manifest %q is not a composed agent", m.Name)
+	}
+
+	p := &pl.Pipeline{
+		Name:        m.Name,
+		Version:     m.Version,
+		Description: m.Description,
+	}
+
+	for _, s := range m.Stages {
+		ps := pl.Stage{
+			Name:            s.Name,
+			Agent:           s.Agent,
+			Agents:          s.Agents,
+			DependsOn:       s.DependsOn,
+			Mode:            s.Mode,
+			Vars:            s.Vars,
+			Condition:       s.Condition,
+			MaxCost:         s.MaxCost,
+			Summarize:       s.Summarize,
+			SummarizePrompt: s.SummarizePrompt,
+		}
+
+		for _, pg := range s.PreGates {
+			ps.PreGates = append(ps.PreGates, pl.PreGate{
+				Command: pg.Command,
+				Label:   pg.Label,
+				OnError: pg.OnError,
+			})
+		}
+
+		if s.Partition != nil {
+			ps.Partition = &pl.Partition{
+				By:              s.Partition.By,
+				Glob:            s.Partition.Glob,
+				MaxPerPartition: s.Partition.MaxPerPartition,
+			}
+		}
+
+		p.Stages = append(p.Stages, ps)
+	}
+
+	for _, g := range m.Gates {
+		p.Gates = append(p.Gates, pl.Gate{
+			After:     g.After,
+			Command:   g.Command,
+			OnFailure: g.OnFailure,
+		})
+	}
+
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("composed agent %q: pipeline validation failed: %w", m.Name, err)
+	}
+
+	return p, nil
+}

--- a/runner/composed_test.go
+++ b/runner/composed_test.go
@@ -220,3 +220,72 @@ func TestManifestToPipeline_TopologicalOrder(t *testing.T) {
 		t.Fatalf("tier 2: expected 'c', got %q", tiers[2][0].Name)
 	}
 }
+
+func TestManifestToPipeline_InlineConfig(t *testing.T) {
+	t.Parallel()
+
+	m := &agent.Manifest{
+		Name:    "inline-test",
+		Version: "v1",
+		Stages: []agent.ComposedStage{
+			{
+				Name:       "inlined",
+				EntryPoint: "system.md",
+				Wrapper:    "agent.md",
+				Task:       "review",
+				References: []string{"ref1.md"},
+				Models: []agent.ModelPreference{
+					{Model: "gpt-4", Provider: "openai"},
+				},
+			},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	if len(p.Stages) != 1 {
+		t.Fatalf("expected 1 stage, got %d", len(p.Stages))
+	}
+	s := p.Stages[0]
+	if s.InlineConfig == nil {
+		t.Fatal("expected InlineConfig to be set")
+	}
+	if s.InlineConfig.EntryPoint != "system.md" {
+		t.Fatalf("expected entrypoint system.md, got %q", s.InlineConfig.EntryPoint)
+	}
+	if s.InlineConfig.Wrapper != "agent.md" {
+		t.Fatalf("expected wrapper agent.md, got %q", s.InlineConfig.Wrapper)
+	}
+	if s.InlineConfig.Task != "review" {
+		t.Fatalf("expected task review, got %q", s.InlineConfig.Task)
+	}
+	if len(s.InlineConfig.References) != 1 || s.InlineConfig.References[0] != "ref1.md" {
+		t.Fatalf("expected references [ref1.md], got %v", s.InlineConfig.References)
+	}
+	if len(s.InlineConfig.Models) != 1 || s.InlineConfig.Models[0].Model != "gpt-4" {
+		t.Fatalf("expected model gpt-4, got %v", s.InlineConfig.Models)
+	}
+}
+
+func TestManifestToPipeline_ValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	m := &agent.Manifest{
+		Name:    "bad-pipeline",
+		Version: "v1",
+		Stages: []agent.ComposedStage{
+			{Name: "s1", Agent: "a1", DependsOn: []string{"nonexistent"}},
+		},
+	}
+
+	_, err := ManifestToPipeline(m)
+	if err == nil {
+		t.Fatal("expected validation error for unknown dependency")
+	}
+	if !strings.Contains(err.Error(), "pipeline validation failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/runner/composed_test.go
+++ b/runner/composed_test.go
@@ -1,0 +1,222 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
+)
+
+func TestManifestToPipeline_Basic(t *testing.T) {
+	m := &agent.Manifest{
+		Name:        "security-audit",
+		Version:     "1.0",
+		Description: "Parallel security audit",
+		Stages: []agent.ComposedStage{
+			{
+				Name:   "scan",
+				Agents: []string{"injection-scanner", "resource-scanner"},
+			},
+			{
+				Name:      "fix",
+				Agent:     "auto-fixer",
+				DependsOn: []string{"scan"},
+				Mode:      "edit",
+			},
+		},
+		Gates: []agent.ComposedGate{
+			{After: "fix", Command: "go build ./...", OnFailure: "stop"},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	if p.Name != "security-audit" {
+		t.Fatalf("expected name 'security-audit', got %q", p.Name)
+	}
+	if p.Version != "1.0" {
+		t.Fatalf("expected version '1.0', got %q", p.Version)
+	}
+	if p.Description != "Parallel security audit" {
+		t.Fatalf("expected description, got %q", p.Description)
+	}
+	if len(p.Stages) != 2 {
+		t.Fatalf("expected 2 stages, got %d", len(p.Stages))
+	}
+	if len(p.Gates) != 1 {
+		t.Fatalf("expected 1 gate, got %d", len(p.Gates))
+	}
+
+	// Stage 0: scan
+	if p.Stages[0].Name != "scan" {
+		t.Fatalf("stage 0 name: expected 'scan', got %q", p.Stages[0].Name)
+	}
+	if len(p.Stages[0].Agents) != 2 {
+		t.Fatalf("stage 0 agents: expected 2, got %d", len(p.Stages[0].Agents))
+	}
+
+	// Stage 1: fix
+	if p.Stages[1].Agent != "auto-fixer" {
+		t.Fatalf("stage 1 agent: expected 'auto-fixer', got %q", p.Stages[1].Agent)
+	}
+	if p.Stages[1].Mode != "edit" {
+		t.Fatalf("stage 1 mode: expected 'edit', got %q", p.Stages[1].Mode)
+	}
+	if len(p.Stages[1].DependsOn) != 1 || p.Stages[1].DependsOn[0] != "scan" {
+		t.Fatalf("stage 1 deps: expected [scan], got %v", p.Stages[1].DependsOn)
+	}
+
+	// Gate
+	if p.Gates[0].After != "fix" {
+		t.Fatalf("gate after: expected 'fix', got %q", p.Gates[0].After)
+	}
+	if p.Gates[0].Command != "go build ./..." {
+		t.Fatalf("gate command: expected 'go build ./...', got %q", p.Gates[0].Command)
+	}
+}
+
+func TestManifestToPipeline_WithPreGates(t *testing.T) {
+	m := &agent.Manifest{
+		Name: "with-pregates",
+		Stages: []agent.ComposedStage{
+			{
+				Name:  "lint",
+				Agent: "linter",
+				PreGates: []agent.ComposedPreGate{
+					{Command: "golangci-lint run", Label: "golangci-lint", OnError: "continue"},
+				},
+			},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	if len(p.Stages[0].PreGates) != 1 {
+		t.Fatalf("expected 1 pre-gate, got %d", len(p.Stages[0].PreGates))
+	}
+	pg := p.Stages[0].PreGates[0]
+	if pg.Command != "golangci-lint run" {
+		t.Fatalf("pre-gate command: expected 'golangci-lint run', got %q", pg.Command)
+	}
+	if pg.Label != "golangci-lint" {
+		t.Fatalf("pre-gate label: expected 'golangci-lint', got %q", pg.Label)
+	}
+	if pg.OnError != "continue" {
+		t.Fatalf("pre-gate on_error: expected 'continue', got %q", pg.OnError)
+	}
+}
+
+func TestManifestToPipeline_WithPartition(t *testing.T) {
+	m := &agent.Manifest{
+		Name: "with-partition",
+		Stages: []agent.ComposedStage{
+			{
+				Name:  "review",
+				Agent: "reviewer",
+				Partition: &agent.ComposedPartition{
+					By:              "files",
+					Glob:            "**/*.go",
+					MaxPerPartition: 20,
+				},
+			},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	part := p.Stages[0].Partition
+	if part == nil {
+		t.Fatal("expected partition, got nil")
+	}
+	if part.By != "files" {
+		t.Fatalf("partition by: expected 'files', got %q", part.By)
+	}
+	if part.Glob != "**/*.go" {
+		t.Fatalf("partition glob: expected '**/*.go', got %q", part.Glob)
+	}
+	if part.MaxPerPartition != 20 {
+		t.Fatalf("partition max: expected 20, got %d", part.MaxPerPartition)
+	}
+}
+
+func TestManifestToPipeline_WithVarsAndCost(t *testing.T) {
+	m := &agent.Manifest{
+		Name: "with-vars",
+		Stages: []agent.ComposedStage{
+			{
+				Name:    "scan",
+				Agent:   "scanner",
+				Vars:    map[string]string{"SCOPE": "internal"},
+				MaxCost: 3.50,
+			},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	if p.Stages[0].Vars["SCOPE"] != "internal" {
+		t.Fatalf("vars: expected SCOPE=internal, got %v", p.Stages[0].Vars)
+	}
+	if p.Stages[0].MaxCost != 3.50 {
+		t.Fatalf("max_cost: expected 3.50, got %f", p.Stages[0].MaxCost)
+	}
+}
+
+func TestManifestToPipeline_LeafManifestErrors(t *testing.T) {
+	m := &agent.Manifest{
+		Name:       "leaf",
+		EntryPoint: "system.md",
+		Wrapper:    "agent.md",
+	}
+
+	_, err := ManifestToPipeline(m)
+	if err == nil {
+		t.Fatal("expected error for leaf manifest")
+	}
+	if !strings.Contains(err.Error(), "not a composed agent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManifestToPipeline_TopologicalOrder(t *testing.T) {
+	m := &agent.Manifest{
+		Name: "topo-test",
+		Stages: []agent.ComposedStage{
+			{Name: "c", Agent: "a3", DependsOn: []string{"a", "b"}},
+			{Name: "a", Agent: "a1"},
+			{Name: "b", Agent: "a2", DependsOn: []string{"a"}},
+		},
+	}
+
+	p, err := ManifestToPipeline(m)
+	if err != nil {
+		t.Fatalf("ManifestToPipeline: %v", err)
+	}
+
+	// Verify topological ordering works.
+	tiers := p.TopologicalOrder()
+	if len(tiers) != 3 {
+		t.Fatalf("expected 3 tiers, got %d", len(tiers))
+	}
+	if tiers[0][0].Name != "a" {
+		t.Fatalf("tier 0: expected 'a', got %q", tiers[0][0].Name)
+	}
+	if tiers[1][0].Name != "b" {
+		t.Fatalf("tier 1: expected 'b', got %q", tiers[1][0].Name)
+	}
+	if tiers[2][0].Name != "c" {
+		t.Fatalf("tier 2: expected 'c', got %q", tiers[2][0].Name)
+	}
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -95,7 +95,9 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 
 	if err != nil {
 		if errors.Is(err, metrics.ErrBudgetExceeded) {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Run stopped: cost budget of $%.4f exceeded (actual: $%.4f)\n", opts.MaxCost, m.TotalCostWithChildren())
+			if _, fmtErr := fmt.Fprintf(cmd.ErrOrStderr(), "Run stopped: cost budget of $%.4f exceeded (actual: $%.4f)\n", opts.MaxCost, m.TotalCostWithChildren()); fmtErr != nil {
+				logging.Warn("failed to write budget warning: %v", fmtErr)
+			}
 			if response != "" {
 				if handleErr := handleResponse(cmd, opts, response, workingDir); handleErr != nil {
 					logging.Warn("failed to handle partial response: %v", handleErr)
@@ -123,7 +125,7 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
 func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir string) (*agent.Bundle, error) {
-	agentDir, err := findAgentDir(opts.Agent, opts.AgentsDir, opts.Config)
+	agentDir, err := FindAgentDir(opts.Agent, opts.AgentsDir, opts.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +158,9 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		if err != nil {
 			logging.Warn("cost estimation failed: %v", err)
 		} else {
-			_, _ = fmt.Fprint(cmd.ErrOrStderr(), metrics.FormatEstimate(estimate, opts.Provider, opts.Model))
+			if _, fmtErr := fmt.Fprint(cmd.ErrOrStderr(), metrics.FormatEstimate(estimate, opts.Provider, opts.Model)); fmtErr != nil {
+				logging.Warn("failed to write cost estimate: %v", fmtErr)
+			}
 		}
 		return nil, nil
 	}
@@ -241,8 +245,9 @@ func resolveWorkingDir(dir string) (string, error) {
 	return filepath.Abs(dir)
 }
 
-// findAgentDir locates an agent by name using the source manager.
-func findAgentDir(agentName, explicitDir string, cfg *config.Config) (string, error) {
+// FindAgentDir locates an agent by name using the source manager.
+// It returns the path to the agent directory (containing agent.yaml).
+func FindAgentDir(agentName, explicitDir string, cfg *config.Config) (string, error) {
 	if explicitDir != "" {
 		absDir, err := filepath.Abs(explicitDir)
 		if err != nil {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -365,7 +365,9 @@ func TestExecuteRunSuccessOllama(t *testing.T) {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"model":"mistral","message":{"role":"assistant","content":"ok"},"done":true}`))
+		if _, err := w.Write([]byte(`{"model":"mistral","message":{"role":"assistant","content":"ok"},"done":true}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -445,30 +447,30 @@ func TestFindAgentDir(t *testing.T) {
 	t.Run("explicit dir", func(t *testing.T) {
 		t.Parallel()
 		tmp := t.TempDir()
-		got, err := findAgentDir("myagent", tmp, nil)
+		got, err := FindAgentDir("myagent", tmp, nil)
 		if err != nil {
-			t.Fatalf("findAgentDir() error = %v", err)
+			t.Fatalf("FindAgentDir() error = %v", err)
 		}
 		want := filepath.Join(tmp, "myagent")
 		if got != want {
-			t.Fatalf("findAgentDir() = %q, want %q", got, want)
+			t.Fatalf("FindAgentDir() = %q, want %q", got, want)
 		}
 	})
 
 	t.Run("nil config returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := findAgentDir("myagent", "", nil)
+		_, err := FindAgentDir("myagent", "", nil)
 		if err == nil {
-			t.Fatal("findAgentDir() expected error with nil config, got nil")
+			t.Fatal("FindAgentDir() expected error with nil config, got nil")
 		}
 	})
 
 	t.Run("config with no sources returns error", func(t *testing.T) {
 		t.Parallel()
 		cfg := &config.Config{}
-		_, err := findAgentDir("myagent", "", cfg)
+		_, err := FindAgentDir("myagent", "", cfg)
 		if err == nil {
-			t.Fatal("findAgentDir() expected error with empty config, got nil")
+			t.Fatal("FindAgentDir() expected error with empty config, got nil")
 		}
 	})
 }


### PR DESCRIPTION
**Key Changes:**

- Unified `squad run` as the entry point for both composed (pipeline) and leaf agents
- Added composed agent manifest support with validation for mutually exclusive fields
- Implemented conversion of composed agent manifests to pipeline execution
- Removed all code and docs references to `squad pipeline run` in favor of `squad run --agent`

**Added:**

- Composed agent manifest support - Introduced `ComposedStage`, `ComposedGate`, `ComposedPreGate`, and `ComposedPartition` types in `agent/composed.go` with validation logic
- Manifest validation for composed vs leaf agents - Ensures only one of `stages` or `entrypoint` is defined (`agent/composed.go`, `agent/bundle.go`)
- Conversion utility to transform composed agent manifests into pipeline objects for execution (`runner/composed.go`)
- Unit tests for composed agent manifest validation, conversion, and pipeline mapping (`agent/composed_test.go`, `runner/composed_test.go`)
- Forking logic in `cmd/squad/run.go` to detect and execute composed agents using the pipeline runner
- Dry-run mode for composed agents to print validated pipeline topology

**Changed:**

- Updated `LoadManifest` in `agent/bundle.go` to perform validation after YAML parsing, rejecting manifests with both `stages` and `entrypoint`
- Refactored `cmd/squad/run.go` to route composed agents through a new execution path, including flag validation and dry-run support
- Added `--json` flag to `squad run` for composed agent output
- Replaced previous pipeline execution logic with composed agent execution in `cmd/squad/pipeline.go`, including renaming and reorganizing pipeline support functions (`buildComposedRunOpts`, `findAgentDirForComposed`, etc.)
- Updated all tests and helpers in `cmd/squad/pipeline_test.go` to use the new composed agent code path and naming
- Improved error handling and logging for composed agent execution and report output
- Modified `runner/run.go` to export `FindAgentDir` for shared use

**Removed:**

- Deprecated `squad pipeline run` command and related CLI registration in `cmd/squad/pipeline.go` and `cmd/squad/root.go`
- Old pipeline command and test code, including `newPipelineCmd`, `newPipelineRunCmd`, and related tests in `cmd/squad/pipeline_test.go`
- Documentation references to `squad pipeline run`; updated all pipeline documentation to refer to composed agents and `squad run --agent` (`docs/pipelines.md`, `docs/observability.md`)