### PR TITLE
add NVIDIA NIM as a supported AI model provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ FIXME.md
 
 # Go vendor directory
 vendor/
+
+# feature file
+ADD_NVIVIA_AS_PROVIDER.md

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ FIXME.md
 
 # Go vendor directory
 vendor/
-
-# feature file
-ADD_NVIVIA_AS_PROVIDER.md

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -280,7 +280,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	_ = cmd.RegisterFlagCompletionFunc("agent", completeAgentNames)
 	// Static completions for --provider.
 	_ = cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini", "nvidia"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("api-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"openai", "azure"}, cobra.ShellCompDirectiveNoFileComp

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ variables, or config file.
 | Anthropic  | supported | `https://api.anthropic.com/v1`        | required | Claude models via LangChainGo                |
 | Google AI  | supported | Google AI endpoints                   | required | Gemini models via LangChainGo                |
 | Ollama     | supported | `http://localhost:11434/v1` (default) | optional | Local models, uses `max_tokens` compat       |
+| NVIDIA NIM | supported | `https://integrate.api.nvidia.com/v1` (default) | required | OpenAI-compatible; models at build.nvidia.com |
 
 ### OpenAI
 
@@ -96,6 +97,22 @@ squad run --agent go-review --provider anthropic --model claude-sonnet-4-2025051
 
 ```bash
 squad run --agent go-review --provider googleai --model gemini-2.5-flash
+```
+
+### NVIDIA NIM
+
+```bash
+# Using an NVIDIA API key from build.nvidia.com
+squad run --agent go-review \
+  --provider nvidia \
+  --api-key $NVIDIA_API_KEY \
+  --model meta/llama-3.1-8b-instruct
+
+# Or via config / env vars
+export SQUAD_PROVIDER_DEFAULT=nvidia
+export SQUAD_PROVIDER_TOKEN=$NVIDIA_API_KEY
+export SQUAD_MODEL_DEFAULT=meta/llama-3.1-8b-instruct
+squad run --agent go-review
 ```
 
 ### Ollama

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -326,6 +326,7 @@ func lookupLiteLLMPricing(provider, model string) (Pricing, bool) {
 		"openai-responses": {"openai", "azure"},
 		"anthropic":        {"anthropic", "bedrock", "vertex_ai"},
 		"gemini":           {"gemini", "vertex_ai", "vertex_ai-language-models"},
+		"nvidia":           {"nvidia"},
 	}
 
 	if prefixes, ok := providerMappings[provider]; ok {

--- a/runner/model.go
+++ b/runner/model.go
@@ -282,6 +282,8 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildAnthropicLLM(opts, model)
 	case "gemini":
 		return buildGeminiLLM(ctx, opts, model)
+	case "nvidia":
+		return buildNvidiaLLM(opts, model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -350,6 +352,22 @@ func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
+func buildNvidiaLLM(opts *RunOptions, model string) (llms.Model, error) {
+	oaiOpts := []openai.Option{}
+	if model != "" {
+		oaiOpts = append(oaiOpts, openai.WithModel(model))
+	}
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = "https://integrate.api.nvidia.com/v1"
+	}
+	oaiOpts = append(oaiOpts, openai.WithBaseURL(baseURL))
+	if opts.APIKey != "" {
+		oaiOpts = append(oaiOpts, openai.WithToken(opts.APIKey))
+	}
+	return openai.New(oaiOpts...)
+}
+
 func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 	baseURL := opts.BaseURL
 	if baseURL == "" {
@@ -363,7 +381,7 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 }
 
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai"
+	return provider == "" || provider == "openai" || provider == "nvidia"
 }
 
 // reasoningPrefixes returns the configured reasoning model prefixes,

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -55,6 +55,7 @@ func TestIsOpenAICompatProvider(t *testing.T) {
 		{"openai", "openai", true},
 		{"ollama", "ollama", false},
 		{"anthropic", "anthropic", false},
+		{"nvidia", "nvidia", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -111,6 +112,7 @@ func TestBuildLLMVariants(t *testing.T) {
 		{"openai", "openai", "gpt-4o", &RunOptions{APIKey: "token"}, "*openai.LLM", false},
 		{"anthropic", "anthropic", "claude-3", &RunOptions{APIKey: "token"}, "*anthropic.LLM", false},
 		{"gemini", "gemini", "gemini-2.0-flash", &RunOptions{APIKey: "token"}, "*googleai.GoogleAI", false},
+		{"nvidia provider", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "*openai.LLM", false},
 		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Key Changes:

  - Added NVIDIA NIM as a new provider using the OpenAI-compatible API at integrate.api.nvidia.com/v1
  - Wired NVIDIA into the provider routing, shell completion, metrics, and build logic alongside existing providers
  - Added tests and documentation covering NVIDIA usage and configuration

  Added:

  - buildNvidiaLLM function in runner/model.go — constructs an OpenAI-compatible LLM client pointing at NVIDIA's NIM endpoint, with optional model, base URL, and API key overrides
  - NVIDIA NIM provider documentation in docs/configuration.md — includes provider table entry and usage examples via CLI flags and environment variables
  - Unit tests for NVIDIA in runner/model_test.go — covers isOpenAICompatProvider and buildLLM variant dispatch for the nvidia provider

  Changed:

  - Provider routing in runner/model.go — added nvidia case to buildLLM switch and included nvidia in isOpenAICompatProvider so it shares OpenAI-compatible response handling
  - Shell completion in cmd/squad/run.go — added "nvidia" to the --provider flag autocomplete list
  - LiteLLM pricing lookup in metrics/metrics.go — added "nvidia" provider mapping for cost tracking
  - .gitignore — removed the PLAN file entry that was used during development