### PR TITLE
refactor: centralize provider list for flag completion and UI launch form

### DIFF
--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -287,9 +287,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	// Dynamic completions for --agent (scan agents directories).
 	_ = cmd.RegisterFlagCompletionFunc("agent", completeAgentNames)
 	// Static completions for --provider.
-	_ = cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return metrics.SupportedProviders, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = cmd.RegisterFlagCompletionFunc("provider", completeProviderNames)
 	_ = cmd.RegisterFlagCompletionFunc("api-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"openai", "azure"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -315,6 +313,10 @@ func hasPipedInput(r io.Reader) bool {
 		return b.Len() > 0
 	}
 	return false
+}
+
+func completeProviderNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return metrics.SupportedProviders, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeAgentNames(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/mcp"
+	"github.com/cowdogmoo/squad/metrics"
 	pl "github.com/cowdogmoo/squad/pipeline"
 	"github.com/cowdogmoo/squad/runner"
 	"github.com/spf13/cobra"
@@ -287,7 +288,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	_ = cmd.RegisterFlagCompletionFunc("agent", completeAgentNames)
 	// Static completions for --provider.
 	_ = cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"openai", "openai-responses", "anthropic", "ollama", "gemini", "nvidia", "databricks"}, cobra.ShellCompDirectiveNoFileComp
+		return metrics.SupportedProviders, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("api-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"openai", "azure"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/config"
+	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/runner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -511,6 +512,27 @@ func TestCompleteAgentNames(t *testing.T) {
 	}
 	if len(names) != 1 || names[0] != "go-tests" {
 		t.Fatalf("names = %v, want [go-tests]", names)
+	}
+}
+
+func TestCompleteProviderNames(t *testing.T) {
+	names, directive := completeProviderNames(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want no file comp", directive)
+	}
+	if len(names) != len(metrics.SupportedProviders) {
+		t.Fatalf("names len = %d, want %d", len(names), len(metrics.SupportedProviders))
+	}
+	want := map[string]bool{"nvidia": false, "databricks": false}
+	for _, n := range names {
+		if _, ok := want[n]; ok {
+			want[n] = true
+		}
+	}
+	for n, found := range want {
+		if !found {
+			t.Errorf("provider %q missing from completion list", n)
+		}
 	}
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -250,6 +250,19 @@ var (
 	pricingFetchOnce sync.Once
 )
 
+// SupportedProviders is the canonical, ordered list of provider names
+// squad recognizes for the --provider flag and the TUI launch form.
+// Keep this in sync with the provider dispatch in runner/model.go.
+var SupportedProviders = []string{
+	"openai",
+	"openai-responses",
+	"anthropic",
+	"gemini",
+	"ollama",
+	"nvidia",
+	"databricks",
+}
+
 // providerMappings maps a squad provider name to the LiteLLM
 // `litellm_provider` keys that supply its models. The first entry is
 // treated as the canonical source when building model lists.

--- a/ui/app/app.go
+++ b/ui/app/app.go
@@ -216,15 +216,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	default:
 		// Route submits and launch requests BEFORE forwarding to the
 		// pane so the pane can also clear its buffer in the same tick.
+		var quitCmd tea.Cmd
 		if sub, ok := pane.AsSubmitted(msg); ok {
-			a.handleSubmit(sub)
+			quitCmd = a.handleSubmit(sub)
 		}
 		if req, ok := pane.AsLaunchRequest(msg); ok {
 			a.launch(req)
 		}
 		var cmd tea.Cmd
 		a.pane, cmd = a.pane.Update(msg)
-		return a, cmd
+		return a, tea.Batch(quitCmd, cmd)
 	}
 }
 
@@ -475,10 +476,10 @@ func (a *App) rediscover() {
 // handleSubmit dispatches a pane.Submitted into the right action.
 // Commands route through handleCommand; other kinds toast a not-yet-
 // wired hint so the user sees feedback.
-func (a *App) handleSubmit(sub pane.Submitted) {
+func (a *App) handleSubmit(sub pane.Submitted) tea.Cmd {
 	switch sub.Kind {
 	case pane.KindCommand:
-		a.handleCommand(sub.Text)
+		return a.handleCommand(sub.Text)
 	case pane.KindShell:
 		a.setToast(style.Faint.Render("shell pass-through is not yet wired"))
 	case pane.KindFile:
@@ -486,12 +487,13 @@ func (a *App) handleSubmit(sub pane.Submitted) {
 	default:
 		a.setToast(style.Faint.Render("bare prompts need an agent — try /run <agent> <prompt>"))
 	}
+	return nil
 }
 
-func (a *App) handleCommand(text string) {
+func (a *App) handleCommand(text string) tea.Cmd {
 	parts := strings.Fields(text)
 	if len(parts) == 0 {
-		return
+		return nil
 	}
 	switch parts[0] {
 	case "run":
@@ -502,9 +504,11 @@ func (a *App) handleCommand(text string) {
 		a.cmdHelp()
 	case "quit", "exit":
 		a.quitting = true
+		return tea.Quit
 	default:
 		a.setToast(style.Faint.Render(fmt.Sprintf("unknown command: /%s — try /help", parts[0])))
 	}
+	return nil
 }
 
 // cmdHelp toasts the available slash commands and global keys.

--- a/ui/pane/launch.go
+++ b/ui/pane/launch.go
@@ -47,7 +47,7 @@ type Launch struct {
 // "use the default" — the agent manifest decides when no value is given.
 var (
 	modeOptions     = []string{"edit", "plan"}
-	providerOptions = []string{"openai", "openai-responses", "anthropic", "gemini", "ollama"}
+	providerOptions = metrics.SupportedProviders
 	isolateOptions  = []string{"", "worktree", "branch", "commit", "staged", "unstaged", "none"}
 )
 
@@ -512,7 +512,7 @@ func (l Launch) contextualHint() string {
 	case fldIters:
 		hint = "max LLM round trips before the agent stops"
 	case fldProvider:
-		hint = "(default): use config.yaml · openai/openai-responses/anthropic/gemini/ollama: override"
+		hint = "(default): use config.yaml · " + strings.Join(metrics.SupportedProviders, "/") + ": override"
 	case fldModel:
 		hint = "↑/↓ pick · enter commit · type to filter · provider-specific; empty = manifest default"
 	case fldIsolate:


### PR DESCRIPTION
**Key Changes:**

- Centralized the list of supported providers into a single exported variable
- Updated provider flag completion and UI launch form to use the centralized provider list
- Ensured consistency between CLI, TUI, and provider dispatch logic

**Added:**

- Canonical provider list - Introduced `metrics.SupportedProviders` as the single source of truth for supported provider names

**Changed:**

- Provider flag completion - Modified provider flag completion in `cmd/squad/run.go` to use `metrics.SupportedProviders` instead of a hardcoded list
- UI launch form provider options - Updated provider selection options in `ui/pane/launch.go` to use `metrics.SupportedProviders` and adjusted the contextual hint to reflect the dynamic list