### PR TITLE
fix: ensure model and provider defaults are taken from manifest if not set

### DIFF
--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -88,6 +88,14 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 		agentOpts.Findings = pipelineRunner.Findings
 		agentOpts.AgentName = agentName
 
+		// Apply manifest model/provider when not explicitly set via CLI flags.
+		if agentOpts.Model == "" && bundle.Model != "" {
+			agentOpts.Model = bundle.Model
+		}
+		if agentOpts.Provider == "" && bundle.Provider != "" {
+			agentOpts.Provider = bundle.Provider
+		}
+
 		// Apply effective budget cap propagated from the pipeline runner.
 		// This accounts for both remaining pipeline budget and per-stage caps.
 		if capStr, ok := mergedVars[pl.PipelineMaxCostVar]; ok {

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -444,6 +444,77 @@ func TestBuildRunAgentFunc_ResolvesAgent(t *testing.T) {
 	}
 }
 
+func TestBuildRunAgentFunc_ManifestModelProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("manifest model and provider applied when opts empty", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := t.TempDir()
+		agentDir := filepath.Join(agentsDir, "model-leaf")
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		manifest := "name: model-leaf\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\nmodels:\n  - model: manifest-model\n    provider: manifest-provider\n"
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("sys"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		opts := &runner.RunOptions{} // No model or provider set
+		pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+		fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+		_, _, err := fn(context.Background(), "model-leaf", "prompt", t.TempDir(), "edit", nil)
+		// Will fail at InvokeModel but confirms manifest values are applied.
+		if err == nil {
+			t.Fatal("expected error from InvokeModel")
+		}
+		// Error should mention manifest-provider (meaning it was applied), not "failed to build agent".
+		if strings.Contains(err.Error(), "failed to build agent") {
+			t.Fatalf("agent resolution failed: %v", err)
+		}
+	})
+
+	t.Run("CLI flags take precedence over manifest", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := t.TempDir()
+		agentDir := filepath.Join(agentsDir, "cli-leaf")
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		manifest := "name: cli-leaf\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\nmodels:\n  - model: manifest-model\n    provider: manifest-provider\n"
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("sys"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		opts := &runner.RunOptions{
+			Provider: "cli-provider",
+			Model:    "cli-model",
+		}
+		pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+		fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+		_, _, err := fn(context.Background(), "cli-leaf", "prompt", t.TempDir(), "edit", nil)
+		if err == nil {
+			t.Fatal("expected error from InvokeModel")
+		}
+		if strings.Contains(err.Error(), "failed to build agent") {
+			t.Fatalf("agent resolution failed: %v", err)
+		}
+	})
+}
+
 func TestBuildRunAgentFunc_BudgetPropagation(t *testing.T) {
 	t.Parallel()
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -138,6 +138,16 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, err
 	}
 
+	// Apply manifest model/provider when not explicitly set via CLI flags.
+	if opts.Model == "" && bundle.Model != "" {
+		opts.Model = bundle.Model
+		logging.InfoContext(cmd.Context(), "using manifest model: %s", bundle.Model)
+	}
+	if opts.Provider == "" && bundle.Provider != "" {
+		opts.Provider = bundle.Provider
+		logging.InfoContext(cmd.Context(), "using manifest provider: %s", bundle.Provider)
+	}
+
 	logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", opts.Agent, opts.Provider, opts.Model)
 
 	if opts.PrintBundle {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -275,6 +275,64 @@ func TestPrepareBundle(t *testing.T) {
 	}
 }
 
+func TestPrepareBundleManifestModelProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("manifest model and provider applied when opts empty", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithModels(t, "model-agent", "manifest-model", "manifest-provider")
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		opts := &RunOptions{
+			Agent:       "model-agent",
+			AgentsDir:   agentsDir,
+			DryRun:      true,
+			PrintBundle: true,
+			BundleOut:   filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+		if err != nil {
+			t.Fatalf("prepareBundle() error = %v", err)
+		}
+		if opts.Model != "manifest-model" {
+			t.Fatalf("expected Model=%q, got %q", "manifest-model", opts.Model)
+		}
+		if opts.Provider != "manifest-provider" {
+			t.Fatalf("expected Provider=%q, got %q", "manifest-provider", opts.Provider)
+		}
+	})
+
+	t.Run("CLI flags take precedence over manifest", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithModels(t, "cli-agent", "manifest-model", "manifest-provider")
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		opts := &RunOptions{
+			Agent:       "cli-agent",
+			AgentsDir:   agentsDir,
+			Model:       "cli-model",
+			Provider:    "cli-provider",
+			DryRun:      true,
+			PrintBundle: true,
+			BundleOut:   filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+		if err != nil {
+			t.Fatalf("prepareBundle() error = %v", err)
+		}
+		if opts.Model != "cli-model" {
+			t.Fatalf("expected Model=%q, got %q", "cli-model", opts.Model)
+		}
+		if opts.Provider != "cli-provider" {
+			t.Fatalf("expected Provider=%q, got %q", "cli-provider", opts.Provider)
+		}
+	})
+}
+
 func TestInvokeModelMissingAPIKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	opts := &RunOptions{Provider: "openai-responses", Model: "gpt-5"}
@@ -536,6 +594,26 @@ func writeTestAgent(t *testing.T, agentName string) string {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	manifest := fmt.Sprintf("name: %s\nversion: 0.0.0\nentrypoint: system.md\nwrapper: wrapper.md\n", agentName)
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("System prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile system.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "wrapper.md"), []byte("Wrapper prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile wrapper.md: %v", err)
+	}
+	return agentsDir
+}
+
+func writeTestAgentWithModels(t *testing.T, agentName, model, provider string) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := fmt.Sprintf("name: %s\nversion: 0.0.0\nentrypoint: system.md\nwrapper: wrapper.md\nmodels:\n  - model: %s\n    provider: %s\n", agentName, model, provider)
 	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
 		t.Fatalf("WriteFile agent.yaml: %v", err)
 	}


### PR DESCRIPTION
**Key Changes:**

- Applied model and provider from manifest when not specified via CLI flags
- Ensured both pipeline and runner logic respect manifest defaults for model/provider
- Added informative logging when manifest values are applied

**Changed:**

- Defaulting logic for agent options - Updated both `buildRunAgentFunc` in `cmd/squad/pipeline.go` and `prepareBundle` in `runner/run.go` to set `Model` and `Provider` from the manifest if not explicitly provided by the user
- Logging enhancements - Added logs in `prepareBundle` to indicate when manifest-supplied model or provider values are used