### PR TITLE
feat: add Databricks AI Gateway as a supported provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Build, share, and run AI agents from the command line. Inspired by
 Define an agent in markdown and YAML, point it at any LLM, and turn it
 loose on a codebase.
 
-- Works with OpenAI, Anthropic, Google AI, and Ollama
+- Works with OpenAI, Anthropic, Google AI, Ollama, NVIDIA NIM, and Databricks AI Gateway
 - Agents are just files: markdown prompts + YAML manifest, checked into git
 - Built-in tools: Read, Write, Edit, Glob, Grep, Bash, plus any MCP server
 - Multi-agent pipelines with dependency ordering, parallel stages, and regression gates
@@ -119,7 +119,7 @@ and can fetch the full bytes (or any byte range) via the
 | Feature                     | Description                                        |
 | --------------------------- | -------------------------------------------------- |
 | **Agent Execution**         | Run agents with Read, Write, Edit, Glob, Grep, Bash |
-| **Multi-provider**          | OpenAI, Anthropic, Google AI, Ollama               |
+| **Multi-provider**          | OpenAI, Anthropic, Google AI, Ollama, NVIDIA NIM, Databricks AI Gateway |
 | **Streaming Output**        | Real-time token streaming to stderr                |
 | **Fix + Analyze Modes**     | Agents can apply fixes or report-only              |
 | **Agent Scaffolding**       | `squad init agent` from templates or existing agents |

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -589,6 +589,11 @@ func buildSystemMessage(manifest *Manifest, displayMode, workingDir, wrapperCont
 	return sys
 }
 
+// BuildBundle assembles a [Bundle] from the named agent in agentsDir.
+// It loads the manifest, processes system/wrapper/task templates with the
+// given mode and vars, resolves references and MCP server configs, and
+// constructs the combined system and user messages. prompt becomes the user
+// message (defaulting to "Begin." when empty).
 func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map[string]string) (*Bundle, error) {
 	agentPath := filepath.Join(agentsDir, agentName)
 

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -283,7 +283,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	_ = cmd.RegisterFlagCompletionFunc("agent", completeAgentNames)
 	// Static completions for --provider.
 	_ = cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini", "nvidia"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini", "nvidia", "databricks"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("api-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"openai", "azure"}, cobra.ShellCompDirectiveNoFileComp

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 
 // OtelConfig holds OpenTelemetry configuration.
 type OtelConfig struct {
+	// Endpoint is the OTLP gRPC endpoint (e.g., "localhost:4317").
+	// An empty string disables telemetry export.
 	Endpoint string `mapstructure:"endpoint" yaml:"endpoint"`
 }
 
@@ -72,27 +74,46 @@ type AgentsConfig struct {
 
 // LogConfig holds logging configuration.
 type LogConfig struct {
-	Level  string `mapstructure:"level" yaml:"level"`
+	// Level is the minimum log level: debug, info, warn, or error.
+	Level string `mapstructure:"level" yaml:"level"`
+	// Format is the log output format: text or json.
 	Format string `mapstructure:"format" yaml:"format"`
 }
 
 // ProviderConfig holds provider defaults.
 type ProviderConfig struct {
-	Default               string `mapstructure:"default" yaml:"default"`
-	BaseURL               string `mapstructure:"base_url" yaml:"base_url"`
-	Organization          string `mapstructure:"organization" yaml:"organization"`
-	APIVersion            string `mapstructure:"api_version" yaml:"api_version"`
-	APIType               string `mapstructure:"api_type" yaml:"api_type"`
-	OpenAICompatMaxTokens bool   `mapstructure:"openai_compat_max_tokens" yaml:"openai_compat_max_tokens"`
-	Token                 string `mapstructure:"token" yaml:"token"`
-	NumCtx                int    `mapstructure:"num_ctx" yaml:"num_ctx"`
+	// Default is the provider name used when none is specified on the
+	// command line or in an agent manifest (e.g., "openai", "anthropic").
+	Default string `mapstructure:"default" yaml:"default"`
+	// BaseURL overrides the provider's default API endpoint URL.
+	BaseURL string `mapstructure:"base_url" yaml:"base_url"`
+	// Organization is the OpenAI organization ID, if required.
+	Organization string `mapstructure:"organization" yaml:"organization"`
+	// APIVersion is used by Azure OpenAI and other versioned APIs.
+	APIVersion string `mapstructure:"api_version" yaml:"api_version"`
+	// APIType selects the API variant (e.g., "azure" for Azure OpenAI).
+	APIType string `mapstructure:"api_type" yaml:"api_type"`
+	// OpenAICompatMaxTokens enforces max_tokens in OpenAI-compatible
+	// requests even when the provider does not strictly require it.
+	OpenAICompatMaxTokens bool `mapstructure:"openai_compat_max_tokens" yaml:"openai_compat_max_tokens"`
+	// Token is the API key or bearer token. It supports command
+	// substitution ($(cmd)) and env-var references ($VAR).
+	Token string `mapstructure:"token" yaml:"token"`
+	// NumCtx is the context window size for Ollama models.
+	NumCtx int `mapstructure:"num_ctx" yaml:"num_ctx"`
 }
 
 // ModelConfig holds model defaults.
 type ModelConfig struct {
-	Default           string   `mapstructure:"default" yaml:"default"`
-	Temperature       float64  `mapstructure:"temperature" yaml:"temperature"`
-	MaxTokens         int      `mapstructure:"max_tokens" yaml:"max_tokens"`
+	// Default is the model identifier used when none is specified on the
+	// command line or in an agent manifest.
+	Default string `mapstructure:"default" yaml:"default"`
+	// Temperature controls sampling randomness (0.0 = deterministic).
+	Temperature float64 `mapstructure:"temperature" yaml:"temperature"`
+	// MaxTokens is the default output-token budget per request.
+	MaxTokens int `mapstructure:"max_tokens" yaml:"max_tokens"`
+	// ReasoningPrefixes lists model name prefixes that support extended
+	// reasoning; requests to these models use higher token budgets.
 	ReasoningPrefixes []string `mapstructure:"reasoning_prefixes" yaml:"reasoning_prefixes"`
 }
 

--- a/docs/agent-quality.md
+++ b/docs/agent-quality.md
@@ -256,6 +256,7 @@ The remaining 75% of the grade requires manual review:
 ### Examples
 
 **Grading mode file input:**
+
 ```bash
 squad grade output.md --agent go-review --iterations 15 --files 12
 ```
@@ -278,6 +279,7 @@ to a file.
 ---
 
 **Grading mode stdin:**
+
 ```bash
 cat output.md | squad grade - --agent go-review --iterations 15 --files 12
 ```
@@ -293,6 +295,7 @@ agent's markdown report to stdout — verify this before using it in CI.
 ---
 
 **Grading with run tracking:**
+
 ```bash
 squad grade output.md --agent go-review --iterations 15 --files 12 \
   --run-id "2026-04-30-main"
@@ -308,6 +311,7 @@ different system prompts.
 ---
 
 **Grading without saving to history:**
+
 ```bash
 squad grade output.md --agent go-review --iterations 15 --files 12 \
   --save=false
@@ -322,6 +326,7 @@ the stats baseline.
 ---
 
 **View grade history (last 10 runs):**
+
 ```bash
 squad grade --history --agent go-review
 ```
@@ -332,6 +337,7 @@ especially after making a prompt change.
 ---
 
 **View grade history — extended window:**
+
 ```bash
 squad grade --history --agent go-review --limit 25
 ```
@@ -341,6 +347,7 @@ squad grade --history --agent go-review --limit 25
 ---
 
 **View grade history as JSON:**
+
 ```bash
 squad grade --history --agent go-review --json
 ```
@@ -351,6 +358,7 @@ import, or a CI quality gate script).
 ---
 
 **View aggregate stats:**
+
 ```bash
 squad grade --stats --agent go-review
 ```

--- a/docs/agent-quality.md
+++ b/docs/agent-quality.md
@@ -91,7 +91,7 @@ Did the agent use its iteration budget well?
 - Read each file once during analysis, catalog all findings, then fix
 - One Grep/Glob on repo root instead of N calls per-directory
 - Verify edits by reading only the changed lines, not the whole file
-- After build+test pass, emit report immediately -- no post-fix exploration
+- After build+test pass, emit report immediately; no post-fix exploration
 
 **Wasteful patterns (deduct points for each):**
 
@@ -153,7 +153,7 @@ list. Strengthen the "follow conventions" rule to name specific patterns
 The agent sees a `panic()` call, knows "panic is bad," and replaces it
 with a warning + fallback. But the panic is intentional (a precondition
 guard) and a test asserts it with `wantPanic: true`. The replacement
-may even pass tests by accident -- e.g. a nil dereference panics before
+may even pass tests by accident; e.g. a nil dereference panics before
 the new code is reached, so `recover()` still catches something.
 
 **Fix:** Make test-asserted behavior an absolute ban: "If a test asserts
@@ -164,7 +164,7 @@ add panic" and "never remove intentional panics."
 
 After applying fixes and verifying build+test pass, the agent spends
 5+ iterations re-reading files, running extra greps, or gathering details
-for the skipped table -- all information it already had from the analysis
+for the skipped table; all information it already had from the analysis
 phase.
 
 **Fix:** Add explicit workflow guidance: "After verification passes, emit
@@ -189,7 +189,9 @@ When creating a new agent (e.g. `go-tests`, `go-cobra`, `security-review`):
    harm), 18 (proportionality), and 19-21 (efficiency) are universal.
 
 2. **Run the agent 3+ times** on the same codebase and grade each run.
-   Look for patterns in what it gets wrong.
+   After each run, pass the agent output to `squad grade` to capture the
+   automated scores, then complete the manual dimensions before recording
+   the final grade. Look for patterns in what it gets wrong.
 
 3. **The first failure mode you see will repeat.** Fix it in the prompt
    immediately. Over-engineering and test-asserted-behavior violations
@@ -206,3 +208,202 @@ When creating a new agent (e.g. `go-tests`, `go-cobra`, `security-review`):
 
 6. **Grade against this rubric after every prompt change.** If the grade
    doesn't improve, the change didn't help -- revert it.
+
+## Using `squad grade`
+
+### What the command automates
+
+`squad grade` scores two dimensions automatically:
+
+- **Report Quality (10%)** checks for required sections using the report
+  parser. The parser auto-detects the report mode from its content and applies
+  the corresponding required-section list:
+  - **Edit mode** (triggered when `## Changes Summary` or
+    `## Issues Found and Fixed` is present): requires `## Changes Summary`,
+    `## Issues Found and Fixed`, `## Files Touched`, `## Validation`.
+  - **Readonly mode** (triggered when `## Analysis Summary` or `## Findings`
+    is present, and neither edit trigger is): requires `## Analysis Summary`,
+    `## Findings`.
+  - If neither trigger is detected the parser defaults to edit mode
+    requirements, which will produce a low Report Quality score. An agent
+    report that uses non-standard headings will be evaluated against the wrong
+    required sections and may score 0% on Report Quality even if all
+    information is present.
+- **Iteration Efficiency (15%)** compares `--iterations` against the
+  target/max thresholds for the codebase size derived from `--files`.
+
+The remaining 75% of the grade requires manual review:
+
+- **Finding Quality (50%)** no tool can judge whether a fix prevents a real
+  bug.
+- **Skip Discipline (25%)** no tool can judge whether the agent respected
+  test-asserted behavior.
+
+### Flag reference
+
+| Flag | Short | Type | Default | Purpose |
+|------|-------|------|---------|---------|
+| `--agent` | `-a` | string | — | Agent name; required for grading and `--stats`; optional for `--history` (omit to show all agents) |
+| `--iterations` | `-i` | int | `0` | Iterations the agent used; required for Efficiency score — omitting silently scores Efficiency as 0% |
+| `--files` | `-f` | int | `0` | Source file count; determines small/medium/large bucket — omitting defaults to the Small bucket (≤20 files) thresholds |
+| `--run-id` | | string | — | Optional label for tracking a specific run in history |
+| `--save` | | bool | `true` | Persist grade to local history store |
+| `--history` | | bool | `false` | Print past grades for the agent instead of grading; takes precedence if combined with `--stats` |
+| `--stats` | | bool | `false` | Print aggregate stats (mean, distribution) for the agent |
+| `--limit` | | int | `10` | Number of history records to show |
+| `--json` | | bool | `false` | Output machine-readable JSON (history and stats modes) |
+
+### Examples
+
+**Grading mode file input:**
+```bash
+squad grade output.md --agent go-review --iterations 15 --files 12
+```
+
+- `output.md` — the report the agent wrote; the parser scans it for required
+  sections to compute the Report Quality score.
+- `--agent go-review` — identifies which agent produced the run. Used to
+  namespace the grade in the history store so `--history` and `--stats`
+  queries stay agent-specific.
+- `--iterations 15` — the number of tool-call iterations the agent consumed.
+  Compared against the target/max thresholds for the codebase size bucket to
+  compute the Iteration Efficiency score.
+- `--files 12` — the number of source files in the codebase. With 12 files the
+  run is classified as "small" (≤20 files), so the efficiency target is ≤12
+  iterations and the max acceptable is 18.
+
+**Use this form** as the default after any `squad run` that writes its output
+to a file.
+
+---
+
+**Grading mode stdin:**
+```bash
+cat output.md | squad grade - --agent go-review --iterations 15 --files 12
+```
+
+The `-` positional argument tells the command to read from stdin instead of a
+file. The flags mean exactly the same thing as the file-input form.
+
+**Use this form** when you want to pipe a report directly into the grader
+without writing an intermediate file, or in CI pipelines. Note: a pipeline of
+the form `squad run ... | squad grade -` only works if `squad run` emits the
+agent's markdown report to stdout — verify this before using it in CI.
+
+---
+
+**Grading with run tracking:**
+```bash
+squad grade output.md --agent go-review --iterations 15 --files 12 \
+  --run-id "2026-04-30-main"
+```
+
+- `--run-id "2026-04-30-main"` an arbitrary label stored alongside the grade.
+  No effect on scoring; exists solely to make history records identifiable when
+  queried later.
+
+**Use this form** when doing systematic prompt tuning across multiple runs with
+different system prompts.
+
+---
+
+**Grading without saving to history:**
+```bash
+squad grade output.md --agent go-review --iterations 15 --files 12 \
+  --save=false
+```
+
+- `--save=false` — overrides the default (`true`) and skips writing to the
+  local grade store.
+
+**Use this form** for exploratory or throwaway runs you do not want polluting
+the stats baseline.
+
+---
+
+**View grade history (last 10 runs):**
+```bash
+squad grade --history --agent go-review
+```
+
+**Use this form** to review how an agent has been trending across recent runs,
+especially after making a prompt change.
+
+---
+
+**View grade history — extended window:**
+```bash
+squad grade --history --agent go-review --limit 25
+```
+
+**Use this form** when you need a longer baseline to spot slow regressions.
+
+---
+
+**View grade history as JSON:**
+```bash
+squad grade --history --agent go-review --json
+```
+
+**Use this form** when piping history into another tool (`jq`, a spreadsheet
+import, or a CI quality gate script).
+
+---
+
+**View aggregate stats:**
+```bash
+squad grade --stats --agent go-review
+```
+
+**Use this form** to get a single-number summary of agent quality across all
+saved runs; useful at the end of a prompt-tuning sprint.
+
+### Interpreting the output
+
+**Grading mode** prints a header line with the letter grade and automated
+score, then per-dimension percentages, run metadata, and a manual-review
+warning:
+
+```
+Grade: B+ (Automated Score: 88%)
+  Report Quality:       100%
+  Iteration Efficiency: 72%
+
+  Iterations: 15 | Files: 12 | Touched: 3 | Fixed: 2 | Skipped: 0
+
+⚠ Manual review required:
+    - Finding Quality (50% of grade)
+    - Skip Discipline (25% of grade)
+  Note: Iteration target: 12 (max acceptable: 18) for 12 files
+```
+
+**Critical**: the letter grade and "Automated Score" reflect only the
+automated 25% of the rubric, scaled to 0–100 using the formula:
+
+```
+automated_points = (report_quality / 100) * 10
+                 + (iteration_efficiency / 100) * 15
+total_score      = (automated_points / 25) * 100
+```
+
+A displayed grade of A+ means the agent scored 100% on the two automated
+dimensions only. The grade is provisional — it will change once Finding
+Quality (50%) and Skip Discipline (25%) are scored manually.
+
+**History mode** prints a table of past grades with timestamps, agent name,
+letter grade, automated score, and iteration count, sorted newest-first.
+
+**Stats mode** prints total runs, latest grade, average automated score,
+average per-dimension scores, and grade distribution (A+/A/A-/B+/… counts).
+
+### Notes
+
+- The grading store is local (no remote sync); grades are written to
+  `~/.cache/squad/grades.json`.
+- Omitting `--iterations` defaults to `0`, which scores Efficiency as 0% and
+  appends "No iteration count provided". Always pass `--iterations` explicitly.
+- Omitting `--files` defaults to `0`, which silently falls into the Small
+  bucket. If the codebase is medium or large this produces an artificially
+  strict score — always pass `--files`.
+- If both `--history` and `--stats` are passed, `--history` takes precedence
+  and `--stats` is silently ignored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ variables, or config file.
 | Google AI  | supported | Google AI endpoints                   | required | Gemini models via LangChainGo                |
 | Ollama     | supported | `http://localhost:11434/v1` (default) | optional | Local models, uses `max_tokens` compat       |
 | NVIDIA NIM | supported | `https://integrate.api.nvidia.com/v1` (default) | required | OpenAI-compatible; models at build.nvidia.com |
+| Databricks AI Gateway | supported | `https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1` | required | OpenAI-compatible; PAT (`dapi-` prefix) as Bearer token |
 
 ### OpenAI
 
@@ -114,6 +115,78 @@ export SQUAD_PROVIDER_TOKEN=$NVIDIA_API_KEY
 export SQUAD_MODEL_DEFAULT=meta/llama-3.1-8b-instruct
 squad run --agent go-review
 ```
+
+### Databricks AI Gateway
+
+Databricks AI Gateway is an OpenAI-compatible proxy that routes requests to
+foundation models hosted on Databricks. It is currently in **beta** (no charges
+during beta; unavailable on GovCloud/Azure Government).
+
+**Endpoint format:** The base URL uses the `ai-gateway` subdomain — not the
+workspace URL. The path is always `/mlflow/v1` regardless of which model you
+target; langchaingo appends `/chat/completions` automatically:
+
+```
+https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
+```
+
+**Authentication:** Send a Databricks PAT (`dapi-` prefix) or OAuth access token
+via `--api-key` / `SQUAD_PROVIDER_TOKEN`. The token is forwarded as
+`Authorization: Bearer <token>`. PATs can be scoped to specific API operations
+for least-privilege access.
+
+**Model field:** The `--model` value is the name of the deployed gateway endpoint
+(e.g. `databricks-gpt-5-5-pro`), not a model family.
+
+```bash
+# CLI flags
+squad run --agent go-review \
+  --provider databricks \
+  --base-url "https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1" \
+  --api-key "dapi-your-databricks-token" \
+  --model databricks-gpt-5-5-pro
+
+# Environment variables
+export SQUAD_PROVIDER_DEFAULT=databricks
+export SQUAD_PROVIDER_BASE_URL=https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
+export SQUAD_PROVIDER_TOKEN=dapi-your-databricks-token
+export SQUAD_MODEL_DEFAULT=databricks-gpt-5-5-pro
+squad run --agent go-review
+```
+
+Config file with short-lived OAuth token via shell substitution:
+
+```yaml
+provider:
+  default: databricks
+  base_url: https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
+  token: $(databricks auth token --host https://<workspace-url> 2>/dev/null | jq -r .access_token)
+model:
+  default: databricks-gpt-5-5-pro
+```
+
+Agent manifest override:
+
+```yaml
+models:
+  - model: databricks-gpt-5-5-pro
+    provider: databricks
+```
+
+Example endpoint names: `databricks-gpt-5-5-pro`, `databricks-claude-sonnet-4-5`,
+`databricks-meta-llama-3-3-70b-instruct`.
+
+**Rate limiting** is configured on the Databricks side per endpoint, per user,
+and per group — not in squad.
+
+**Claude Code integration:** Databricks AI Gateway natively supports Claude Code
+as a coding agent, making it straightforward to route squad's LLM calls through
+the gateway for enterprise governance.
+
+**Known limitation:** The `usage_context` map (per-request cost attribution stored
+as `request_tags` in `system.ai_gateway.usage`) requires `extra_body` support in
+the OpenAI client, which langchaingo does not currently provide. This is a
+candidate follow-on item.
 
 ### Ollama
 

--- a/grading/grading.go
+++ b/grading/grading.go
@@ -38,12 +38,15 @@ type GradeResult struct {
 }
 
 // GradeOptions configures the grading calculation.
-
 type GradeOptions struct {
-	Agent      string
+	// Agent is the name of the agent being graded.
+	Agent string
+	// Iterations is the number of model iterations consumed by the run.
 	Iterations int
-	FileCount  int
-	RunID      string
+	// FileCount is the number of files in the target codebase.
+	FileCount int
+	// RunID is an optional identifier linking the grade to a specific run.
+	RunID string
 }
 
 // iterationTargets defines iteration budgets by codebase size.
@@ -57,7 +60,10 @@ var iterationTargets = []struct {
 	{999999, 40, 60}, // Large
 }
 
-// ComputeGrade calculates the grade for a parsed agent output.
+// ComputeGrade calculates the automated grade for a parsed agent output.
+// It scores report quality (10% of total) and iteration efficiency (15%),
+// returning a [GradeResult] with a letter grade and component breakdowns.
+// The remaining 75% requires manual review.
 func ComputeGrade(parsed *ParsedOutput, opts GradeOptions) *GradeResult {
 	result := &GradeResult{
 		Agent:      opts.Agent,
@@ -196,7 +202,7 @@ func calculateLetterGrade(score float64) string {
 	}
 }
 
-// FormatResult returns a human-readable summary of the grade.
+// FormatResult returns a human-readable multi-line summary of the grade result.
 func FormatResult(r *GradeResult) string {
 	s := fmt.Sprintf("Grade: %s (Automated Score: %.0f%%)\n", r.Grade, r.TotalScore)
 	s += fmt.Sprintf("  Report Quality:       %.0f%%\n", r.ReportQuality)

--- a/grading/parser.go
+++ b/grading/parser.go
@@ -53,7 +53,6 @@ type Parser struct {
 }
 
 // NewParser creates a new output parser.
-
 func NewParser() *Parser {
 	return &Parser{
 		sectionPatterns: map[string]*regexp.Regexp{

--- a/grading/store.go
+++ b/grading/store.go
@@ -8,18 +8,20 @@ import (
 	"sort"
 )
 
-// Store persists grade results to disk.
+// Store persists grade results to a JSON file on disk.
+// Use [NewStore] to create one at the default cache location or
+// [NewStoreAt] to specify an explicit path.
 type Store struct {
-	path string
+	path string // absolute path to the grades JSON file
 }
 
-// GradeHistory holds all stored grades.
+// GradeHistory is the top-level container written to and read from the store
+// file. It holds all recorded [GradeResult] values in append order.
 type GradeHistory struct {
 	Grades []*GradeResult `json:"grades"`
 }
 
 // NewStore creates a store at the default location (~/.cache/squad/grades.json).
-
 func NewStore() (*Store, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,6 +21,8 @@ const (
 // ErrBudgetExceeded is returned when the configured cost budget is exhausted.
 var ErrBudgetExceeded = fmt.Errorf("cost budget exceeded")
 
+// ChildMetrics holds token usage from a single child agent run,
+// recorded in the parent [Metrics] by [Metrics.AddChild].
 type ChildMetrics struct {
 	Agent        string
 	InputTokens  int64
@@ -326,7 +328,8 @@ func lookupLiteLLMPricing(provider, model string) (Pricing, bool) {
 		"openai-responses": {"openai", "azure"},
 		"anthropic":        {"anthropic", "bedrock", "vertex_ai"},
 		"gemini":           {"gemini", "vertex_ai", "vertex_ai-language-models"},
-		"nvidia":           {"nvidia"},
+		"nvidia":      {"nvidia"},
+		"databricks": {"databricks"},
 	}
 
 	if prefixes, ok := providerMappings[provider]; ok {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -328,8 +328,8 @@ func lookupLiteLLMPricing(provider, model string) (Pricing, bool) {
 		"openai-responses": {"openai", "azure"},
 		"anthropic":        {"anthropic", "bedrock", "vertex_ai"},
 		"gemini":           {"gemini", "vertex_ai", "vertex_ai-language-models"},
-		"nvidia":      {"nvidia"},
-		"databricks": {"databricks"},
+		"nvidia":           {"nvidia"},
+		"databricks":       {"databricks"},
 	}
 
 	if prefixes, ok := providerMappings[provider]; ok {

--- a/runner/model.go
+++ b/runner/model.go
@@ -284,6 +284,8 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildGeminiLLM(ctx, opts, model)
 	case "nvidia":
 		return buildNvidiaLLM(opts, model)
+	case "databricks":
+		return buildDatabricksLLM(opts, model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -368,6 +370,28 @@ func buildNvidiaLLM(opts *RunOptions, model string) (llms.Model, error) {
 	return openai.New(oaiOpts...)
 }
 
+func buildDatabricksLLM(opts *RunOptions, model string) (llms.Model, error) {
+	if opts.BaseURL == "" {
+		return nil, fmt.Errorf(
+			"databricks provider requires --base-url " +
+				"(e.g. https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1)",
+		)
+	}
+	if opts.APIKey == "" {
+		return nil, fmt.Errorf(
+			"databricks provider requires --api-key (Databricks PAT, prefix dapi-)",
+		)
+	}
+	oaiOpts := []openai.Option{
+		openai.WithBaseURL(opts.BaseURL),
+		openai.WithToken(opts.APIKey),
+	}
+	if model != "" {
+		oaiOpts = append(oaiOpts, openai.WithModel(model))
+	}
+	return openai.New(oaiOpts...)
+}
+
 func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 	baseURL := opts.BaseURL
 	if baseURL == "" {
@@ -381,7 +405,7 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 }
 
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai" || provider == "nvidia"
+	return provider == "" || provider == "openai" || provider == "nvidia" || provider == "databricks"
 }
 
 // reasoningPrefixes returns the configured reasoning model prefixes,

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -56,6 +56,7 @@ func TestIsOpenAICompatProvider(t *testing.T) {
 		{"ollama", "ollama", false},
 		{"anthropic", "anthropic", false},
 		{"nvidia", "nvidia", true},
+		{"databricks", "databricks", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,6 +115,33 @@ func TestBuildLLMVariants(t *testing.T) {
 		{"gemini", "gemini", "gemini-2.0-flash", &RunOptions{APIKey: "token"}, "*googleai.GoogleAI", false},
 		{"nvidia provider", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "*openai.LLM", false},
 		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
+		{
+			"databricks provider",
+			"databricks",
+			"databricks-gpt-5-5-pro",
+			&RunOptions{
+				APIKey:  "dapi-test-token",
+				BaseURL: "https://7474657828785521.ai-gateway.cloud.databricks.com/mlflow/v1",
+			},
+			"*openai.LLM",
+			false,
+		},
+		{
+			"databricks provider missing base URL",
+			"databricks",
+			"databricks-gpt-5-5-pro",
+			&RunOptions{APIKey: "dapi-test-token"},
+			"",
+			true,
+		},
+		{
+			"databricks provider missing api key",
+			"databricks",
+			"databricks-gpt-5-5-pro",
+			&RunOptions{BaseURL: "https://7474657828785521.ai-gateway.cloud.databricks.com/mlflow/v1"},
+			"",
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runner/run.go
+++ b/runner/run.go
@@ -23,43 +23,82 @@ import (
 
 // RunOptions holds the resolved configuration for a single run invocation.
 type RunOptions struct {
-	Agent              string
-	AgentsDir          string
-	WorkingDir         string
-	APIKey             string
-	BaseURL            string
-	Org                string
-	APIVersion         string
-	APIType            string
-	OpenAICompatMax    bool
-	Provider           string
-	Model              string
-	Temperature        float64
-	MaxTokens          int
-	System             string
-	Output             string
-	Print              bool
-	BundleOut          string
-	PrintBundle        bool
-	DryRun             bool
-	RequireActionable  bool
-	Apply              bool
-	ApplyFallback      bool
-	NumCtx             int
-	MaxIterations      int
-	MaxCost            float64
-	Mode               string
-	Vars               map[string]string // Template variables (e.g., COVERAGE_TARGET=85)
-	ConfigAvailable    bool
-	Config             *config.Config
-	Findings           *tools.FindingsStore // shared findings store (set by pipeline runner)
-	AgentName          string               // current agent name for finding attribution
-	MCPServers         []mcp.ServerConfig   // MCP servers from CLI --mcp-server flags
-	Stream             bool                 // stream model output tokens to stderr as they arrive
-	MaxConcurrentTasks int                  // max concurrent background child tasks (0 = default)
-	ResumeID           string               // session id to resume; empty = start a new session
-	ResumeResponseID   string               // OpenAI response id to chain from (set by openSession when resuming)
-	NoSession          bool                 // disable session log entirely (e.g. for tests)
+	// Agent is the name of the agent to run (must exist under AgentsDir).
+	Agent string
+	// AgentsDir is the directory containing agent sub-directories.
+	AgentsDir string
+	// WorkingDir is the directory the agent operates in.
+	WorkingDir string
+	// APIKey is the provider API key (overrides config/env).
+	APIKey string
+	// BaseURL overrides the provider's default API endpoint.
+	BaseURL string
+	// Org is the OpenAI organization ID.
+	Org string
+	// APIVersion is used by Azure OpenAI and other versioned APIs.
+	APIVersion string
+	// APIType selects the API variant (e.g., "azure").
+	APIType string
+	// OpenAICompatMax enforces max_tokens for OpenAI-compatible providers.
+	OpenAICompatMax bool
+	// Provider is the model provider name (e.g., "openai", "anthropic").
+	Provider string
+	// Model is the model identifier, overriding the agent manifest.
+	Model string
+	// Temperature controls sampling randomness.
+	Temperature float64
+	// MaxTokens is the per-request output token budget.
+	MaxTokens int
+	// System overrides the agent's assembled system prompt.
+	System string
+	// Output is the file path for writing the model's final response.
+	Output string
+	// Print reports whether to write the response to stdout.
+	Print bool
+	// BundleOut is the file path for writing the assembled prompt bundle.
+	BundleOut string
+	// PrintBundle reports whether to print the bundle to stdout.
+	PrintBundle bool
+	// DryRun reports whether to estimate cost and exit without running.
+	DryRun bool
+	// RequireActionable reports whether the run must produce file edits.
+	RequireActionable bool
+	// Apply reports whether to apply a unified diff from the response.
+	Apply bool
+	// ApplyFallback reports whether to attempt diff parsing as a fallback.
+	ApplyFallback bool
+	// NumCtx is the context window size for Ollama models.
+	NumCtx int
+	// MaxIterations caps the number of model iterations (0 = unlimited).
+	MaxIterations int
+	// MaxCost is the total cost budget in USD (0 = unlimited).
+	MaxCost float64
+	// Mode is the run mode passed to prompt templates (e.g., "edit").
+	Mode string
+	// Vars holds template variables passed to prompt templates.
+	Vars map[string]string
+	// ConfigAvailable reports whether a config file was loaded.
+	ConfigAvailable bool
+	// Config is the loaded squad configuration.
+	Config *config.Config
+	// Findings is a shared findings store set by the pipeline runner.
+	Findings *tools.FindingsStore
+	// AgentName is the current agent name used for finding attribution.
+	AgentName string
+	// MCPServers lists MCP servers declared via --mcp-server flags.
+	MCPServers []mcp.ServerConfig
+	// Stream reports whether to stream response tokens to stderr.
+	Stream bool
+	// MaxConcurrentTasks is the maximum number of concurrent background
+	// child tasks (0 = default).
+	MaxConcurrentTasks int
+	// ResumeID is the session ID to resume; empty starts a new session.
+	ResumeID string
+	// ResumeResponseID is the OpenAI response ID to chain from, set by
+	// openSession when resuming an existing session.
+	ResumeResponseID string
+	// NoSession disables session logging (e.g., for tests).
+	NoSession bool
 }
 
 // ExecuteRun contains the full run command logic, parameterized by RunOptions.


### PR DESCRIPTION
Key Changes:

  - Databricks AI Gateway is now a first-class provider alongside OpenAI, Anthropic, Google AI, Ollama, and NVIDIA NIM
  - Comprehensive squad grade command reference added to docs/agent-quality.md covering all flags, modes, output interpretation, and usage examples
  - Extensive Go doc comments added across RunOptions, config structs, grading types, and public functions

  Added:

  - Databricks provider implementation - buildDatabricksLLM in runner/model.go constructs an OpenAI-compatible client requiring explicit --base-url and --api-key (Databricks PAT);
  "databricks" added to shell completion list and isOpenAICompatProvider
  - Databricks pricing mapping - added "databricks" entry in metrics/metrics.go lookupLiteLLMPricing provider mappings
  - Databricks test coverage - three new cases in runner/model_test.go covering successful init, missing base URL, and missing API key
  - squad grade documentation - full flag reference table, graded/history/stats mode examples, automated-score formula, and output interpretation guide added to
  docs/agent-quality.md

  Changed:

  - Configuration docs - docs/configuration.md updated with a dedicated Databricks AI Gateway section covering endpoint format, authentication, model naming, rate limiting, Claude
  Code integration note, and known usage_context limitation
  - README provider lists - updated feature table and intro bullet in README.md to include NVIDIA NIM and Databricks AI Gateway
  - Doc comments - comprehensive field-level comments added to RunOptions (runner/run.go), ProviderConfig/ModelConfig/LogConfig/OtelConfig (config/config.go),
  GradeOptions/Store/GradeHistory (grading/), ChildMetrics (metrics/metrics.go), and BuildBundle (agent/bundle.go)
  - Punctuation cleanup - replaced -- em-dash usage with semicolons in two prose sentences in docs/agent-quality.md