### PR TITLE
refactor: separate explicit and config model/provider for manifest precedence

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -90,6 +90,20 @@ type ChildBudget struct {
 	MaxIterations int     `yaml:"max_iterations,omitempty"` // iteration cap for child (0 = inherit parent's cap)
 }
 
+// FindModel returns the ModelPreference matching the given provider and model,
+// or nil if not found. An empty provider or model never matches.
+func (b *Bundle) FindModel(provider, model string) *ModelPreference {
+	if provider == "" || model == "" {
+		return nil
+	}
+	for i := range b.Models {
+		if b.Models[i].Provider == provider && b.Models[i].Model == model {
+			return &b.Models[i]
+		}
+	}
+	return nil
+}
+
 // ChildNames returns the list of child agent names.
 func (b *BudgetConfig) ChildNames() []string {
 	if b == nil {

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1223,3 +1223,58 @@ models:
 		t.Fatalf("Models[2].Model = %q, want claude-sonnet-4-6", bundle.Models[2].Model)
 	}
 }
+
+func TestBundle_FindModel(t *testing.T) {
+	t.Parallel()
+	b := &Bundle{
+		Models: []ModelPreference{
+			{Model: "gemini-2.5-flash", Provider: "google"},
+			{Model: "gpt-4.1-mini", Provider: "openai"},
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		wantNil  bool
+	}{
+		{"match first entry", "google", "gemini-2.5-flash", false},
+		{"match middle entry", "openai", "gpt-4.1-mini", false},
+		{"match last entry", "anthropic", "claude-sonnet-4-6", false},
+		{"unknown provider", "azure", "gpt-4.1-mini", true},
+		{"unknown model for known provider", "openai", "gpt-5", true},
+		{"empty provider", "", "gpt-4.1-mini", true},
+		{"empty model", "openai", "", true},
+		{"both empty", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := b.FindModel(tt.provider, tt.model)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("FindModel(%q, %q) = %+v, want nil", tt.provider, tt.model, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("FindModel(%q, %q) = nil, want match", tt.provider, tt.model)
+			}
+			if got.Provider != tt.provider || got.Model != tt.model {
+				t.Fatalf("FindModel(%q, %q) = {%q, %q}, want {%q, %q}",
+					tt.provider, tt.model, got.Provider, got.Model, tt.provider, tt.model)
+			}
+		})
+	}
+}
+
+func TestBundle_FindModel_EmptyModelsList(t *testing.T) {
+	t.Parallel()
+	b := &Bundle{}
+	if got := b.FindModel("openai", "gpt-5"); got != nil {
+		t.Fatalf("FindModel on empty bundle = %+v, want nil", got)
+	}
+}

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -88,13 +88,7 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 		agentOpts.Findings = pipelineRunner.Findings
 		agentOpts.AgentName = agentName
 
-		// Apply manifest model/provider when not explicitly set via CLI flags.
-		if agentOpts.Model == "" && bundle.Model != "" {
-			agentOpts.Model = bundle.Model
-		}
-		if agentOpts.Provider == "" && bundle.Provider != "" {
-			agentOpts.Provider = bundle.Provider
-		}
+		runner.ResolveModelPrecedence(ctx, &agentOpts, bundle)
 
 		// Apply effective budget cap propagated from the pipeline runner.
 		// This accounts for both remaining pipeline budget and per-stage caps.
@@ -150,8 +144,24 @@ func outputReport(cmd *cobra.Command, p *pl.Pipeline, pipelineRunner *pl.Runner,
 func buildComposedRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOptions {
 	v := viperFromContext(cmd)
 
-	provider := flagOrViper(cmd, "provider", v, "provider.default")
-	model := flagOrViper(cmd, "model", v, "model.default")
+	// Split provider/model into explicit (CLI) vs config-default buckets
+	// so manifest preferences can win over config defaults.
+	var providerVal, modelVal string
+	if v != nil {
+		providerVal = v.GetString("provider.default")
+		modelVal = v.GetString("model.default")
+	}
+	var explicitProvider, configProvider, explicitModel, configModel string
+	if cmd.Flags().Changed("provider") {
+		explicitProvider, _ = cmd.Flags().GetString("provider")
+	} else {
+		configProvider = providerVal
+	}
+	if cmd.Flags().Changed("model") {
+		explicitModel, _ = cmd.Flags().GetString("model")
+	} else {
+		configModel = modelVal
+	}
 	apiKey := flagOrViper(cmd, "api-key", v, "provider.token")
 	baseURL := flagOrViper(cmd, "base-url", v, "provider.base_url")
 	org := flagOrViper(cmd, "organization", v, "provider.organization")
@@ -182,8 +192,10 @@ func buildComposedRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOpt
 		APIVersion:      apiVersion,
 		APIType:         apiType,
 		OpenAICompatMax: openAICompatMax,
-		Provider:        provider,
-		Model:           model,
+		Provider:        explicitProvider,
+		Model:           explicitModel,
+		ConfigProvider:  configProvider,
+		ConfigModel:     configModel,
 		Temperature:     temp,
 		MaxTokens:       maxTokens,
 		NumCtx:          numCtx,

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -88,7 +88,9 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 		agentOpts.Findings = pipelineRunner.Findings
 		agentOpts.AgentName = agentName
 
-		runner.ResolveModelPrecedence(ctx, &agentOpts, bundle)
+		if warn := runner.ResolveModelPrecedence(ctx, &agentOpts, bundle); warn != "" {
+			fmt.Fprintln(os.Stderr, warn)
+		}
 
 		// Apply effective budget cap propagated from the pipeline runner.
 		// This accounts for both remaining pipeline budget and per-stage caps.

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -157,6 +157,59 @@ func TestBuildComposedRunOpts(t *testing.T) {
 			t.Fatalf("expected MaxTokens=2048, got %d", opts.MaxTokens)
 		}
 	})
+
+}
+
+// TestBuildComposedRunOptsExplicitFlagBucket asserts that explicit
+// --provider/--model CLI flags populate Model/Provider and leave
+// ConfigModel/ConfigProvider empty, so the manifest precedence logic
+// treats them as user-explicit (highest precedence).
+func TestBuildComposedRunOptsExplicitFlagBucket(t *testing.T) {
+	t.Parallel()
+	cmd := newTestRunCmdWithContext(nil)
+	_ = cmd.Flags().Set("provider", "openai")
+	_ = cmd.Flags().Set("model", "gpt-4")
+	opts := buildComposedRunOpts(cmd, nil)
+	if opts.Provider != "openai" {
+		t.Fatalf("Provider=%q, want openai", opts.Provider)
+	}
+	if opts.Model != "gpt-4" {
+		t.Fatalf("Model=%q, want gpt-4", opts.Model)
+	}
+	if opts.ConfigProvider != "" {
+		t.Fatalf("explicit flag should not populate ConfigProvider, got %q", opts.ConfigProvider)
+	}
+	if opts.ConfigModel != "" {
+		t.Fatalf("explicit flag should not populate ConfigModel, got %q", opts.ConfigModel)
+	}
+}
+
+// TestBuildComposedRunOptsConfigDefaultsBucket asserts that config-file
+// defaults route into ConfigModel/ConfigProvider rather than the explicit
+// Model/Provider fields. If they collapsed into Model/Provider, the agent
+// manifest's model preference would be silently overridden.
+func TestBuildComposedRunOptsConfigDefaultsBucket(t *testing.T) {
+	t.Parallel()
+	cmd := newRunCmd()
+	ctx := context.Background()
+	v := viper.New()
+	v.Set("provider.default", "nvidia")
+	v.Set("model.default", "qwen/qwen3-coder")
+	ctx = withViper(ctx, v)
+	cmd.SetContext(ctx)
+	opts := buildComposedRunOpts(cmd, nil)
+	if opts.Provider != "" {
+		t.Fatalf("config default leaked into explicit Provider: %q", opts.Provider)
+	}
+	if opts.Model != "" {
+		t.Fatalf("config default leaked into explicit Model: %q", opts.Model)
+	}
+	if opts.ConfigProvider != "nvidia" {
+		t.Fatalf("ConfigProvider=%q, want nvidia", opts.ConfigProvider)
+	}
+	if opts.ConfigModel != "qwen/qwen3-coder" {
+		t.Fatalf("ConfigModel=%q, want qwen/qwen3-coder", opts.ConfigModel)
+	}
 }
 
 func TestOutputReport(t *testing.T) {

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -566,6 +567,53 @@ func TestBuildRunAgentFunc_ManifestModelProvider(t *testing.T) {
 			t.Fatalf("agent resolution failed: %v", err)
 		}
 	})
+}
+
+// TestBuildRunAgentFunc_ConfigDefaultNotInManifestWarns asserts that when the
+// config default model/provider is not listed in the agent manifest, the
+// fallback warning is emitted on stderr.
+func TestBuildRunAgentFunc_ConfigDefaultNotInManifestWarns(t *testing.T) {
+	// Redirects os.Stderr; cannot run in parallel with other os.Stderr users.
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "warn-leaf")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: warn-leaf\nversion: v1\nentrypoint: system.md\nwrapper: agent.md\nmodels:\n  - model: manifest-model\n    provider: manifest-provider\n"
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("sys"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.md"), []byte("wrap"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	opts := &runner.RunOptions{
+		ConfigModel:    "other-model",
+		ConfigProvider: "other-provider",
+	}
+	pRunner := &pl.Runner{InlineAgents: make(map[string]*pl.InlineConfig)}
+
+	fn := buildRunAgentFunc(opts, agentsDir, "", &config.Config{}, nil, pRunner)
+	_, _, runErr := fn(context.Background(), "warn-leaf", "prompt", t.TempDir(), "edit", nil)
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	if runErr == nil {
+		t.Fatal("expected error from InvokeModel")
+	}
+	if !strings.Contains(string(out), "not listed in the agent manifest") {
+		t.Fatalf("expected warning on stderr, got %q", string(out))
+	}
 }
 
 func TestBuildRunAgentFunc_BudgetPropagation(t *testing.T) {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -93,6 +93,24 @@ func newRunOptions(cmd *cobra.Command) *runner.RunOptions {
 	}
 
 	cfg := configFromContext(cmd)
+
+	// Split provider/model into explicit (CLI flag) vs config-default
+	// buckets so manifest preferences can win over config defaults but
+	// still yield to an explicit --provider / --model.
+	providerVal := v.GetString("provider.default")
+	modelVal := v.GetString("model.default")
+	var explicitProvider, configProvider, explicitModel, configModel string
+	if cmd.Flags().Changed("provider") {
+		explicitProvider = providerVal
+	} else {
+		configProvider = providerVal
+	}
+	if cmd.Flags().Changed("model") {
+		explicitModel = modelVal
+	} else {
+		configModel = modelVal
+	}
+
 	return &runner.RunOptions{
 		Agent:              agent,
 		AgentsDir:          agentsDir,
@@ -104,8 +122,10 @@ func newRunOptions(cmd *cobra.Command) *runner.RunOptions {
 		APIVersion:         v.GetString("provider.api_version"),
 		APIType:            v.GetString("provider.api_type"),
 		OpenAICompatMax:    v.GetBool("provider.openai_compat_max_tokens"),
-		Provider:           v.GetString("provider.default"),
-		Model:              v.GetString("model.default"),
+		Provider:           explicitProvider,
+		Model:              explicitModel,
+		ConfigProvider:     configProvider,
+		ConfigModel:        configModel,
 		Temperature:        v.GetFloat64("model.temperature"),
 		MaxTokens:          v.GetInt("model.max_tokens"),
 		System:             system,

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -414,6 +414,70 @@ func TestBindRunFlags(t *testing.T) {
 	}
 }
 
+func TestNewRunOptionsProviderModelPrecedence(t *testing.T) {
+	t.Run("changed flags route to explicit fields", func(t *testing.T) {
+		cmd := newRunCmd()
+		v := viper.New()
+		if err := bindRunFlags(cmd, v); err != nil {
+			t.Fatalf("bindRunFlags: %v", err)
+		}
+		// Setting the flag propagates through BindPFlag into viper; no v.Set
+		// here so we don't override the flag value with viper's own store.
+		if err := cmd.Flags().Set("provider", "cli-provider"); err != nil {
+			t.Fatalf("Set provider: %v", err)
+		}
+		if err := cmd.Flags().Set("model", "cli-model"); err != nil {
+			t.Fatalf("Set model: %v", err)
+		}
+
+		ctx := withViper(context.Background(), v)
+		ctx = withConfig(ctx, config.Defaults())
+		cmd.SetContext(ctx)
+
+		opts := newRunOptions(cmd)
+		if opts.Provider != "cli-provider" {
+			t.Fatalf("Provider = %q, want cli-provider", opts.Provider)
+		}
+		if opts.Model != "cli-model" {
+			t.Fatalf("Model = %q, want cli-model", opts.Model)
+		}
+		if opts.ConfigProvider != "" {
+			t.Fatalf("ConfigProvider = %q, want empty when flag is set", opts.ConfigProvider)
+		}
+		if opts.ConfigModel != "" {
+			t.Fatalf("ConfigModel = %q, want empty when flag is set", opts.ConfigModel)
+		}
+	})
+
+	t.Run("unchanged flags route to config fields", func(t *testing.T) {
+		cmd := newRunCmd()
+		v := viper.New()
+		if err := bindRunFlags(cmd, v); err != nil {
+			t.Fatalf("bindRunFlags: %v", err)
+		}
+		v.Set("provider.default", "config-provider")
+		v.Set("model.default", "config-model")
+
+		ctx := withViper(context.Background(), v)
+		ctx = withConfig(ctx, config.Defaults())
+		cmd.SetContext(ctx)
+
+		opts := newRunOptions(cmd)
+		if opts.Provider != "" {
+			t.Fatalf("Provider = %q, want empty when flag unchanged", opts.Provider)
+		}
+		if opts.Model != "" {
+			t.Fatalf("Model = %q, want empty when flag unchanged", opts.Model)
+		}
+		if opts.ConfigProvider != "config-provider" {
+			t.Fatalf("ConfigProvider = %q, want config-provider", opts.ConfigProvider)
+		}
+		if opts.ConfigModel != "config-model" {
+			t.Fatalf("ConfigModel = %q, want config-model", opts.ConfigModel)
+		}
+	})
+}
+
 func TestBindRunFlagsMissingFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	v := viper.New()

--- a/routine/daemon/daemon.go
+++ b/routine/daemon/daemon.go
@@ -133,8 +133,10 @@ func newRunOptions(entry routine.Entry, cfg *config.Config, workingDir string) *
 	return &runner.RunOptions{
 		Agent:           r.Agent,
 		WorkingDir:      workingDir,
-		Provider:        firstNonEmpty(r.Provider, cfg.Provider.Default),
-		Model:           firstNonEmpty(r.Model, cfg.Model.Default),
+		Provider:        r.Provider,
+		Model:           r.Model,
+		ConfigProvider:  cfg.Provider.Default,
+		ConfigModel:     cfg.Model.Default,
 		Temperature:     cfg.Model.Temperature,
 		MaxTokens:       cfg.Model.MaxTokens,
 		NumCtx:          cfg.Provider.NumCtx,

--- a/routine/daemon/daemon_test.go
+++ b/routine/daemon/daemon_test.go
@@ -140,8 +140,11 @@ func TestNewRunOptionsAppliesRoutineFields(t *testing.T) {
 	if opts.Provider != "openai" {
 		t.Errorf("provider override not applied: %q", opts.Provider)
 	}
-	if opts.Model != "claude-sonnet-4-6" {
-		t.Errorf("model from config not inherited: %q", opts.Model)
+	if opts.Model != "" {
+		t.Errorf("unset routine model should not populate opts.Model: %q", opts.Model)
+	}
+	if opts.ConfigModel != "claude-sonnet-4-6" {
+		t.Errorf("config model not threaded into ConfigModel fallback: %q", opts.ConfigModel)
 	}
 	if opts.MaxCost != 3.0 {
 		t.Errorf("max_cost: %v", opts.MaxCost)
@@ -167,8 +170,11 @@ func TestNewRunOptionsAppliesDefaultsForUnsetFields(t *testing.T) {
 		Routine: &routine.Routine{Agent: "any"},
 	}
 	opts := newRunOptions(entry, cfg, "/tmp")
-	if opts.Provider != "ollama" {
-		t.Errorf("provider default not applied: %q", opts.Provider)
+	if opts.Provider != "" {
+		t.Errorf("unset routine provider should not populate opts.Provider: %q", opts.Provider)
+	}
+	if opts.ConfigProvider != "ollama" {
+		t.Errorf("config provider not threaded into ConfigProvider fallback: %q", opts.ConfigProvider)
 	}
 	if opts.MaxIterations != 100 {
 		t.Errorf("max_iter default: %d", opts.MaxIterations)

--- a/runner/run.go
+++ b/runner/run.go
@@ -226,24 +226,49 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 }
 
 // ResolveModelPrecedence fills opts.Model and opts.Provider using the
-// precedence: explicit (CLI flag / routine field) > agent manifest >
-// config default. Already-set fields are preserved; empty fields are
-// populated from the bundle's manifest preference and, failing that,
-// from opts.ConfigModel / opts.ConfigProvider.
-func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) {
+// precedence: explicit (CLI flag / routine field) > config default (when
+// supported by the manifest) > manifest first model > config default.
+// Already-set fields are preserved. Returns a non-empty warning string when
+// the config default is set but not listed in the agent manifest; callers
+// should display this to the user on stderr.
+func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) string {
 	if opts == nil || bundle == nil {
-		return
+		return ""
 	}
+
+	var warn string
 	if opts.Model == "" {
+		configMatch := bundle.FindModel(opts.ConfigProvider, opts.ConfigModel)
+
 		switch {
+		case configMatch != nil:
+			// Config default is supported by this agent — use it; provider is also set.
+			opts.Model = configMatch.Model
+			opts.Provider = configMatch.Provider
+			logging.InfoContext(ctx, "using config default model: %s (%s)", opts.Model, opts.Provider)
+			return ""
+
+		case opts.ConfigModel != "" && bundle.Model != "":
+			// Config default exists but is not in the manifest — warn and fall back.
+			warn = fmt.Sprintf(
+				"⚠  Config default model %q (%s) is not listed in the agent manifest.\n"+
+					"   Add it to the agent's models: list to avoid this fallback.\n"+
+					"   Falling back to manifest model %q (%s).",
+				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
+			logging.WarnContext(ctx, "config default model %q (%s) is not listed in agent manifest; falling back to manifest model %q (%s)",
+				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
+			opts.Model = bundle.Model
+
 		case bundle.Model != "":
 			opts.Model = bundle.Model
 			logging.InfoContext(ctx, "using manifest model: %s", bundle.Model)
+
 		case opts.ConfigModel != "":
 			opts.Model = opts.ConfigModel
 			logging.InfoContext(ctx, "using config model: %s", opts.ConfigModel)
 		}
 	}
+
 	if opts.Provider == "" {
 		switch {
 		case bundle.Provider != "":
@@ -254,6 +279,7 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 			logging.InfoContext(ctx, "using config provider: %s", opts.ConfigProvider)
 		}
 	}
+	return warn
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
@@ -271,7 +297,11 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, err
 	}
 
-	ResolveModelPrecedence(cmd.Context(), opts, bundle)
+	if warn := ResolveModelPrecedence(cmd.Context(), opts, bundle); warn != "" {
+		if _, fmtErr := fmt.Fprintln(cmd.ErrOrStderr(), warn); fmtErr != nil {
+			logging.Warn("failed to write model warning: %v", fmtErr)
+		}
+	}
 
 	logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", opts.Agent, opts.Provider, opts.Model)
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -42,10 +42,24 @@ type RunOptions struct {
 	APIType string
 	// OpenAICompatMax enforces max_tokens for OpenAI-compatible providers.
 	OpenAICompatMax bool
-	// Provider is the model provider name (e.g., "openai", "anthropic").
+	// Provider is the explicitly requested model provider (from a CLI flag
+	// or routine definition). Highest precedence; empty falls through to
+	// manifest then ConfigProvider.
 	Provider string
-	// Model is the model identifier, overriding the agent manifest.
+	// Model is the explicitly requested model identifier (from a CLI flag
+	// or routine definition). Highest precedence; empty falls through to
+	// manifest then ConfigModel.
 	Model string
+	// ConfigProvider holds the provider default from the loaded config
+	// file. Used only when neither the CLI/routine nor the agent manifest
+	// specifies a provider. Kept separate from Provider so manifest
+	// preferences can win over config defaults.
+	ConfigProvider string
+	// ConfigModel holds the model default from the loaded config file.
+	// Used only when neither the CLI/routine nor the agent manifest
+	// specifies a model. Kept separate from Model so manifest preferences
+	// can win over config defaults.
+	ConfigModel string
 	// Temperature controls sampling randomness.
 	Temperature float64
 	// MaxTokens is the per-request output token budget.
@@ -211,6 +225,37 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 	return err
 }
 
+// ResolveModelPrecedence fills opts.Model and opts.Provider using the
+// precedence: explicit (CLI flag / routine field) > agent manifest >
+// config default. Already-set fields are preserved; empty fields are
+// populated from the bundle's manifest preference and, failing that,
+// from opts.ConfigModel / opts.ConfigProvider.
+func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) {
+	if opts == nil || bundle == nil {
+		return
+	}
+	if opts.Model == "" {
+		switch {
+		case bundle.Model != "":
+			opts.Model = bundle.Model
+			logging.InfoContext(ctx, "using manifest model: %s", bundle.Model)
+		case opts.ConfigModel != "":
+			opts.Model = opts.ConfigModel
+			logging.InfoContext(ctx, "using config model: %s", opts.ConfigModel)
+		}
+	}
+	if opts.Provider == "" {
+		switch {
+		case bundle.Provider != "":
+			opts.Provider = bundle.Provider
+			logging.InfoContext(ctx, "using manifest provider: %s", bundle.Provider)
+		case opts.ConfigProvider != "":
+			opts.Provider = opts.ConfigProvider
+			logging.InfoContext(ctx, "using config provider: %s", opts.ConfigProvider)
+		}
+	}
+}
+
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
 func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir string) (*agent.Bundle, error) {
 	agentDir, err := FindAgentDir(opts.Agent, opts.AgentsDir, opts.Config)
@@ -226,15 +271,7 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, err
 	}
 
-	// Apply manifest model/provider when not explicitly set via CLI flags.
-	if opts.Model == "" && bundle.Model != "" {
-		opts.Model = bundle.Model
-		logging.InfoContext(cmd.Context(), "using manifest model: %s", bundle.Model)
-	}
-	if opts.Provider == "" && bundle.Provider != "" {
-		opts.Provider = bundle.Provider
-		logging.InfoContext(cmd.Context(), "using manifest provider: %s", bundle.Provider)
-	}
+	ResolveModelPrecedence(cmd.Context(), opts, bundle)
 
 	logging.InfoContext(cmd.Context(), "agent bundle ready (agent=%s provider=%s model=%s)", opts.Agent, opts.Provider, opts.Model)
 

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -290,16 +290,30 @@ func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	}
 }
 
+func runAndAssertBundle(t *testing.T, opts *RunOptions, wantModel, wantProvider string) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+	if err != nil {
+		t.Fatalf("prepareBundle() error = %v", err)
+	}
+	if opts.Model != wantModel {
+		t.Fatalf("expected Model=%q, got %q", wantModel, opts.Model)
+	}
+	if opts.Provider != wantProvider {
+		t.Fatalf("expected Provider=%q, got %q", wantProvider, opts.Provider)
+	}
+}
+
 func TestPrepareBundleManifestModelProvider(t *testing.T) {
 	t.Parallel()
 
 	t.Run("manifest model and provider applied when opts empty", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "model-agent", "manifest-model", "manifest-provider")
-		cmd := &cobra.Command{}
-		cmd.SetContext(context.Background())
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
 		opts := &RunOptions{
 			Agent:       "model-agent",
 			AgentsDir:   agentsDir,
@@ -307,25 +321,12 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle: true,
 			BundleOut:   filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
-		if err != nil {
-			t.Fatalf("prepareBundle() error = %v", err)
-		}
-		if opts.Model != "manifest-model" {
-			t.Fatalf("expected Model=%q, got %q", "manifest-model", opts.Model)
-		}
-		if opts.Provider != "manifest-provider" {
-			t.Fatalf("expected Provider=%q, got %q", "manifest-provider", opts.Provider)
-		}
+		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
 	})
 
 	t.Run("manifest wins over config defaults", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "manifest-vs-config", "manifest-model", "manifest-provider")
-		cmd := &cobra.Command{}
-		cmd.SetContext(context.Background())
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
 		opts := &RunOptions{
 			Agent:          "manifest-vs-config",
 			AgentsDir:      agentsDir,
@@ -335,25 +336,12 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle:    true,
 			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
-		if err != nil {
-			t.Fatalf("prepareBundle() error = %v", err)
-		}
-		if opts.Model != "manifest-model" {
-			t.Fatalf("expected Model=%q (manifest wins over config), got %q", "manifest-model", opts.Model)
-		}
-		if opts.Provider != "manifest-provider" {
-			t.Fatalf("expected Provider=%q (manifest wins over config), got %q", "manifest-provider", opts.Provider)
-		}
+		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
 	})
 
 	t.Run("config defaults fill in when manifest is silent", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentNoModels(t, "config-fallback")
-		cmd := &cobra.Command{}
-		cmd.SetContext(context.Background())
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
 		opts := &RunOptions{
 			Agent:          "config-fallback",
 			AgentsDir:      agentsDir,
@@ -363,25 +351,28 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle:    true,
 			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
-		if err != nil {
-			t.Fatalf("prepareBundle() error = %v", err)
+		runAndAssertBundle(t, opts, "config-model", "config-provider")
+	})
+
+	t.Run("config default wins when it is listed in manifest", func(t *testing.T) {
+		t.Parallel()
+		// Agent manifest lists exactly the config default model/provider.
+		agentsDir := writeTestAgentWithModels(t, "config-in-manifest", "config-model", "config-provider")
+		opts := &RunOptions{
+			Agent:          "config-in-manifest",
+			AgentsDir:      agentsDir,
+			ConfigModel:    "config-model",
+			ConfigProvider: "config-provider",
+			DryRun:         true,
+			PrintBundle:    true,
+			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		if opts.Model != "config-model" {
-			t.Fatalf("expected Model=%q from config fallback, got %q", "config-model", opts.Model)
-		}
-		if opts.Provider != "config-provider" {
-			t.Fatalf("expected Provider=%q from config fallback, got %q", "config-provider", opts.Provider)
-		}
+		runAndAssertBundle(t, opts, "config-model", "config-provider")
 	})
 
 	t.Run("CLI flags take precedence over manifest", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "cli-agent", "manifest-model", "manifest-provider")
-		cmd := &cobra.Command{}
-		cmd.SetContext(context.Background())
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
 		opts := &RunOptions{
 			Agent:       "cli-agent",
 			AgentsDir:   agentsDir,
@@ -391,16 +382,7 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle: true,
 			BundleOut:   filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
-		if err != nil {
-			t.Fatalf("prepareBundle() error = %v", err)
-		}
-		if opts.Model != "cli-model" {
-			t.Fatalf("expected Model=%q, got %q", "cli-model", opts.Model)
-		}
-		if opts.Provider != "cli-provider" {
-			t.Fatalf("expected Provider=%q, got %q", "cli-provider", opts.Provider)
-		}
+		runAndAssertBundle(t, opts, "cli-model", "cli-provider")
 	})
 }
 

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -384,6 +384,34 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		}
 		runAndAssertBundle(t, opts, "cli-model", "cli-provider")
 	})
+
+	t.Run("config default not in manifest emits warning to stderr", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithModels(t, "warn-fallback", "manifest-model", "manifest-provider")
+		opts := &RunOptions{
+			Agent:          "warn-fallback",
+			AgentsDir:      agentsDir,
+			ConfigModel:    "other-model",
+			ConfigProvider: "other-provider",
+			DryRun:         true,
+			PrintBundle:    true,
+			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		if _, err := prepareBundle(cmd, opts, "prompt", t.TempDir()); err != nil {
+			t.Fatalf("prepareBundle() error = %v", err)
+		}
+		if opts.Model != "manifest-model" || opts.Provider != "manifest-provider" {
+			t.Fatalf("expected fallback to manifest, got Model=%q Provider=%q", opts.Model, opts.Provider)
+		}
+		if !strings.Contains(stderr.String(), "not listed in the agent manifest") {
+			t.Fatalf("expected warning on stderr, got %q", stderr.String())
+		}
+	})
 }
 
 func TestInvokeModelMissingAPIKey(t *testing.T) {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -304,6 +304,62 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("manifest wins over config defaults", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithModels(t, "manifest-vs-config", "manifest-model", "manifest-provider")
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		opts := &RunOptions{
+			Agent:          "manifest-vs-config",
+			AgentsDir:      agentsDir,
+			ConfigModel:    "config-model",
+			ConfigProvider: "config-provider",
+			DryRun:         true,
+			PrintBundle:    true,
+			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+		if err != nil {
+			t.Fatalf("prepareBundle() error = %v", err)
+		}
+		if opts.Model != "manifest-model" {
+			t.Fatalf("expected Model=%q (manifest wins over config), got %q", "manifest-model", opts.Model)
+		}
+		if opts.Provider != "manifest-provider" {
+			t.Fatalf("expected Provider=%q (manifest wins over config), got %q", "manifest-provider", opts.Provider)
+		}
+	})
+
+	t.Run("config defaults fill in when manifest is silent", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentNoModels(t, "config-fallback")
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		opts := &RunOptions{
+			Agent:          "config-fallback",
+			AgentsDir:      agentsDir,
+			ConfigModel:    "config-model",
+			ConfigProvider: "config-provider",
+			DryRun:         true,
+			PrintBundle:    true,
+			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		_, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+		if err != nil {
+			t.Fatalf("prepareBundle() error = %v", err)
+		}
+		if opts.Model != "config-model" {
+			t.Fatalf("expected Model=%q from config fallback, got %q", "config-model", opts.Model)
+		}
+		if opts.Provider != "config-provider" {
+			t.Fatalf("expected Provider=%q from config fallback, got %q", "config-provider", opts.Provider)
+		}
+	})
+
 	t.Run("CLI flags take precedence over manifest", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "cli-agent", "manifest-model", "manifest-provider")
@@ -587,6 +643,26 @@ func TestWriteResponsePrintAndFile(t *testing.T) {
 }
 
 func writeTestAgent(t *testing.T, agentName string) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := fmt.Sprintf("name: %s\nversion: 0.0.0\nentrypoint: system.md\nwrapper: wrapper.md\n", agentName)
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("System prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile system.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "wrapper.md"), []byte("Wrapper prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile wrapper.md: %v", err)
+	}
+	return agentsDir
+}
+
+func writeTestAgentNoModels(t *testing.T, agentName string) string {
 	t.Helper()
 	agentsDir := t.TempDir()
 	agentDir := filepath.Join(agentsDir, agentName)

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -275,6 +275,21 @@ func TestPrepareBundle(t *testing.T) {
 	}
 }
 
+func TestResolveModelPrecedenceNilGuard(t *testing.T) {
+	t.Parallel()
+	// Calling with either argument nil must be a no-op rather than a panic;
+	// pipeline code passes a bundle that may be nil on early-exit paths.
+	ResolveModelPrecedence(context.Background(), nil, nil)
+	ResolveModelPrecedence(context.Background(), &RunOptions{}, nil)
+	ResolveModelPrecedence(context.Background(), nil, &agent.Bundle{})
+
+	opts := &RunOptions{Model: "preset", Provider: "preset"}
+	ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
+	if opts.Model != "preset" || opts.Provider != "preset" {
+		t.Fatalf("explicit values must win over manifest: Model=%q Provider=%q", opts.Model, opts.Provider)
+	}
+}
+
 func TestPrepareBundleManifestModelProvider(t *testing.T) {
 	t.Parallel()
 

--- a/tools/efficiency.go
+++ b/tools/efficiency.go
@@ -15,6 +15,8 @@ import (
 
 type readCacheKeyType struct{}
 
+// ReadCacheEntry records metadata about a file that has already been read
+// during the current tool-loop session.
 type ReadCacheEntry struct {
 	ContentHash     string // SHA-256 of file content
 	Lines           int    // number of lines
@@ -37,14 +39,17 @@ type ReadCache struct {
 	compactionEpoch int // incremented each time context compaction occurs
 }
 
+// NewReadCache creates an empty ReadCache.
 func NewReadCache() *ReadCache {
 	return &ReadCache{entries: csync.NewMap[string, ReadCacheEntry]()}
 }
 
+// InitReadCache attaches a new ReadCache to ctx for the duration of a run.
 func InitReadCache(ctx context.Context) context.Context {
 	return context.WithValue(ctx, readCacheKeyType{}, NewReadCache())
 }
 
+// GetReadCache retrieves the ReadCache from ctx, or nil if not set.
 func GetReadCache(ctx context.Context) *ReadCache {
 	if rc, ok := ctx.Value(readCacheKeyType{}).(*ReadCache); ok {
 		return rc
@@ -52,6 +57,7 @@ func GetReadCache(ctx context.Context) *ReadCache {
 	return nil
 }
 
+// HashContent returns a hex-encoded SHA-256 hash of data.
 func HashContent(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
@@ -69,6 +75,7 @@ func (rc *ReadCache) BumpCompactionEpoch() {
 	rc.mu.Unlock()
 }
 
+// CompactionEpoch returns the current compaction epoch for the cache.
 func (rc *ReadCache) CompactionEpoch() int {
 	if rc == nil {
 		return 0
@@ -134,6 +141,7 @@ func (rc *ReadCache) Store(path, contentHash string, lines, bytes, iteration int
 	})
 }
 
+// IncrementStreak increments and returns the consecutive cache-hit streak counter.
 func (rc *ReadCache) IncrementStreak() int {
 	if rc == nil {
 		return 0
@@ -144,6 +152,7 @@ func (rc *ReadCache) IncrementStreak() int {
 	return rc.cacheStreak
 }
 
+// ResetStreak resets the consecutive cache-hit streak counter to zero.
 func (rc *ReadCache) ResetStreak() {
 	if rc == nil {
 		return
@@ -171,6 +180,7 @@ func (rc *ReadCache) Summaries() map[string]string {
 	return result
 }
 
+// Len returns the number of files currently tracked in the read cache.
 func (rc *ReadCache) Len() int {
 	if rc == nil {
 		return 0
@@ -180,17 +190,20 @@ func (rc *ReadCache) Len() int {
 
 type iterationKeyType struct{}
 
+// InitIterationCounter attaches an iteration counter (starting at 0) to ctx.
 func InitIterationCounter(ctx context.Context) context.Context {
 	counter := 0
 	return context.WithValue(ctx, iterationKeyType{}, &counter)
 }
 
+// SetIteration updates the current iteration index stored on ctx.
 func SetIteration(ctx context.Context, i int) {
 	if p, ok := ctx.Value(iterationKeyType{}).(*int); ok {
 		*p = i
 	}
 }
 
+// GetIteration returns the current iteration index from ctx, or 0 if not set.
 func GetIteration(ctx context.Context) int {
 	if p, ok := ctx.Value(iterationKeyType{}).(*int); ok {
 		return *p
@@ -200,10 +213,12 @@ func GetIteration(ctx context.Context) int {
 
 type phaseEnforcerKeyType struct{}
 
+// SetPhaseEnforcer stores pe on ctx so tool handlers can retrieve it.
 func SetPhaseEnforcer(ctx context.Context, pe *PhaseEnforcer) context.Context {
 	return context.WithValue(ctx, phaseEnforcerKeyType{}, pe)
 }
 
+// GetPhaseEnforcer retrieves the PhaseEnforcer from ctx, or nil if not set.
 func GetPhaseEnforcer(ctx context.Context) *PhaseEnforcer {
 	if pe, ok := ctx.Value(phaseEnforcerKeyType{}).(*PhaseEnforcer); ok {
 		return pe
@@ -225,6 +240,7 @@ type PhaseEnforcer struct {
 	editSeen      bool
 }
 
+// NudgesSent returns the number of nudge messages sent so far.
 func (pe *PhaseEnforcer) NudgesSent() int {
 	if pe == nil {
 		return 0

--- a/tools/task.go
+++ b/tools/task.go
@@ -179,6 +179,9 @@ type ChildMaxCostFunc func(agentName string) float64
 // Returns 0 if no dedicated cap is configured (inherit parent's cap).
 type ChildMaxIterFunc func(agentName string) int
 
+// TaskConfig holds the configuration needed to spawn child agent runs
+// from within the Task tool. It is created once per parent run and shared
+// across all Task tool invocations in that run.
 type TaskConfig struct {
 	AgentsDir     string
 	WorkingDir    string

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// MaxToolIterations is the default cap on tool-calling iterations per run
+// when no explicit --max-iterations flag is provided.
 const MaxToolIterations = 100
 const maxToolOutput = 64 * 1024
 const maxSameToolRepeat = 10
@@ -97,23 +99,27 @@ func sanitizeRegex(pattern string) string {
 	})
 }
 
+// InitEdits attaches an edits-applied flag to ctx, defaulting to false.
 func InitEdits(ctx context.Context) context.Context {
 	b := false
 	return context.WithValue(ctx, editsKeyType{}, &b)
 }
 
+// ResetEditsApplied resets the edits-applied flag to false on ctx.
 func ResetEditsApplied(ctx context.Context) {
 	if b, ok := ctx.Value(editsKeyType{}).(*bool); ok {
 		*b = false
 	}
 }
 
+// MarkEditsApplied sets the edits-applied flag to true on ctx.
 func MarkEditsApplied(ctx context.Context) {
 	if b, ok := ctx.Value(editsKeyType{}).(*bool); ok {
 		*b = true
 	}
 }
 
+// EditsApplied reports whether any file edits have been applied in this run.
 func EditsApplied(ctx context.Context) bool {
 	if b, ok := ctx.Value(editsKeyType{}).(*bool); ok {
 		return *b
@@ -142,17 +148,24 @@ func EditDeadlineReached(ctx context.Context) bool {
 	return false
 }
 
+// Handler pairs a tool definition with its implementation function.
+// Extra tools (e.g., from MCP servers) are registered as Handlers so they
+// participate in the same dispatch path as built-in tools.
 type Handler struct {
 	Def  llms.Tool
 	Call func(ctx context.Context, rawArgs []byte) (string, error)
 }
 
+// RepeatTracker detects when the model calls the same tool with identical
+// arguments multiple times in a row so the loop can be interrupted.
 type RepeatTracker struct {
 	lastSignature string
 	LastName      string
 	Count         int
 }
 
+// Update records the current batch of tool calls and increments the repeat
+// counter when the call signature is identical to the previous batch.
 func (t *RepeatTracker) Update(calls []llms.ToolCall) {
 	signature := ""
 	name := ""
@@ -169,6 +182,7 @@ func (t *RepeatTracker) Update(calls []llms.ToolCall) {
 	}
 }
 
+// Exceeded reports whether the repeat limit for the last tool has been reached.
 func (t *RepeatTracker) Exceeded() bool {
 	limit := maxSameToolRepeat
 	if highRepeatTools[t.LastName] {
@@ -292,6 +306,10 @@ func (e *EditEnforcer) ConfirmEdit(toolCalls []llms.ToolCall, results map[string
 	}
 }
 
+// RunWithTools drives the tool-calling loop for a LangChain-compatible LLM.
+// It initialises the read cache, file tracker, and enforcer machinery, then
+// iterates between model calls and tool executions until the model stops
+// calling tools, the iteration cap is hit, or a budget/loop error is raised.
 func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, maxIterations, editDeadline int, taskCfg *TaskConfig, m *metrics.Metrics, ex executor.Executor, callOpts ...llms.CallOption) (string, error) {
 	ctx, span := telemetry.Tracer().Start(ctx, "tool.loop",
 		trace.WithAttributes(
@@ -1071,6 +1089,11 @@ func toolArgsSummaryComplex(toolName string, args map[string]interface{}) string
 	return ""
 }
 
+// BuildHandlers returns a map of tool-name → Handler and a sorted list of tool
+// definitions to be passed to the LLM. When taskCfg is non-nil the Task and
+// TaskResult tools are registered; when taskCfg.Findings is set the
+// ReportFinding tool is also registered. MCP tools from taskCfg.ExtraTools
+// are appended last.
 func BuildHandlers(workingDir string, taskCfg *TaskConfig, ex executor.Executor) (map[string]Handler, []llms.Tool) {
 	handlers := map[string]Handler{}
 
@@ -1929,6 +1952,8 @@ func compactMessages(ctx context.Context, messages []llms.MessageContent, m *met
 	return compacted
 }
 
+// TruncateToolOutputHeadTail trims tool output that exceeds maxBytes, keeping
+// 75% from the head and 25% from the tail with an omission notice in between.
 func TruncateToolOutputHeadTail(output string, maxBytes int) string {
 	if len(output) <= maxBytes {
 		return output
@@ -1986,6 +2011,8 @@ func (b *FlexBool) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ResolvePath resolves input against workingDir and verifies the result is
+// inside the working directory, rejecting path-traversal attempts.
 func ResolvePath(workingDir, input string) (string, error) {
 	if strings.TrimSpace(input) == "" {
 		return "", fmt.Errorf("path is required")
@@ -2067,6 +2094,8 @@ func globToRegex(pattern string) (string, error) {
 	return buf.String(), nil
 }
 
+// TruncateString truncates s to maxLen bytes, appending "..." when truncation
+// occurs.
 func TruncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s


### PR DESCRIPTION
**Key Changes:**

- Refactored model and provider option handling to distinguish explicit (CLI/routine) values from config defaults
- Introduced `ConfigModel` and `ConfigProvider` fields to `RunOptions` for clear precedence logic
- Centralized model/provider precedence resolution in a new `ResolveModelPrecedence` function
- Expanded and improved tests to validate correct precedence between CLI flags, manifest, and config defaults

**Added:**

- `ConfigModel` and `ConfigProvider` fields to `RunOptions` to separately track config-file defaults for model and provider
- `ResolveModelPrecedence` function in `runner/run.go` to apply explicit > manifest > config precedence for model and provider selection
- New and expanded tests in `cmd/squad/pipeline_test.go`, `runner/run_test.go`, and `routine/daemon/daemon_test.go` to assert explicit/config/manifest precedence logic, including helpers for test agent manifests without models

**Changed:**

- Updated construction of `RunOptions` in `cmd/squad/pipeline.go`, `cmd/squad/run.go`, and `routine/daemon/daemon.go` to bucket model/provider into explicit and config fields rather than collapsing both into a single value
- Replaced direct manifest application logic in pipeline and bundle preparation with calls to `ResolveModelPrecedence`
- Improved documentation and comments for model/provider precedence within `RunOptions` and related logic
- Adjusted tests to check that config defaults are threaded into the correct fields and do not override manifest or explicit values

**Removed:**

- Legacy logic that directly applied manifest model/provider over empty CLI fields without considering config-file defaults separately in `cmd/squad/pipeline.go` and `runner/run.go`