### PR TITLE
feat: add provider API key readiness checks to launch form

### DIFF
--- a/cmd/squad/ui.go
+++ b/cmd/squad/ui.go
@@ -72,6 +72,10 @@ func runUI(cmd *cobra.Command, _ []string) error {
 		}
 		workingDir = cwd
 	}
+	providerToken := ""
+	if cfg, _, err := config.Load(); err == nil && cfg != nil {
+		providerToken = cfg.Provider.Token
+	}
 
 	// Kick the LiteLLM pricing fetch off in the background so the launch
 	// form's model typeahead has the live registry ready to suggest from.
@@ -79,14 +83,14 @@ func runUI(cmd *cobra.Command, _ []string) error {
 
 	var model app.App
 	if useMock {
-		model = app.New(app.MockRuns())
+		model = app.New(app.MockRuns()).WithProviderToken(providerToken)
 	} else {
 		root := sessionsDir
 		if root == "" {
 			root = filepath.Join(workingDir, session.SessionsRoot)
 		}
 		var err error
-		model, err = app.NewWithSessions(root, workingDir)
+		model, err = app.NewWithSessions(root, workingDir, providerToken)
 		if err != nil {
 			return fmt.Errorf("discover sessions: %w", err)
 		}

--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"os"
+	"strings"
+)
+
+// APIKeyState is the launch-readiness state for a provider credential.
+type APIKeyState string
+
+const (
+	APIKeyOK        APIKeyState = "ok"
+	APIKeyMissing   APIKeyState = "missing"
+	APIKeyNotNeeded APIKeyState = "notNeeded"
+)
+
+// APIKeySource describes where the usable credential came from.
+type APIKeySource string
+
+const (
+	APIKeySourceConfig APIKeySource = "config"
+	APIKeySourceEnv    APIKeySource = "env"
+	APIKeySourceNone   APIKeySource = "none"
+)
+
+// APIKeyStatus reports whether a provider has the credential it needs.
+type APIKeyStatus struct {
+	State  APIKeyState
+	EnvVar string
+	Source APIKeySource
+}
+
+var providerAPIKeyEnv = map[string]string{
+	"openai":           "OPENAI_API_KEY",
+	"openai-responses": "OPENAI_API_KEY",
+	"anthropic":        "ANTHROPIC_API_KEY",
+	"gemini":           "GOOGLE_API_KEY",
+	"nvidia":           "NVIDIA_API_KEY",
+	"databricks":       "DATABRICKS_TOKEN",
+}
+
+// KeyStatus mirrors provider token precedence used by the runner: an
+// explicitly resolved provider.token wins, then the provider-specific env var.
+// Ollama is local and does not need an API key.
+func KeyStatus(provider, providerToken string) APIKeyStatus {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		provider = "openai"
+	}
+	if provider == "ollama" {
+		return APIKeyStatus{State: APIKeyNotNeeded, Source: APIKeySourceNone}
+	}
+	envVar, ok := providerAPIKeyEnv[provider]
+	if !ok {
+		return APIKeyStatus{State: APIKeyNotNeeded, Source: APIKeySourceNone}
+	}
+	if strings.TrimSpace(providerToken) != "" {
+		return APIKeyStatus{State: APIKeyOK, EnvVar: envVar, Source: APIKeySourceConfig}
+	}
+	if os.Getenv(envVar) != "" {
+		return APIKeyStatus{State: APIKeyOK, EnvVar: envVar, Source: APIKeySourceEnv}
+	}
+	return APIKeyStatus{State: APIKeyMissing, EnvVar: envVar, Source: APIKeySourceNone}
+}

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -45,3 +45,10 @@ func TestKeyStatusOllamaNotNeeded(t *testing.T) {
 		t.Fatalf("ollama status = %+v, want not-needed/no env", got)
 	}
 }
+
+func TestKeyStatusUnknownProviderNotNeeded(t *testing.T) {
+	got := KeyStatus("not-a-real-provider", "")
+	if got.State != APIKeyNotNeeded || got.EnvVar != "" || got.Source != APIKeySourceNone {
+		t.Fatalf("unknown provider status = %+v, want not-needed/no env", got)
+	}
+}

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -1,0 +1,47 @@
+package metrics
+
+import "testing"
+
+func TestKeyStatusProviderEnvTable(t *testing.T) {
+	cases := []struct {
+		provider string
+		envVar   string
+	}{
+		{"", "OPENAI_API_KEY"},
+		{"openai", "OPENAI_API_KEY"},
+		{"openai-responses", "OPENAI_API_KEY"},
+		{"anthropic", "ANTHROPIC_API_KEY"},
+		{"gemini", "GOOGLE_API_KEY"},
+		{"nvidia", "NVIDIA_API_KEY"},
+		{"databricks", "DATABRICKS_TOKEN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Setenv(tc.envVar, "")
+			got := KeyStatus(tc.provider, "")
+			if got.State != APIKeyMissing || got.EnvVar != tc.envVar || got.Source != APIKeySourceNone {
+				t.Fatalf("KeyStatus(%q) = %+v, want missing %s from none", tc.provider, got, tc.envVar)
+			}
+		})
+	}
+}
+
+func TestKeyStatusPrecedence(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "env-token")
+	got := KeyStatus("openai", "config-token")
+	if got.State != APIKeyOK || got.Source != APIKeySourceConfig || got.EnvVar != "OPENAI_API_KEY" {
+		t.Fatalf("config token should win: got %+v", got)
+	}
+
+	got = KeyStatus("openai", "")
+	if got.State != APIKeyOK || got.Source != APIKeySourceEnv || got.EnvVar != "OPENAI_API_KEY" {
+		t.Fatalf("env token should be used: got %+v", got)
+	}
+}
+
+func TestKeyStatusOllamaNotNeeded(t *testing.T) {
+	got := KeyStatus("ollama", "")
+	if got.State != APIKeyNotNeeded || got.EnvVar != "" || got.Source != APIKeySourceNone {
+		t.Fatalf("ollama status = %+v, want not-needed/no env", got)
+	}
+}

--- a/ui/app/app.go
+++ b/ui/app/app.go
@@ -53,10 +53,11 @@ type App struct {
 	knownDirs     map[string]bool
 	lastDiscovery time.Time
 
-	registry   *registry.Registry
-	workingDir string // for launched subprocesses
-	toast      string // transient message ("Launched ..."), cleared after toastUntil
-	toastUntil time.Time
+	registry      *registry.Registry
+	workingDir    string // for launched subprocesses
+	providerToken string // resolved config provider.token for launch-form key checks
+	toast         string // transient message ("Launched ..."), cleared after toastUntil
+	toastUntil    time.Time
 
 	// launchPairs maps session ID → registry Launch ID. Filled when
 	// rediscover() sees a new session dir following a recent launch
@@ -140,11 +141,18 @@ func (a App) WithAgents(names []string) App {
 	return a
 }
 
+// WithProviderToken seeds the resolved config provider.token used by the
+// launch form's API-key readiness check.
+func (a App) WithProviderToken(token string) App {
+	a.providerToken = token
+	return a
+}
+
 // NewWithSessions returns an App that auto-discovers + tails the session
 // directories under sessionsRoot (typically ".squad/sessions"). Missing
 // root is not an error — the app renders empty until sessions appear.
 // workingDir is the directory in which launched subprocesses are spawned.
-func NewWithSessions(sessionsRoot, workingDir string) (App, error) {
+func NewWithSessions(sessionsRoot, workingDir, providerToken string) (App, error) {
 	tailers, err := watch.Discover(sessionsRoot)
 	if err != nil {
 		return App{}, err
@@ -163,6 +171,7 @@ func NewWithSessions(sessionsRoot, workingDir string) (App, error) {
 		knownDirs:     known,
 		sessionsRoot:  sessionsRoot,
 		workingDir:    workingDir,
+		providerToken: providerToken,
 		selected:      selected,
 		pane:          pane.NewComposer(),
 		registry:      registry.New(),
@@ -585,15 +594,16 @@ func (a *App) cmdPresetLoad(args []string) {
 	}
 	// Open the form with the preset's values pre-populated.
 	form := pane.NewLaunch(a.pane, pane.LaunchDefaults{
-		Agent:      p.Agent,
-		WorkingDir: presetOrDefault(p.WorkingDir, a.workingDir),
-		MaxCost:    p.MaxCost,
-		Mode:       p.Mode,
-		MaxIter:    p.MaxIter,
-		Provider:   p.Provider,
-		Model:      p.Model,
-		Isolate:    p.Isolate,
-		Agents:     a.agents,
+		Agent:         p.Agent,
+		WorkingDir:    presetOrDefault(p.WorkingDir, a.workingDir),
+		MaxCost:       p.MaxCost,
+		Mode:          p.Mode,
+		MaxIter:       p.MaxIter,
+		Provider:      p.Provider,
+		Model:         p.Model,
+		Isolate:       p.Isolate,
+		ProviderToken: a.providerToken,
+		Agents:        a.agents,
 	})
 	form.SetSize(a.width, a.height)
 	// If the preset has a prompt, seed the textarea.
@@ -769,8 +779,9 @@ func (a *App) cancelFocused() {
 // is preserved as the form's parent so Esc / submit returns to it.
 func (a *App) openLaunchForm() {
 	form := pane.NewLaunch(a.pane, pane.LaunchDefaults{
-		WorkingDir: a.workingDir,
-		Agents:     a.agents,
+		WorkingDir:    a.workingDir,
+		ProviderToken: a.providerToken,
+		Agents:        a.agents,
 	})
 	form.SetSize(a.width, a.height)
 	a.pane = form

--- a/ui/app/helpers_test.go
+++ b/ui/app/helpers_test.go
@@ -37,7 +37,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestNewWithSessionsEmpty(t *testing.T) {
-	a, err := NewWithSessions(t.TempDir(), t.TempDir())
+	a, err := NewWithSessions(t.TempDir(), t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("NewWithSessions on empty dir should not error, got %v", err)
 	}
@@ -53,7 +53,7 @@ func TestNewWithSessionsWithSession(t *testing.T) {
 	if err := mkSessionDir(t, dir, session.Meta{SessionID: sid, Agent: "go-review", Status: session.StatusRunning}); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestCurrentRunsFromTailers(t *testing.T) {
 	if err := mkSessionDir(t, dir, session.Meta{SessionID: sid, Agent: "go-review", Status: session.StatusRunning}); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +302,7 @@ func TestCurrentRunsFromTailers(t *testing.T) {
 }
 
 func TestTailerStateForUnknown(t *testing.T) {
-	a, _ := NewWithSessions(t.TempDir(), t.TempDir())
+	a, _ := NewWithSessions(t.TempDir(), t.TempDir(), "")
 	if _, ok := a.tailerStateFor("nope"); ok {
 		t.Error("unknown session should return false")
 	}
@@ -542,7 +542,7 @@ func TestUpdateFrameTickRefreshesTailers(t *testing.T) {
 	if err := mkSessionDir(t, dir, session.Meta{SessionID: sid, Agent: "x", Status: session.StatusRunning}); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,7 +620,7 @@ func TestRunFromTailerWithCreatedTime(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -646,7 +646,7 @@ func TestRunFromTailerCompletedUsesUpdatedDelta(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -666,7 +666,7 @@ func TestRunFromTailerCompletedUsesUpdatedDelta(t *testing.T) {
 func TestRediscoverPicksUpNewSessions(t *testing.T) {
 	root := t.TempDir()
 	// Start with empty root.
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -691,7 +691,7 @@ func TestRediscoverPicksUpNewSessions(t *testing.T) {
 
 func TestRediscoverPairsPendingLaunch(t *testing.T) {
 	root := t.TempDir()
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -812,7 +812,7 @@ func TestRenderFocusedWithTailerState(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	a, err := NewWithSessions(root, t.TempDir())
+	a, err := NewWithSessions(root, t.TempDir(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ui/app/helpers_test.go
+++ b/ui/app/helpers_test.go
@@ -29,6 +29,13 @@ func TestWithAgents(t *testing.T) {
 	}
 }
 
+func TestWithProviderToken(t *testing.T) {
+	a := makeApp().WithProviderToken("cfg-token")
+	if a.providerToken != "cfg-token" {
+		t.Errorf("providerToken: got %q, want %q", a.providerToken, "cfg-token")
+	}
+}
+
 func TestInit(t *testing.T) {
 	a := makeApp()
 	if a.Init() == nil {

--- a/ui/pane/helpers_test.go
+++ b/ui/pane/helpers_test.go
@@ -455,6 +455,7 @@ func TestLaunchEnterOnCancelReturnsParent(t *testing.T) {
 }
 
 func TestLaunchEnterOnLaunchSubmits(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	parent := stubView{name: "parent"}
 	form := NewLaunch(parent, LaunchDefaults{Agent: "go-review"})
 	form.prompt.SetValue("do the thing")

--- a/ui/pane/launch.go
+++ b/ui/pane/launch.go
@@ -38,8 +38,9 @@ type Launch struct {
 	isolate    selectField
 	prompt     textarea.Model
 
-	focus int
-	err   string
+	providerToken string
+	focus         int
+	err           string
 }
 
 // modeOptions, providerOptions, isolateOptions are the closed sets
@@ -160,6 +161,10 @@ type LaunchDefaults struct {
 	Provider string
 	Model    string
 	Isolate  string
+	// ProviderToken is the resolved config provider.token value. It is
+	// intentionally separate from provider selection so the form can mirror
+	// runner credential precedence without importing config.
+	ProviderToken string
 
 	Agents []string
 }
@@ -205,17 +210,18 @@ func NewLaunch(parent View, defaults LaunchDefaults) Launch {
 	prompt.Prompt = "  "
 
 	f := Launch{
-		parent:     parent,
-		agent:      agentInput,
-		workingDir: workingDir,
-		budget:     budget,
-		mode:       mode,
-		iter:       iter,
-		provider:   provider,
-		model:      model,
-		isolate:    isolate,
-		prompt:     prompt,
-		focus:      fldAgent,
+		parent:        parent,
+		agent:         agentInput,
+		workingDir:    workingDir,
+		budget:        budget,
+		mode:          mode,
+		iter:          iter,
+		provider:      provider,
+		model:         model,
+		isolate:       isolate,
+		prompt:        prompt,
+		providerToken: defaults.ProviderToken,
+		focus:         fldAgent,
 	}
 	f.applyFocus()
 	return f
@@ -589,6 +595,13 @@ func (l Launch) submit() (View, tea.Cmd) {
 		l.applyFocus()
 		return l, nil
 	}
+	key := metrics.KeyStatus(l.provider.Value(), l.providerToken)
+	if key.State == metrics.APIKeyMissing {
+		l.err = fmt.Sprintf("%s not set — export it (or set provider.token in config) before launching", key.EnvVar)
+		l.focus = fldProvider
+		l.applyFocus()
+		return l, nil
+	}
 	// isolate is a closed-set selectField — no validation needed.
 	req := LaunchRequest{
 		Agent:      agent,
@@ -602,6 +615,20 @@ func (l Launch) submit() (View, tea.Cmd) {
 		Isolate:    l.isolate.Value(),
 	}
 	return l.parent, func() tea.Msg { return req }
+}
+
+func (l Launch) keyStatusView() string {
+	status := metrics.KeyStatus(l.provider.Value(), l.providerToken)
+	switch status.State {
+	case metrics.APIKeyOK:
+		return style.Success.Render("key: ✓ " + status.EnvVar)
+	case metrics.APIKeyMissing:
+		return style.Error.Render("key: ✗ " + status.EnvVar + " missing")
+	case metrics.APIKeyNotNeeded:
+		return style.Faint.Render("key: —")
+	default:
+		return ""
+	}
 }
 
 // View renders the form. Width is supplied by the host; when ≤ 0 the
@@ -645,9 +672,10 @@ func (l Launch) View(width, height int) string {
 		labelW("mode", 6), l.mode.View(9),
 		labelW("iter", 6), boxed(l.iter.View(), l.focus == fldIters),
 	)
-	row3 := style.Faint.Render("advanced  ") + fmt.Sprintf("%s  %s    %s  %s    %s  %s",
+	row3 := style.Faint.Render("advanced  ") + fmt.Sprintf("%s  %s    %s  %s  %s    %s  %s",
 		labelW("provider", 9), boxed(l.provider.View(), l.focus == fldProvider),
 		labelW("model", 6), boxed(l.model.View(), l.focus == fldModel),
+		l.keyStatusView(),
 		labelW("isolate", 8), l.isolate.View(10),
 	)
 	var providerDropdown string

--- a/ui/pane/launch_test.go
+++ b/ui/pane/launch_test.go
@@ -126,6 +126,15 @@ func TestLaunchViewRendersFields(t *testing.T) {
 	}
 }
 
+func TestLaunchViewRendersKeyIndicator(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	form := NewLaunch(stubView{name: "parent"}, LaunchDefaults{Provider: "openai"})
+	out := form.View(120, 0)
+	if !strings.Contains(out, "✓ OPENAI_API_KEY") {
+		t.Fatalf("View missing API key indicator: %s", out)
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {
 		if s[i:i+len(substr)] == substr {
@@ -136,6 +145,7 @@ func contains(s, substr string) bool {
 }
 
 func TestLaunchSubmitEmitsRequest(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	parent := stubView{name: "parent"}
 	form := NewLaunch(parent, LaunchDefaults{
 		WorkingDir: "/tmp",
@@ -176,6 +186,7 @@ func TestLaunchSubmitEmitsRequest(t *testing.T) {
 }
 
 func TestLaunchSubmitIncludesAdvanced(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	parent := stubView{name: "parent"}
 	form := NewLaunch(parent, LaunchDefaults{
 		Agent:    "go-review",
@@ -472,6 +483,53 @@ func TestLaunchModelOptionsFollowProvider(t *testing.T) {
 		if !contains(opt, "gemini") {
 			t.Errorf("gemini provider showed non-Gemini model %q", opt)
 		}
+	}
+}
+
+func TestLaunchSubmitBlocksMissingProviderKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	form := NewLaunch(stubView{name: "parent"}, LaunchDefaults{
+		Agent:    "go-review",
+		Provider: "openai",
+		MaxIter:  10,
+	})
+	form.prompt.SetValue("do the thing")
+
+	v, cmd := form.submit()
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			t.Fatalf("missing key should not emit a command, got %T", msg)
+		}
+	}
+	l, ok := AsLaunchView(v)
+	if !ok {
+		t.Fatalf("missing key should keep form open, got %T", v)
+	}
+	want := "OPENAI_API_KEY not set — export it (or set provider.token in config) before launching"
+	if l.err != want {
+		t.Fatalf("err = %q, want %q", l.err, want)
+	}
+	if l.focus != fldProvider {
+		t.Fatalf("focus = %d, want provider %d", l.focus, fldProvider)
+	}
+}
+
+func TestLaunchSubmitAllowsProviderKeyFromEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	form := NewLaunch(stubView{name: "parent"}, LaunchDefaults{
+		Agent:    "go-review",
+		Provider: "openai",
+		MaxIter:  10,
+	})
+	form.prompt.SetValue("do the thing")
+
+	next, cmd := form.submit()
+	req := asLaunchRequest(t, cmd)
+	if req.Provider != "openai" || req.Agent != "go-review" {
+		t.Fatalf("request = %+v", req)
+	}
+	if next.Title() != "parent" {
+		t.Fatalf("after submit Title=%q, want parent", next.Title())
 	}
 }
 

--- a/ui/pane/launch_test.go
+++ b/ui/pane/launch_test.go
@@ -135,6 +135,23 @@ func TestLaunchViewRendersKeyIndicator(t *testing.T) {
 	}
 }
 
+func TestLaunchViewKeyIndicatorMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	form := NewLaunch(stubView{name: "parent"}, LaunchDefaults{Provider: "openai"})
+	out := form.View(120, 0)
+	if !strings.Contains(out, "✗ OPENAI_API_KEY missing") {
+		t.Fatalf("View missing API key 'missing' indicator: %s", out)
+	}
+}
+
+func TestLaunchViewKeyIndicatorNotNeededForOllama(t *testing.T) {
+	form := NewLaunch(stubView{name: "parent"}, LaunchDefaults{Provider: "ollama"})
+	out := form.View(120, 0)
+	if !strings.Contains(out, "key: —") {
+		t.Fatalf("View should render not-needed key indicator for ollama: %s", out)
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
**Key Changes:**

- Implemented a new API key readiness check for provider credentials in the launch form
- Added visual key indicator to the launch form UI to reflect credential status
- Updated app and pane logic to pass and handle resolved provider tokens for accurate credential precedence
- Introduced comprehensive unit tests for provider key checks and credential precedence

**Added:**

- API key status logic and types in `metrics/apikey.go` to encapsulate provider credential state and source
- `metrics/apikey_test.go` with table-driven tests to ensure correct key resolution and precedence
- Key indicator rendering in the launch form UI via `Launch.keyStatusView` and its integration in the form layout
- Launch form submission logic to block launch when the required provider key is missing and display a helpful error message
- Unit tests in `ui/pane/launch_test.go` for key indicator rendering, blocking on missing keys, and correct acceptance of credentials from config or environment

**Changed:**

- Modified `cmd/squad/ui.go` and `ui/app/app.go` to resolve and propagate `providerToken` from config to the UI application and launch form
- Updated `NewWithSessions` in `ui/app/app.go` and all its call sites and tests to accept and pass along the `providerToken` parameter
- Enhanced launch form construction and preset loading to include the resolved provider token in `ui/app/app.go` and `ui/pane/launch.go`
- Adjusted launch form rendering to include the key status indicator in the advanced settings row for real-time credential feedback
- Updated launch form submission logic to invoke API key status checks and enforce credential presence before allowing launch

**Removed:**

- Implicit, unchecked credential usage during launch; now all launches require an explicit provider token or environment variable when needed