### PR TITLE
feat: replace nvidia/databricks providers with unified openai-compat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Inspired by [Daniel Miessler's Fabric](https://github.com/danielmiessler/fabric)
 Define an agent in markdown and YAML, point it at any LLM, and turn it
 loose on a codebase.
 
-- Works with OpenAI, Anthropic, Google AI, Ollama, NVIDIA NIM, and Databricks AI Gateway
+- Works with OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, DeepInfra, Together AI, vLLM, LM Studio, and more)
 - Agents are just files: markdown prompts + YAML manifest, checked into git
 - Built-in tools: Read, Write, Edit, Glob, Grep, Bash, plus any MCP server
 - Multi-agent pipelines with dependency ordering, parallel stages, and regression gates
@@ -124,7 +124,7 @@ and can fetch the full bytes (or any byte range) via the
 | Feature                     | Description                                        |
 | --------------------------- | -------------------------------------------------- |
 | **Agent Execution**         | Run agents with Read, Write, Edit, Glob, Grep, Bash |
-| **Multi-provider**          | OpenAI, Anthropic, Google AI, Ollama, NVIDIA NIM, Databricks AI Gateway |
+| **Multi-provider**          | OpenAI, Anthropic, Google AI, Ollama, any OpenAI-compatible endpoint |
 | **Streaming Output**        | Real-time token streaming to stderr                |
 | **Fix + Analyze Modes**     | Agents can apply fixes or report-only              |
 | **Agent Scaffolding**       | `squad init agent` from templates or existing agents |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ loose on a codebase.
 - Built-in tools: Read, Write, Edit, Glob, Grep, Bash, plus any MCP server
 - Multi-agent pipelines with dependency ordering, parallel stages, and regression gates
 - Runs locally, in Docker, on Kubernetes, or over AWS SSM
+- Scheduled unattended runs via OS-native daemons (launchd, systemd, Task Scheduler)
 
 **Built for:**
 
@@ -39,16 +40,36 @@ loose on a codebase.
 
 ## Prerequisites
 
-| Requirement    | Version | Notes                         |
-| -------------- | ------- | ----------------------------- |
-| **Go**         | 1.24+   | Required for `go install`     |
-| **LLM access** | -      | OpenAI, Anthropic, Google AI, or Ollama |
+| Requirement    | Version | Notes                                   |
+| -------------- | ------- | --------------------------------------- |
+| **Go**         | 1.24+   | Required for `go install`               |
+| **LLM access** | -       | OpenAI, Anthropic, Google AI, or Ollama |
+
+## Installation
+
+```bash
+go install github.com/cowdogmoo/squad/cmd/squad@latest
+```
+
+### Build from Source
+
+```bash
+git clone https://github.com/cowdogmoo/squad.git
+cd squad
+go build -o squad ./cmd/squad
+```
+
+### Verification
+
+```bash
+squad version
+```
 
 ## Quick Start
 
 ```bash
-# Install
-go install github.com/cowdogmoo/squad/cmd/squad@latest
+# Initialize configuration
+squad config init
 
 # Add the official agents repository
 squad agents add official https://github.com/cowdogmoo/squad-agents.git
@@ -59,7 +80,7 @@ squad agents list
 # Run an agent against your codebase
 squad run --agent go-review --provider openai --model gpt-4.1-mini
 
-# Run with local Ollama
+# Run with local Ollama — no API key required
 squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
 
 # Run a composed (multi-agent) pipeline
@@ -70,88 +91,350 @@ squad run --agent go-review --resume 20260429T150220Z-a1b2c3d4 \
     "continue where you left off; finish the remaining files"
 ```
 
+## Usage
+
+### Key Run Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--agent` | Agent name to run | required |
+| `--provider` | LLM provider | config default |
+| `--model` | Model identifier | config default |
+| `--working-dir` | Target directory | current dir |
+| `--max-cost` | USD budget cap | `5.00` |
+| `--max-iterations` | Max tool-call loops | `100` |
+| `--apply` | Apply suggested diffs via git apply | `false` |
+| `--dry-run` | Estimate cost without running | `false` |
+| `--stream` | Stream tokens to stderr in real time | `false` |
+| `--resume` | Resume a session by ID | — |
+| `--out` | Write response to file | — |
+| `--var KEY=VALUE` | Template variable (repeatable) | — |
+| `--mcp-server` | MCP server spec (repeatable) | — |
+| `--isolate` | Isolation mode (e.g. `worktree`) | — |
+
 ### Sessions
 
-Every run writes an append-only event log to
-`./.squad/sessions/<id>/`:
+Every run writes an append-only event log to `./.squad/sessions/<id>/`:
 
-| File                   | Contents                                              |
-| ---------------------- | ----------------------------------------------------- |
-| `meta.json`            | run options, last response id, cost, status          |
-| `events.jsonl`         | one line per prompt, response, tool call, tool result |
-| `results/<id>.txt`     | full bytes of any tool result that exceeded 8 KiB     |
+| File               | Contents                                               |
+| ------------------ | ------------------------------------------------------ |
+| `meta.json`        | Run options, last response id, cost, status            |
+| `events.jsonl`     | One line per prompt, response, tool call, tool result  |
+| `results/<id>.txt` | Full bytes of any tool result that exceeded 8 KiB      |
 
 `--resume <id>` reopens that session and chains the next request to the
 prior OpenAI Responses API id, so the model picks up server-side state
 without re-sending the transcript. When a tool result is too large to
 inline, the model sees a `[result:<id> — N bytes elided …]` placeholder
-and can fetch the full bytes (or any byte range) via the
-`get_tool_result` tool.
+and can fetch the full bytes via the `get_tool_result` tool.
 
-## Documentation
+### Creating Your Own Agent
 
-### Getting Started
+```bash
+# Scaffold from a built-in template
+squad init agent my-review --lang go
 
-- **[Configuration](docs/configuration.md)** - Providers, environment variables,
-  and config file reference
-- **[Creating Agents](docs/creating-agents.md)** - Build your own agents from
-  scratch or from templates
-- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** - LLM
-  fundamentals, context windows, and how to write effective agent prompts
+# Edit the prompts
+$EDITOR agents/my-review/system.md
 
-### Guides
+# Test it
+squad run --agent my-review --print
+```
 
-- **[Pipelines](docs/pipelines.md)** - Multi-agent orchestration with stages,
-  gates, and cost budgets
-- **[Execution Backends](docs/execution-backends.md)** - Run agents in Docker,
-  Kubernetes, or AWS SSM
-- **[MCP Servers](docs/mcp-servers.md)** - Connect agents to external tools
-  via Model Context Protocol
-- **[Observability](docs/observability.md)** - Streaming output, OpenTelemetry
-  tracing, cost budgeting, and grading
+Agent directory structure:
 
-### Agents
+```
+my-review/
+├── agent.yaml      # Manifest (model preferences, tools, budget, pipeline)
+├── system.md       # Agent identity, rules, and workflow
+├── agent.md        # Execution wrapper
+├── task.md         # Default task instructions
+└── references/     # Optional knowledge-base documents
+```
 
-- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** - Production-ready
-  agents for Go, Python, Ansible, and Molecule
-- **[Agent Quality Guide](docs/agent-quality.md)** - Tuning methodology and
-  grading rubric
+## Multi-Agent Pipelines
+
+Define pipelines declaratively in `agent.yaml` using `stages` and `gates`:
+
+```yaml
+name: security-audit
+stages:
+  - name: scan
+    agents: [go-review, dependency-check]  # run in parallel
+  - name: report
+    agent: summarize
+    depends_on: [scan]
+gates:
+  - name: tests-pass
+    command: go test ./...
+    on_error: halt
+```
+
+```bash
+squad run --agent security-audit "Audit all changes since last release"
+```
+
+Stages can also partition work automatically across files:
+
+```yaml
+stages:
+  - name: review-files
+    agent: go-review
+    partition:
+      by: glob
+      glob: "**/*.go"
+      max_per_partition: 10
+```
+
+## Scheduled Runs (Routines)
+
+Routines enable unattended agent runs via OS-native schedulers (macOS launchd,
+Linux systemd, Windows Task Scheduler).
+
+```bash
+# Create a nightly audit routine (installs daemon automatically)
+squad routine create nightly-audit
+
+# List all routines and their next fire time
+squad routine list
+
+# Fire a routine immediately to test it
+squad routine run-now nightly-audit
+
+# Tail the daemon log
+squad routine logs --follow
+
+# Check daemon health
+squad routine doctor
+```
+
+Per-repo routine manifest (`.squad/routines/nightly-audit.yaml`):
+
+```yaml
+id: nightly-audit
+agent: go-security-audit
+schedule: "0 2 * * *"           # standard cron or @daily / @every 30m
+prompt: "Audit changes merged in the last 24 hours"
+provider: anthropic
+model: claude-sonnet-4-6
+max_cost: 5.00
+max_iterations: 30
+enabled: true
+```
+
+Checked into git, per-repo routines give the whole team the same automated
+reviews. Global routines live in `~/.config/squad/routines/` for
+personal cross-repo automations.
+
+| Routine Command | Description |
+|----------------|-------------|
+| `routine create <id>` | Create and install a routine |
+| `routine list` | List all routines with status |
+| `routine show <id>` | Full details and next fire time |
+| `routine run-now <id>` | Fire immediately |
+| `routine enable/disable <id>` | Toggle a routine |
+| `routine history <id>` | List past sessions |
+| `routine logs [--follow]` | Tail daemon output |
+| `routine doctor` | Health check |
+| `routine repair` | Reinstall the OS service |
+
+## Configuration
+
+Config is loaded from (highest to lowest precedence):
+CLI flags → `SQUAD_*` environment variables → config file → built-in defaults.
+
+```bash
+squad config init    # Create config at the default location
+squad config show    # View the merged effective config
+squad config path    # Show the active config file path
+squad config set provider.default anthropic
+squad config get model.default
+```
+
+**Default path:** `~/.config/squad/config.yaml`
+
+### Config File Reference
+
+```yaml
+log:
+  level: info              # debug | info | warn | error
+  format: text             # text | json | color
+
+provider:
+  default: openai          # openai | anthropic | google | ollama | openai-compat
+  token: $OPENAI_API_KEY   # supports $VAR and $(command) for dynamic resolution
+  base_url: ""             # override provider endpoint (OpenAI-compatible APIs)
+  organization: ""         # OpenAI organization ID
+  api_version: ""          # for Azure OpenAI
+
+model:
+  default: gpt-4.1-mini
+  temperature: 0.2
+  max_tokens: 1024
+
+agents:
+  repositories:
+    official: https://github.com/cowdogmoo/squad-agents.git
+  local_paths: []          # additional local agent search directories
+
+run:
+  max_iterations: 100
+  max_cost: 5.0            # USD
+  stream: false
+  apply: false
+  require_actionable: true
+
+otel:
+  endpoint: ""             # OTLP endpoint; empty disables tracing
+```
+
+### Environment Variables
+
+All config keys are available as `SQUAD_*` environment variables
+(replace `.` with `_`, uppercase):
+
+```bash
+SQUAD_PROVIDER_DEFAULT=anthropic
+SQUAD_PROVIDER_TOKEN=$ANTHROPIC_API_KEY
+SQUAD_MODEL_DEFAULT=claude-sonnet-4-6
+SQUAD_RUN_MAX_COST=10.0
+SQUAD_LOG_LEVEL=debug
+```
+
+### OpenAI-Compatible Endpoints
+
+```yaml
+provider:
+  default: openai-compat
+  base_url: https://api.together.xyz/v1
+  token: $TOGETHER_API_KEY
+```
+
+Works with NVIDIA NIM, Databricks, Together AI, vLLM, LM Studio, and any
+OpenAI-compatible API.
+
+## Execution Backends
+
+Run agents in isolated or remote environments by adding an `environment` block
+to `agent.yaml`:
+
+### Docker
+
+```yaml
+environment:
+  type: docker
+  options:
+    image: golang:1.24
+    volumes: ".:/workspace"
+    working_dir: /workspace
+```
+
+### Kubernetes
+
+```yaml
+environment:
+  type: kubectl
+  options:
+    namespace: default
+    image: golang:1.24
+    resources:
+      requests:
+        memory: "512Mi"
+```
+
+### AWS SSM
+
+```yaml
+environment:
+  type: ssm
+  options:
+    instance_id: i-1234567890abcdef0
+    region: us-east-1
+```
 
 ## Features
 
 ### Core Capabilities
 
-| Feature                     | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| **Agent Execution**         | Run agents with Read, Write, Edit, Glob, Grep, Bash |
-| **Multi-provider**          | OpenAI, Anthropic, Google AI, Ollama, any OpenAI-compatible endpoint |
-| **Streaming Output**        | Real-time token streaming to stderr                |
-| **Fix + Analyze Modes**     | Agents can apply fixes or report-only              |
-| **Agent Scaffolding**       | `squad init agent` from templates or existing agents |
-| **Agent Repositories**      | Git-based agent sharing and discovery              |
+| Feature | Description |
+|---------|-------------|
+| **Agent Execution** | Run agents with Read, Write, Edit, Glob, Grep, Bash tools |
+| **Multi-provider** | OpenAI, Anthropic, Google AI, Ollama, any OpenAI-compatible endpoint |
+| **Streaming Output** | Real-time token streaming to stderr |
+| **Fix + Analyze Modes** | Agents can apply fixes or report only |
+| **Agent Scaffolding** | `squad init agent` from templates or existing agents |
+| **Agent Repositories** | Git-based agent sharing and discovery |
 
 ### Orchestration
 
-| Feature                     | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| **Declarative Pipelines**   | Multi-stage YAML pipelines with dependency ordering |
-| **Parallel Execution**      | Multiple agents in a stage run concurrently        |
-| **Regression Gates**        | Shell commands validate state between stages       |
-| **Background Tasks**        | Spawn child agents with `Task(background=true)`    |
-| **Cost Budgeting**          | `--max-cost` limits total spend across agents      |
+| Feature | Description |
+|---------|-------------|
+| **Declarative Pipelines** | Multi-stage YAML pipelines with dependency ordering |
+| **Parallel Execution** | Multiple agents in a stage run concurrently |
+| **Regression Gates** | Shell commands validate state between stages |
+| **Background Tasks** | Spawn child agents with `Task(background=true)` |
+| **Cost Budgeting** | Per-run and per-stage USD caps with dry-run estimation |
 
 ### Infrastructure
 
-| Feature                     | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| **Execution Backends**      | Local, Docker, Kubernetes, AWS SSM                 |
-| **MCP Integration**         | Connect to any Model Context Protocol server       |
-| **OpenTelemetry**           | OTLP tracing for agent runs and tool calls         |
-| **Agent Grading**           | Grade outputs against quality rubrics              |
-| **XDG Configuration**       | Standard config paths with env var overrides       |
+| Feature | Description |
+|---------|-------------|
+| **Execution Backends** | Local, Docker, Kubernetes, AWS SSM |
+| **MCP Integration** | Connect to any Model Context Protocol server |
+| **OpenTelemetry** | OTLP tracing for agent runs and tool calls |
+| **Agent Grading** | Grade outputs against quality rubrics |
+| **XDG Configuration** | Standard config paths with env var overrides |
+| **Routines** | OS-native daemon for scheduled unattended agent runs |
+
+## Documentation
+
+### Getting Started
+
+- **[Configuration](docs/configuration.md)** - Providers, environment variables, and config file reference
+- **[Creating Agents](docs/creating-agents.md)** - Build your own agents from scratch or from templates
+- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** - LLM fundamentals, context windows, and how to write effective agent prompts
+
+### Guides
+
+- **[Pipelines](docs/pipelines.md)** - Multi-agent orchestration with stages, gates, and cost budgets
+- **[Execution Backends](docs/execution-backends.md)** - Run agents in Docker, Kubernetes, or AWS SSM
+- **[MCP Servers](docs/mcp-servers.md)** - Connect agents to external tools via Model Context Protocol
+- **[Observability](docs/observability.md)** - Streaming output, OpenTelemetry tracing, cost budgeting, and grading
+- **[Routines](docs/routines.md)** - Scheduled unattended runs via OS-native daemons
+
+### Agents
+
+- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** - Production-ready agents for Go, Python, Ansible, and Molecule
+- **[Agent Quality Guide](docs/agent-quality.md)** - Tuning methodology and grading rubric
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/my-feature`
+3. Make your changes and add tests
+4. Run the test suite: `go test ./...`
+5. Commit your changes: `git commit -m 'Add my feature'`
+6. Push to the branch: `git push origin feature/my-feature`
+7. Open a Pull Request
+
+### Development Setup
+
+```bash
+git clone https://github.com/cowdogmoo/squad.git
+cd squad
+go mod download
+go build ./...
+go test ./...
+```
 
 ## Built With
 
 - [LangChainGo](https://github.com/tmc/langchaingo)
 - [Cobra](https://github.com/spf13/cobra)
 - [Viper](https://github.com/spf13/viper)
+- [Bubble Tea](https://github.com/charmbracelet/bubbletea)
+- [go-git](https://github.com/go-git/go-git)
+
+## License
+
+[MIT License](./LICENSE)

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -22,8 +22,8 @@ import (
 // ModelPreference represents a ranked model recommendation for an agent.
 // The first entry in a models list is the primary (preferred) model.
 type ModelPreference struct {
-	Model    string `yaml:"model"`
-	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`    // model identifier (e.g. "claude-sonnet-4-6")
+	Provider string `yaml:"provider"` // squad provider name (e.g. "anthropic", "openai-compat")
 	BaseURL  string `yaml:"base_url,omitempty"` // optional endpoint override; required when Provider is "openai-compat"
 }
 

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -22,8 +22,8 @@ import (
 // ModelPreference represents a ranked model recommendation for an agent.
 // The first entry in a models list is the primary (preferred) model.
 type ModelPreference struct {
-	Model    string `yaml:"model"`    // model identifier (e.g. "claude-sonnet-4-6")
-	Provider string `yaml:"provider"` // squad provider name (e.g. "anthropic", "openai-compat")
+	Model    string `yaml:"model"`              // model identifier (e.g. "claude-sonnet-4-6")
+	Provider string `yaml:"provider"`           // squad provider name (e.g. "anthropic", "openai-compat")
 	BaseURL  string `yaml:"base_url,omitempty"` // optional endpoint override; required when Provider is "openai-compat"
 }
 

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -24,6 +24,7 @@ import (
 type ModelPreference struct {
 	Model    string `yaml:"model"`
 	Provider string `yaml:"provider"`
+	BaseURL  string `yaml:"base_url,omitempty"`
 }
 
 // Manifest represents the structure of an agent's manifest file.
@@ -163,6 +164,7 @@ type Bundle struct {
 	WorkDir       string
 	Model         string             // primary model override (first from models list or single model field)
 	Provider      string             // primary provider override (first from models list or single provider field)
+	BaseURL       string             // primary model's base URL override (for openai-compat)
 	Models        []ModelPreference  // ranked model preferences from manifest
 	Budget        *BudgetConfig      // budget configuration from manifest
 	Environment   *executor.Config   // execution environment from agent manifest
@@ -660,10 +662,11 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		return nil, err
 	}
 
-	var primaryModel, primaryProvider string
+	var primaryModel, primaryProvider, primaryBaseURL string
 	if len(manifest.Models) > 0 {
 		primaryModel = manifest.Models[0].Model
 		primaryProvider = manifest.Models[0].Provider
+		primaryBaseURL = manifest.Models[0].BaseURL
 	}
 
 	return &Bundle{
@@ -673,6 +676,7 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		WorkDir:       workingDir,
 		Model:         primaryModel,
 		Provider:      primaryProvider,
+		BaseURL:       primaryBaseURL,
 		Models:        manifest.Models,
 		Budget:        manifest.Budget,
 		Environment:   manifest.Environment,
@@ -756,10 +760,11 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 	combined.WriteString(userMessage)
 	combined.WriteString("\n")
 
-	var primaryModel, primaryProvider string
+	var primaryModel, primaryProvider, primaryBaseURL string
 	if len(manifest.Models) > 0 {
 		primaryModel = manifest.Models[0].Model
 		primaryProvider = manifest.Models[0].Provider
+		primaryBaseURL = manifest.Models[0].BaseURL
 	}
 
 	return &Bundle{
@@ -769,6 +774,7 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 		WorkDir:  workingDir,
 		Model:    primaryModel,
 		Provider: primaryProvider,
+		BaseURL:  primaryBaseURL,
 		Models:   manifest.Models,
 	}, nil
 }

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -24,7 +24,7 @@ import (
 type ModelPreference struct {
 	Model    string `yaml:"model"`
 	Provider string `yaml:"provider"`
-	BaseURL  string `yaml:"base_url,omitempty"`
+	BaseURL  string `yaml:"base_url,omitempty"` // optional endpoint override; required when Provider is "openai-compat"
 }
 
 // Manifest represents the structure of an agent's manifest file.
@@ -627,7 +627,7 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		displayMode = "edit"
 	}
 
-	data := TemplateData{Mode: mode, Vars: vars}
+	data := TemplateData{Mode: displayMode, Vars: vars}
 	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(agentPath, agentsDir, manifest, data)
 	if err != nil {
 		return nil, err
@@ -731,7 +731,7 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 		displayMode = "edit"
 	}
 
-	data := TemplateData{Mode: mode, Vars: vars}
+	data := TemplateData{Mode: displayMode, Vars: vars}
 	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(promptDir, baseDir, manifest, data)
 	if err != nil {
 		return nil, err

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -91,6 +91,15 @@ type ChildBudget struct {
 	MaxIterations int     `yaml:"max_iterations,omitempty"` // iteration cap for child (0 = inherit parent's cap)
 }
 
+// PrimaryModel returns the first ranked ModelPreference, or the zero value
+// if no models are declared.
+func (m *Manifest) PrimaryModel() ModelPreference {
+	if len(m.Models) == 0 {
+		return ModelPreference{}
+	}
+	return m.Models[0]
+}
+
 // FindModel returns the ModelPreference matching the given provider and model,
 // or nil if not found. An empty provider or model never matches.
 func (b *Bundle) FindModel(provider, model string) *ModelPreference {
@@ -225,14 +234,20 @@ func makeIncludeFunc(agentsDir string) func(string) (string, error) {
 	}
 }
 
+// resolveDisplayMode returns mode, defaulting to "edit" when empty.
+func resolveDisplayMode(mode string) string {
+	if mode == "" {
+		return "edit"
+	}
+	return mode
+}
+
 // processTemplate executes a Go text/template with the given data.
 // Templates can use {{if eq .Mode "edit"}}...{{end}} conditionals.
 // Templates can use {{include "hard-rules/universal.md"}} to include shared content.
 // Templates can use {{.Var "KEY"}} or {{.Default "KEY" "default"}} for custom variables.
 func processTemplate(name, content, agentsDir string, data TemplateData) (string, error) {
-	if data.Mode == "" {
-		data.Mode = "edit"
-	}
+	data.Mode = resolveDisplayMode(data.Mode)
 
 	funcMap := template.FuncMap{
 		"include": makeIncludeFunc(agentsDir),
@@ -251,7 +266,8 @@ func processTemplate(name, content, agentsDir string, data TemplateData) (string
 	return buf.String(), nil
 }
 
-// loadReferences reads all reference files and returns formatted content.
+// readFileInRoot opens path relative to root using os.OpenInRoot (Go 1.24+)
+// for traversal-resistant reads, then returns the file contents.
 func readFileInRoot(root, path string) (data []byte, retErr error) {
 	f, err := os.OpenInRoot(root, path)
 	if err != nil {
@@ -408,10 +424,6 @@ func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, data
 	return system, wrapper, task, nil
 }
 
-// BuildBundle assembles the agent bundle from manifest, system prompt, wrapper, references, and task.
-// The task instructions are included in the system bundle. The CLI prompt becomes the user message.
-// If no CLI prompt is provided, a default user message is used.
-// The vars parameter allows passing custom template variables (e.g., COVERAGE_TARGET=85).
 // toolEfficiencyPrompt is injected into all agent system prompts to encourage
 // batching of tool calls and efficient file reading.
 const toolEfficiencyPrompt = `## Tool Efficiency
@@ -480,9 +492,6 @@ func repoSummaryVisitFile(rel string, d fs.DirEntry, dirs map[string]*dirInfo, t
 	}
 	*totalFiles++
 	dir := filepath.Dir(rel)
-	if dir == "." {
-		dir = "."
-	}
 	if dirs[dir] == nil {
 		dirs[dir] = &dirInfo{exts: make(map[string]int)}
 	}
@@ -622,10 +631,7 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		return nil, err
 	}
 
-	displayMode := mode
-	if displayMode == "" {
-		displayMode = "edit"
-	}
+	displayMode := resolveDisplayMode(mode)
 
 	data := TemplateData{Mode: displayMode, Vars: vars}
 	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(agentPath, agentsDir, manifest, data)
@@ -662,21 +668,16 @@ func BuildBundle(agentsDir, agentName, prompt, workingDir, mode string, vars map
 		return nil, err
 	}
 
-	var primaryModel, primaryProvider, primaryBaseURL string
-	if len(manifest.Models) > 0 {
-		primaryModel = manifest.Models[0].Model
-		primaryProvider = manifest.Models[0].Provider
-		primaryBaseURL = manifest.Models[0].BaseURL
-	}
+	primary := manifest.PrimaryModel()
 
 	return &Bundle{
 		System:        sys.String(),
 		User:          userMessage,
 		Combined:      combined.Bytes(),
 		WorkDir:       workingDir,
-		Model:         primaryModel,
-		Provider:      primaryProvider,
-		BaseURL:       primaryBaseURL,
+		Model:         primary.Model,
+		Provider:      primary.Provider,
+		BaseURL:       primary.BaseURL,
 		Models:        manifest.Models,
 		Budget:        manifest.Budget,
 		Environment:   manifest.Environment,
@@ -726,10 +727,7 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 		References: cfg.References,
 	}
 
-	displayMode := mode
-	if displayMode == "" {
-		displayMode = "edit"
-	}
+	displayMode := resolveDisplayMode(mode)
 
 	data := TemplateData{Mode: displayMode, Vars: vars}
 	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(promptDir, baseDir, manifest, data)
@@ -760,21 +758,16 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 	combined.WriteString(userMessage)
 	combined.WriteString("\n")
 
-	var primaryModel, primaryProvider, primaryBaseURL string
-	if len(manifest.Models) > 0 {
-		primaryModel = manifest.Models[0].Model
-		primaryProvider = manifest.Models[0].Provider
-		primaryBaseURL = manifest.Models[0].BaseURL
-	}
+	primary := manifest.PrimaryModel()
 
 	return &Bundle{
 		System:   sys.String(),
 		User:     userMessage,
 		Combined: combined.Bytes(),
 		WorkDir:  workingDir,
-		Model:    primaryModel,
-		Provider: primaryProvider,
-		BaseURL:  primaryBaseURL,
+		Model:    primary.Model,
+		Provider: primary.Provider,
+		BaseURL:  primary.BaseURL,
 		Models:   manifest.Models,
 	}, nil
 }

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -587,7 +587,7 @@ func TestCompleteProviderNames(t *testing.T) {
 	if len(names) != len(metrics.SupportedProviders) {
 		t.Fatalf("names len = %d, want %d", len(names), len(metrics.SupportedProviders))
 	}
-	want := map[string]bool{"nvidia": false, "databricks": false}
+	want := map[string]bool{"openai-compat": false}
 	for _, n := range names {
 		if _, ok := want[n]; ok {
 			want[n] = true

--- a/docs/agents-engineering-pipeline-basics.md
+++ b/docs/agents-engineering-pipeline-basics.md
@@ -137,7 +137,10 @@ graph LR
     S2["Stage 2: Access Extraction"] --> F2["access-controls.md"]
     S3["Stage 3: Flow Mapping"] --> F3["data-flows.md"]
     S4["Stage 4: Assumption Articulation"] --> F4["assumptions.md"]
-    F1 & F2 & F3 & F4 --> S5["Stage 5: Flaw Probing"]
+    F1 --> S5["Stage 5: Flaw Probing"]
+    F2 --> S5
+    F3 --> S5
+    F4 --> S5
 ```
 
 This is not the same as a bloated context window. Each artifact is structured and signal-rich because a specialist agent wrote it with a single purpose. The accumulation is additive without being noisy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,8 +230,7 @@ variables, or config file.
 | Anthropic | supported | `https://api.anthropic.com/v1` | required | Claude models via LangChainGo |
 | Google AI | supported | Google AI endpoints | required | Gemini models via LangChainGo |
 | Ollama | supported | `http://localhost:11434/v1` (default) | optional | Local models; use `--num-ctx` for context size |
-| NVIDIA NIM | supported | `https://integrate.api.nvidia.com/v1` (default) | required | OpenAI-compatible; models at build.nvidia.com |
-| Databricks AI Gateway | supported | `https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1` | required | OpenAI-compatible; PAT (`dapi-` prefix) as Bearer token |
+| OpenAI-compatible | supported | provider-specific (required) | optional | Any `/v1/chat/completions` endpoint; use `--base-url` |
 
 ### OpenAI
 
@@ -251,48 +250,83 @@ squad run --agent go-review --provider anthropic --model claude-sonnet-4-2025051
 squad run --agent go-review --provider gemini --model gemini-2.5-flash
 ```
 
-### NVIDIA NIM
+### OpenAI-compatible endpoints
+
+The `openai-compat` provider works with any service that exposes a
+`/v1/chat/completions` API — NVIDIA NIM, Databricks AI Gateway, DeepInfra,
+Together AI, Fireworks, Groq, Perplexity, LM Studio, vLLM, and more. Only
+`--base-url` and (optionally) `--api-key` are required; no per-service provider
+name is needed.
 
 ```bash
-# Using an NVIDIA API key from build.nvidia.com
+# DeepInfra
 squad run --agent go-review \
-  --provider nvidia \
-  --api-key $NVIDIA_API_KEY \
-  --model meta/llama-3.1-8b-instruct
+  --provider openai-compat \
+  --base-url "https://api.deepinfra.com/v1/openai" \
+  --api-key "$DEEPINFRA_API_KEY" \
+  --model "meta-llama/Meta-Llama-3-70B-Instruct"
 
-# Or via config / env vars
-export SQUAD_PROVIDER_DEFAULT=nvidia
-export SQUAD_PROVIDER_TOKEN=$NVIDIA_API_KEY
-export SQUAD_MODEL_DEFAULT=meta/llama-3.1-8b-instruct
-squad run --agent go-review
+# Together AI
+squad run --agent go-review \
+  --provider openai-compat \
+  --base-url "https://api.together.xyz/v1" \
+  --api-key "$TOGETHER_API_KEY" \
+  --model "mistralai/Mixtral-8x7B-Instruct-v0.1"
+
+# LM Studio (local, no auth)
+squad run --agent go-review \
+  --provider openai-compat \
+  --base-url "http://localhost:1234/v1" \
+  --model "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF"
+
+# vLLM self-hosted
+squad run --agent go-review \
+  --provider openai-compat \
+  --base-url "http://my-vllm-host:8000/v1" \
+  --model "mistral-7b-instruct"
 ```
 
-### Databricks AI Gateway
+#### NVIDIA NIM
+
+```bash
+squad run --agent go-review \
+  --provider openai-compat \
+  --base-url https://integrate.api.nvidia.com/v1 \
+  --api-key $NVIDIA_API_KEY \
+  --model meta/llama-3.1-8b-instruct
+```
+
+#### Databricks AI Gateway
 
 Databricks AI Gateway is an OpenAI-compatible proxy that routes requests to
 foundation models hosted on Databricks. It is currently in **beta** (no charges
 during beta; unavailable on GovCloud/Azure Government).
 
-The base URL uses the `ai-gateway` subdomain, not the workspace URL. The path is always `/mlflow/v1` regardless of which model you target; langchaingo appends `/chat/completions` automatically:
+The base URL uses the `ai-gateway` subdomain, not the workspace URL. The path is
+always `/mlflow/v1` regardless of which model you target; langchaingo appends
+`/chat/completions` automatically:
 
 ```
 https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
 ```
 
-Send a Databricks PAT (`dapi-` prefix) or OAuth access token via `--api-key` / `SQUAD_PROVIDER_TOKEN`. The token is forwarded as `Authorization: Bearer <token>`. PATs can be scoped to specific API operations for least-privilege access.
+Send a Databricks PAT (`dapi-` prefix) or OAuth access token via `--api-key` /
+`SQUAD_PROVIDER_TOKEN`. The `--model` value is the name of the deployed gateway
+endpoint (e.g. `databricks-gpt-5-5-pro`), not a model family.
 
-The `--model` value is the name of the deployed gateway endpoint (e.g. `databricks-gpt-5-5-pro`), not a model family.
+Rate limiting is configured on the Databricks side per endpoint, per user, and
+per group, not in squad.
 
 ```bash
 # CLI flags
 squad run --agent go-review \
-  --provider databricks \
+  --provider openai-compat \
   --base-url "https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1" \
   --api-key "dapi-your-databricks-token" \
   --model databricks-gpt-5-5-pro
 
 # Environment variables
-export SQUAD_PROVIDER_DEFAULT=databricks
+export SQUAD_PROVIDER_DEFAULT=openai-compat
 export SQUAD_PROVIDER_BASE_URL=https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
 export SQUAD_PROVIDER_TOKEN=dapi-your-databricks-token
 export SQUAD_MODEL_DEFAULT=databricks-gpt-5-5-pro
@@ -303,29 +337,37 @@ Config file with short-lived OAuth token via shell substitution:
 
 ```yaml
 provider:
-  default: databricks
+  default: openai-compat
   base_url: https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1
   token: $(databricks auth token --host https://<workspace-url> 2>/dev/null | jq -r .access_token)
 model:
   default: databricks-gpt-5-5-pro
 ```
 
-Agent manifest override:
+Example Databricks endpoint names: `databricks-gpt-5-5-pro`,
+`databricks-claude-sonnet-4-5`, `databricks-meta-llama-3-3-70b-instruct`.
+
+#### Agent manifest with base_url
+
+Include `base_url` in the manifest so agents that require a specific endpoint
+are self-contained — no `--base-url` flag needed at runtime:
 
 ```yaml
 models:
-  - model: databricks-gpt-5-5-pro
-    provider: databricks
+  - provider: openai-compat
+    model: meta-llama/Meta-Llama-3-70B-Instruct
+    base_url: https://api.deepinfra.com/v1/openai
 ```
 
-Example endpoint names: `databricks-gpt-5-5-pro`, `databricks-claude-sonnet-4-5`,
-`databricks-meta-llama-3-3-70b-instruct`.
+Only `--api-key` (or the env var) is still required at runtime; keys are never
+stored in manifests.
 
-Rate limiting is configured on the Databricks side per endpoint, per user, and per group, not in squad.
-
-Databricks AI Gateway natively supports Claude Code as a coding agent, so you can route squad's LLM calls through the gateway for enterprise governance.
-
-Known limitation: the `usage_context` map (per-request cost attribution stored as `request_tags` in `system.ai_gateway.usage`) requires `extra_body` support in the OpenAI client, which langchaingo does not currently provide. This is a candidate follow-on item.
+> **Migration from `nvidia` or `databricks` provider**
+>
+> Replace `provider: nvidia` or `provider: databricks` with
+> `provider: openai-compat` and add an explicit `base_url`. For NVIDIA use
+> `https://integrate.api.nvidia.com/v1`; for Databricks use your
+> `https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1` URL.
 
 ### Ollama
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -259,8 +259,7 @@ var SupportedProviders = []string{
 	"anthropic",
 	"gemini",
 	"ollama",
-	"nvidia",
-	"databricks",
+	"openai-compat",
 }
 
 // providerMappings maps a squad provider name to the LiteLLM
@@ -271,8 +270,7 @@ var providerMappings = map[string][]string{
 	"openai-responses": {"openai", "azure"},
 	"anthropic":        {"anthropic", "bedrock", "vertex_ai"},
 	"gemini":           {"gemini", "vertex_ai", "vertex_ai-language-models"},
-	"nvidia":           {"nvidia"},
-	"databricks":       {"databricks"},
+	"openai-compat":    {"openai"},
 }
 
 func fetchPricing() {
@@ -387,8 +385,6 @@ var modelListingProviders = map[string]string{
 	"openai-responses": "openai",
 	"anthropic":        "anthropic",
 	"gemini":           "gemini",
-	"nvidia":           "nvidia",
-	"databricks":       "databricks",
 	"ollama":           "ollama_chat",
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -253,6 +253,10 @@ var (
 // SupportedProviders is the canonical, ordered list of provider names
 // squad recognizes for the --provider flag and the TUI launch form.
 // Keep this in sync with the provider dispatch in runner/model.go.
+//
+// Note: "nvidia" and "databricks" are still accepted by the runner as
+// deprecated shims that redirect to "openai-compat". They are intentionally
+// omitted here so completion and UI forms guide users toward the replacement.
 var SupportedProviders = []string{
 	"openai",
 	"openai-responses",
@@ -380,6 +384,10 @@ func ModelsForProvider(provider string) []string {
 // under "anthropic". Ollama maps to LiteLLM's "ollama_chat" key; users
 // still need the model pulled locally, but at least the typeahead
 // hints at popular options instead of going blank.
+//
+// "openai-compat" is intentionally absent: it targets arbitrary third-party
+// endpoints (DeepInfra, vLLM, NIM, etc.) that have no shared model catalog,
+// so dynamic listing is not supported.
 var modelListingProviders = map[string]string{
 	"openai":           "openai",
 	"openai-responses": "openai",

--- a/routine/daemon/daemon.go
+++ b/routine/daemon/daemon.go
@@ -135,6 +135,7 @@ func newRunOptions(entry routine.Entry, cfg *config.Config, workingDir string) *
 		WorkingDir:      workingDir,
 		Provider:        r.Provider,
 		Model:           r.Model,
+		BaseURL:         r.BaseURL,
 		ConfigProvider:  cfg.Provider.Default,
 		ConfigModel:     cfg.Model.Default,
 		Temperature:     cfg.Model.Temperature,

--- a/routine/manifest.go
+++ b/routine/manifest.go
@@ -61,6 +61,9 @@ type Routine struct {
 	Provider string `yaml:"provider,omitempty"`
 	// Model overrides the default model for this routine.
 	Model string `yaml:"model,omitempty"`
+	// BaseURL overrides the provider's API endpoint for this routine.
+	// Required when Provider is "openai-compat".
+	BaseURL string `yaml:"base_url,omitempty"`
 	// MaxCost caps the total USD spend for one fire (0 = inherit default).
 	MaxCost float64 `yaml:"max_cost,omitempty"`
 	// MaxIterations caps the per-fire tool-call iterations (0 = inherit default).
@@ -148,6 +151,9 @@ func (r *Routine) Validate() error {
 	}
 	if r.MaxIterations < 0 {
 		return fmt.Errorf("max_iterations must not be negative")
+	}
+	if r.Provider == "openai-compat" && r.BaseURL == "" {
+		return errors.New("provider \"openai-compat\" requires base_url")
 	}
 	return nil
 }

--- a/routine/manifest_test.go
+++ b/routine/manifest_test.go
@@ -92,6 +92,11 @@ func TestRoutineValidate(t *testing.T) {
 		{"catchup fire-once ok", func(r *Routine) { r.Catchup = CatchupFireOnce }, false},
 		{"negative max_cost", func(r *Routine) { r.MaxCost = -1 }, true},
 		{"negative max_iterations", func(r *Routine) { r.MaxIterations = -1 }, true},
+		{"openai-compat missing base_url", func(r *Routine) { r.Provider = "openai-compat" }, true},
+		{"openai-compat with base_url ok", func(r *Routine) {
+			r.Provider = "openai-compat"
+			r.BaseURL = "https://api.deepinfra.com/v1/openai"
+		}, false},
 	}
 	for _, c := range cases {
 		r := base

--- a/runner/model.go
+++ b/runner/model.go
@@ -226,8 +226,23 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	if taskCfg != nil {
 		taskCfg.ParentMetrics = m
 	}
+	// Only the LangChain Anthropic provider handles CachedContent; all other
+	// LangChain providers (openai, openai-compat, gemini, ollama) silently drop it.
+	useCacheControl := provider == "anthropic"
+	// openai-compat endpoints default to tool_choice:"auto", allowing the model
+	// to respond without calling any tools. Force the first iteration to use
+	// tool_choice:"required" so the model must explore before answering.
+	forceFirstTool := provider == "openai-compat" || provider == "openai"
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
-	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, opts.MaxIterations, bundle.EditDeadline, taskCfg, m, ex, callOpts...)
+	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, tools.RunWithToolsConfig{
+		MaxIterations:      opts.MaxIterations,
+		EditDeadline:       bundle.EditDeadline,
+		TaskCfg:            taskCfg,
+		Metrics:            m,
+		Executor:           ex,
+		UseCacheControl:    useCacheControl,
+		ForceFirstToolCall: forceFirstTool,
+	}, callOpts...)
 	m.Finish()
 	if err != nil {
 		if errors.Is(err, metrics.ErrBudgetExceeded) {
@@ -282,16 +297,33 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 	case "gemini":
 		return buildGeminiLLM(ctx, opts, model)
 	case "openai-compat":
+		return buildOpenAICompatLLM(opts, "openai-compat", model)
+	case "nvidia":
+		// Deprecated: use provider: openai-compat with base_url: https://integrate.api.nvidia.com/v1
+		logging.Warn("provider 'nvidia' is deprecated; use 'openai-compat' with base_url: https://integrate.api.nvidia.com/v1")
 		if opts.BaseURL == "" {
-			return nil, fmt.Errorf("openai-compat provider requires --base-url (e.g. https://api.deepinfra.com/v1/openai)")
+			opts.BaseURL = "https://integrate.api.nvidia.com/v1"
 		}
+		return buildOpenAICompatLLM(opts, "openai-compat", model)
+	case "databricks":
+		// Deprecated: use provider: openai-compat with base_url pointing to your Databricks AI Gateway
+		logging.Warn("provider 'databricks' is deprecated; use 'openai-compat' with base_url and api_key set")
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
 }
 
+// buildOpenAICompatLLM constructs an OpenAI-compatible LangChain LLM for any
+// provider that speaks the OpenAI chat-completions API (openai, openai-compat,
+// and the legacy Azure path). When provider is "openai" or empty, organization
+// and API-version headers are applied; otherwise only base URL and token are
+// set, making it suitable for third-party endpoints like DeepInfra or vLLM.
 func buildOpenAICompatLLM(opts *RunOptions, provider, model string) (llms.Model, error) {
+	if provider == "openai-compat" && opts.BaseURL == "" {
+		return nil, fmt.Errorf("openai-compat provider requires --base-url (e.g. https://api.deepinfra.com/v1/openai)")
+	}
+
 	oaiOpts := []openai.Option{}
 	if model != "" {
 		oaiOpts = append(oaiOpts, openai.WithModel(model))
@@ -301,8 +333,15 @@ func buildOpenAICompatLLM(opts *RunOptions, provider, model string) (llms.Model,
 		oaiOpts = append(oaiOpts, openai.WithBaseURL(opts.BaseURL))
 	}
 
-	if opts.APIKey != "" {
-		oaiOpts = append(oaiOpts, openai.WithToken(opts.APIKey))
+	apiKey := opts.APIKey
+	if apiKey == "" && provider == "openai-compat" {
+		apiKey = os.Getenv("OPENAI_COMPAT_API_KEY")
+	}
+	if apiKey == "" && provider == "openai-compat" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey != "" {
+		oaiOpts = append(oaiOpts, openai.WithToken(apiKey))
 	}
 
 	if provider == "openai" || provider == "" {
@@ -367,7 +406,8 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 }
 
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai" || provider == "openai-compat"
+	return provider == "" || provider == "openai" || provider == "openai-compat" ||
+		provider == "nvidia" || provider == "databricks"
 }
 
 // reasoningPrefixes returns the configured reasoning model prefixes,

--- a/runner/model.go
+++ b/runner/model.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
-
-	"io"
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/config"
@@ -282,10 +281,11 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildAnthropicLLM(opts, model)
 	case "gemini":
 		return buildGeminiLLM(ctx, opts, model)
-	case "nvidia":
-		return buildNvidiaLLM(opts, model)
-	case "databricks":
-		return buildDatabricksLLM(opts, model)
+	case "openai-compat":
+		if opts.BaseURL == "" {
+			return nil, fmt.Errorf("openai-compat provider requires --base-url (e.g. https://api.deepinfra.com/v1/openai)")
+		}
+		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -354,44 +354,6 @@ func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
-func buildNvidiaLLM(opts *RunOptions, model string) (llms.Model, error) {
-	oaiOpts := []openai.Option{}
-	if model != "" {
-		oaiOpts = append(oaiOpts, openai.WithModel(model))
-	}
-	baseURL := opts.BaseURL
-	if baseURL == "" {
-		baseURL = "https://integrate.api.nvidia.com/v1"
-	}
-	oaiOpts = append(oaiOpts, openai.WithBaseURL(baseURL))
-	if opts.APIKey != "" {
-		oaiOpts = append(oaiOpts, openai.WithToken(opts.APIKey))
-	}
-	return openai.New(oaiOpts...)
-}
-
-func buildDatabricksLLM(opts *RunOptions, model string) (llms.Model, error) {
-	if opts.BaseURL == "" {
-		return nil, fmt.Errorf(
-			"databricks provider requires --base-url " +
-				"(e.g. https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1)",
-		)
-	}
-	if opts.APIKey == "" {
-		return nil, fmt.Errorf(
-			"databricks provider requires --api-key (Databricks PAT, prefix dapi-)",
-		)
-	}
-	oaiOpts := []openai.Option{
-		openai.WithBaseURL(opts.BaseURL),
-		openai.WithToken(opts.APIKey),
-	}
-	if model != "" {
-		oaiOpts = append(oaiOpts, openai.WithModel(model))
-	}
-	return openai.New(oaiOpts...)
-}
-
 func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 	baseURL := opts.BaseURL
 	if baseURL == "" {
@@ -405,7 +367,7 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 }
 
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai" || provider == "nvidia" || provider == "databricks"
+	return provider == "" || provider == "openai" || provider == "openai-compat"
 }
 
 // reasoningPrefixes returns the configured reasoning model prefixes,
@@ -432,8 +394,13 @@ func applyChildIterationCap(ctx context.Context, childOpts *RunOptions, cfg *too
 	}
 }
 
-// applyChildModelOverrides applies model and provider overrides from the
-// child agent's manifest to the child options.
+// applyChildModelOverrides applies model, provider, and base URL overrides
+// from the child agent's manifest to the child options.
+//
+// BaseURL must be propagated here because child agents are dispatched via
+// InvokeModel directly (not ExecuteRun), so ResolveModelPrecedence is never
+// called on the child path — without this, openai-compat child agents would
+// always fail with "openai-compat provider requires --base-url".
 func applyChildModelOverrides(ctx context.Context, childOpts *RunOptions, childBundle *agent.Bundle, agentName string) {
 	if childBundle.Model != "" {
 		childOpts.Model = childBundle.Model
@@ -442,6 +409,10 @@ func applyChildModelOverrides(ctx context.Context, childOpts *RunOptions, childB
 	if childBundle.Provider != "" {
 		childOpts.Provider = childBundle.Provider
 		logging.InfoContext(ctx, "child agent %s using manifest provider override: %s", agentName, childBundle.Provider)
+	}
+	if childBundle.BaseURL != "" && childOpts.BaseURL == "" {
+		childOpts.BaseURL = childBundle.BaseURL
+		logging.InfoContext(ctx, "child agent %s using manifest base URL override", agentName)
 	}
 	if len(childBundle.Models) > 1 {
 		altModels := make([]string, 0, len(childBundle.Models)-1)

--- a/runner/model.go
+++ b/runner/model.go
@@ -232,7 +232,8 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	// openai-compat endpoints default to tool_choice:"auto", allowing the model
 	// to respond without calling any tools. Force the first iteration to use
 	// tool_choice:"required" so the model must explore before answering.
-	forceFirstTool := provider == "openai-compat" || provider == "openai"
+	// Regular openai users rely on the auto behavior; only restrict compat endpoints.
+	forceFirstTool := provider == "openai-compat"
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
 	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, tools.RunWithToolsConfig{
 		MaxIterations:      opts.MaxIterations,
@@ -300,14 +301,20 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	case "nvidia":
 		// Deprecated: use provider: openai-compat with base_url: https://integrate.api.nvidia.com/v1
-		logging.Warn("provider 'nvidia' is deprecated; use 'openai-compat' with base_url: https://integrate.api.nvidia.com/v1")
+		logging.WarnContext(ctx, "provider 'nvidia' is deprecated; use 'openai-compat' with base_url: https://integrate.api.nvidia.com/v1")
 		if opts.BaseURL == "" {
 			opts.BaseURL = "https://integrate.api.nvidia.com/v1"
 		}
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	case "databricks":
 		// Deprecated: use provider: openai-compat with base_url pointing to your Databricks AI Gateway
-		logging.Warn("provider 'databricks' is deprecated; use 'openai-compat' with base_url and api_key set")
+		logging.WarnContext(ctx, "provider 'databricks' is deprecated; use 'openai-compat' with base_url and api_key set")
+		if opts.BaseURL == "" {
+			return nil, fmt.Errorf(
+				"databricks provider requires --base-url " +
+					"(e.g. https://<workspace>.ai-gateway.cloud.databricks.com/mlflow/v1)",
+			)
+		}
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
@@ -335,10 +342,11 @@ func buildOpenAICompatLLM(opts *RunOptions, provider, model string) (llms.Model,
 
 	apiKey := opts.APIKey
 	if apiKey == "" && provider == "openai-compat" {
-		apiKey = os.Getenv("OPENAI_COMPAT_API_KEY")
-	}
-	if apiKey == "" && provider == "openai-compat" {
-		apiKey = os.Getenv("OPENAI_API_KEY")
+		if v := os.Getenv("OPENAI_COMPAT_API_KEY"); v != "" {
+			apiKey = v
+		} else {
+			apiKey = os.Getenv("OPENAI_API_KEY")
+		}
 	}
 	if apiKey != "" {
 		oaiOpts = append(oaiOpts, openai.WithToken(apiKey))

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -194,6 +194,9 @@ func TestBuildOpenAICompatLLM(t *testing.T) {
 }
 
 func TestBuildOpenAICompatLLMEnvFallback(t *testing.T) {
+	// t.Setenv must run before any subtests — the outer test is intentionally
+	// sequential, and subtests must NOT call t.Parallel() here, as that would
+	// race with the env var set by the parent.
 	t.Setenv("OPENAI_COMPAT_API_KEY", "compat-key-from-env")
 
 	t.Run("openai-compat picks up env var when no explicit key", func(t *testing.T) {

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -56,8 +56,8 @@ func TestIsOpenAICompatProvider(t *testing.T) {
 		{"ollama", "ollama", false},
 		{"anthropic", "anthropic", false},
 		{"openai-compat", "openai-compat", true},
-		{"nvidia returns false", "nvidia", false},
-		{"databricks returns false", "databricks", false},
+		{"nvidia", "nvidia", true},
+		{"databricks", "databricks", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,8 +117,9 @@ func TestBuildLLMVariants(t *testing.T) {
 		{"anthropic", "anthropic", "claude-3", &RunOptions{APIKey: "token"}, "*anthropic.LLM", false},
 		{"gemini", "gemini", "gemini-2.0-flash", &RunOptions{APIKey: "token"}, "*googleai.GoogleAI", false},
 		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
-		{"nvidia returns error", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "", true},
-		{"databricks returns error", "databricks", "databricks-gpt-5-5-pro", &RunOptions{APIKey: "dapi-test-token", BaseURL: "https://example.com"}, "", true},
+		// nvidia/databricks are deprecated shims that redirect to openai-compat with a warning
+		{"nvidia deprecated shim", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "*openai.LLM", false},
+		{"databricks deprecated shim", "databricks", "databricks-gpt-5-5-pro", &RunOptions{APIKey: "dapi-test-token", BaseURL: "https://example.com"}, "*openai.LLM", false},
 		{
 			"openai-compat/deepinfra",
 			"openai-compat",
@@ -129,6 +130,28 @@ func TestBuildLLMVariants(t *testing.T) {
 			},
 			"*openai.LLM",
 			false,
+		},
+		{
+			"openai-compat/nvidia-nim",
+			"openai-compat",
+			"nvidia/llama-3.1-nemotron-70b-instruct",
+			&RunOptions{
+				APIKey:  "nvapi-test-key",
+				BaseURL: "https://integrate.api.nvidia.com/v1",
+			},
+			"*openai.LLM",
+			false,
+		},
+		{
+			// langchaingo validates key presence at construction; users of keyless
+			// endpoints (e.g. local vLLM) must set OPENAI_COMPAT_API_KEY or OPENAI_API_KEY
+			// to a dummy value. The error is caught here, not at HTTP call time.
+			"openai-compat/no-api-key fails at construction",
+			"openai-compat",
+			"some-model",
+			&RunOptions{BaseURL: "http://localhost:8000/v1"},
+			"",
+			true,
 		},
 		{
 			"openai-compat/missing base-url",
@@ -168,6 +191,29 @@ func TestBuildOpenAICompatLLM(t *testing.T) {
 	if err != nil || model == nil {
 		t.Fatalf("buildOpenAICompatLLM() error = %v", err)
 	}
+}
+
+func TestBuildOpenAICompatLLMEnvFallback(t *testing.T) {
+	t.Setenv("OPENAI_COMPAT_API_KEY", "compat-key-from-env")
+
+	t.Run("openai-compat picks up env var when no explicit key", func(t *testing.T) {
+		opts := &RunOptions{BaseURL: "https://integrate.api.nvidia.com/v1"}
+		model, err := buildOpenAICompatLLM(opts, "openai-compat", "nvidia/llama-3.1-nemotron-70b-instruct")
+		if err != nil || model == nil {
+			t.Fatalf("buildOpenAICompatLLM() error = %v", err)
+		}
+	})
+
+	t.Run("openai provider does not consume OPENAI_COMPAT_API_KEY", func(t *testing.T) {
+		// With OPENAI_COMPAT_API_KEY set but OPENAI_API_KEY absent, the openai
+		// provider must error — proving it does not fall back to the compat key.
+		t.Setenv("OPENAI_API_KEY", "")
+		opts := &RunOptions{BaseURL: "https://example.com"}
+		_, err := buildOpenAICompatLLM(opts, "openai", "gpt-4o")
+		if err == nil {
+			t.Fatal("expected error: openai provider should not consume OPENAI_COMPAT_API_KEY")
+		}
+	})
 }
 
 func TestBuildAnthropicLLM(t *testing.T) {
@@ -264,6 +310,115 @@ func TestCallLangChainLLMWithOllama(t *testing.T) {
 	}
 	if response != "hello" {
 		t.Fatalf("response = %q, want hello", response)
+	}
+}
+
+// TestCallLangChainLLMOpenAICompat verifies that callLangChainLLM with the
+// openai-compat provider sends non-empty system and user prompts to the API.
+// This is a regression guard for the CachedContent bug: before the fix,
+// langchaingo's OpenAI provider silently dropped CachedContent parts, causing
+// both prompts to arrive as empty strings at the backend.
+func TestCallLangChainLLMOpenAICompat(t *testing.T) {
+	t.Parallel()
+
+	type msgEntry struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	type reqPayload struct {
+		Messages []msgEntry `json:"messages"`
+	}
+
+	var captured reqPayload
+	reqErr := make(chan error, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "chat/completions") {
+			reqErr <- fmt.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			reqErr <- fmt.Errorf("decode request: %w", err)
+			return
+		}
+		reqErr <- nil
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 1234567890,
+			"model":   "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
+			"choices": []map[string]any{
+				{
+					"index":         0,
+					"message":       map[string]any{"role": "assistant", "content": "code looks fine"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15,
+			},
+		})
+	}))
+	defer server.Close()
+
+	opts := &RunOptions{
+		Provider:      "openai-compat",
+		APIKey:        "di_test_key",
+		BaseURL:       server.URL,
+		MaxIterations: 1,
+	}
+	bundle := &agent.Bundle{
+		System:  "You are a code reviewer.",
+		User:    "Review this Go project.",
+		WorkDir: t.TempDir(),
+	}
+	ex := &executor.LocalExecutor{WorkingDir: bundle.WorkDir}
+	m := metrics.New("openai-compat", "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo")
+
+	response, err := callLangChainLLM(
+		context.Background(),
+		opts,
+		"openai-compat",
+		"Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
+		bundle.System,
+		bundle,
+		0.4,
+		0,
+		nil,
+		ex,
+		m,
+	)
+	if err != nil {
+		t.Fatalf("callLangChainLLM() error = %v", err)
+	}
+	if err := <-reqErr; err != nil {
+		t.Fatalf("request handler error: %v", err)
+	}
+	if response != "code looks fine" {
+		t.Fatalf("response = %q, want %q", response, "code looks fine")
+	}
+
+	// Verify the system and user prompts arrived as non-empty strings.
+	// With CachedContent wrapping (the bug), both would be empty ("").
+	var sysMsg, userMsg *msgEntry
+	for i := range captured.Messages {
+		switch captured.Messages[i].Role {
+		case "system":
+			sysMsg = &captured.Messages[i]
+		case "user":
+			userMsg = &captured.Messages[i]
+		}
+	}
+	emptyContent := func(raw json.RawMessage) bool {
+		s := strings.TrimSpace(string(raw))
+		return s == "" || s == `""` || s == "null"
+	}
+	if sysMsg == nil || emptyContent(sysMsg.Content) {
+		t.Fatalf("system message missing or empty in HTTP request body — CachedContent regression? got: %v", sysMsg)
+	}
+	if userMsg == nil || emptyContent(userMsg.Content) {
+		t.Fatalf("user message missing or empty in HTTP request body — CachedContent regression? got: %v", userMsg)
 	}
 }
 

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -55,8 +55,9 @@ func TestIsOpenAICompatProvider(t *testing.T) {
 		{"openai", "openai", true},
 		{"ollama", "ollama", false},
 		{"anthropic", "anthropic", false},
-		{"nvidia", "nvidia", true},
-		{"databricks", "databricks", true},
+		{"openai-compat", "openai-compat", true},
+		{"nvidia returns false", "nvidia", false},
+		{"databricks returns false", "databricks", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -87,6 +88,8 @@ func TestBuildCallOpts(t *testing.T) {
 		{"anthropic no max tokens", &RunOptions{}, "anthropic", 0.5, 0, 2},
 		{"streaming adds func", &RunOptions{Stream: true}, "openai", 0.3, 0, 2},
 		{"streaming with anthropic", &RunOptions{Stream: true}, "anthropic", 0.5, 2048, 4},
+		// openai-compat uses the legacy max_tokens field (useLegacy=true because provider!="openai")
+		{"openai-compat with max tokens", &RunOptions{}, "openai-compat", 0.3, 200, 3},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,32 +116,25 @@ func TestBuildLLMVariants(t *testing.T) {
 		{"openai", "openai", "gpt-4o", &RunOptions{APIKey: "token"}, "*openai.LLM", false},
 		{"anthropic", "anthropic", "claude-3", &RunOptions{APIKey: "token"}, "*anthropic.LLM", false},
 		{"gemini", "gemini", "gemini-2.0-flash", &RunOptions{APIKey: "token"}, "*googleai.GoogleAI", false},
-		{"nvidia provider", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "*openai.LLM", false},
 		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
+		{"nvidia returns error", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "", true},
+		{"databricks returns error", "databricks", "databricks-gpt-5-5-pro", &RunOptions{APIKey: "dapi-test-token", BaseURL: "https://example.com"}, "", true},
 		{
-			"databricks provider",
-			"databricks",
-			"databricks-gpt-5-5-pro",
+			"openai-compat/deepinfra",
+			"openai-compat",
+			"meta-llama/Meta-Llama-3-70B-Instruct",
 			&RunOptions{
-				APIKey:  "dapi-test-token",
-				BaseURL: "https://7474657828785521.ai-gateway.cloud.databricks.com/mlflow/v1",
+				APIKey:  "di_abc123",
+				BaseURL: "https://api.deepinfra.com/v1/openai",
 			},
 			"*openai.LLM",
 			false,
 		},
 		{
-			"databricks provider missing base URL",
-			"databricks",
-			"databricks-gpt-5-5-pro",
-			&RunOptions{APIKey: "dapi-test-token"},
-			"",
-			true,
-		},
-		{
-			"databricks provider missing api key",
-			"databricks",
-			"databricks-gpt-5-5-pro",
-			&RunOptions{BaseURL: "https://7474657828785521.ai-gateway.cloud.databricks.com/mlflow/v1"},
+			"openai-compat/missing base-url",
+			"openai-compat",
+			"meta-llama/Meta-Llama-3-70B-Instruct",
+			&RunOptions{APIKey: "somekey"},
 			"",
 			true,
 		},
@@ -1069,6 +1065,34 @@ func TestBuildTaskConfigChildModelOverride(t *testing.T) {
 	if !strings.Contains(err.Error(), "API key") && !strings.Contains(err.Error(), "failed") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestApplyChildModelOverridesBaseURL(t *testing.T) {
+	t.Parallel()
+	bundle := &agent.Bundle{
+		Provider: "openai-compat",
+		Model:    "meta-llama/Meta-Llama-3-70B-Instruct",
+		BaseURL:  "https://api.deepinfra.com/v1/openai",
+	}
+
+	t.Run("propagates BaseURL when child opts is empty", func(t *testing.T) {
+		t.Parallel()
+		childOpts := &RunOptions{}
+		applyChildModelOverrides(context.Background(), childOpts, bundle, "child")
+		if childOpts.BaseURL != bundle.BaseURL {
+			t.Fatalf("BaseURL = %q, want %q", childOpts.BaseURL, bundle.BaseURL)
+		}
+	})
+
+	t.Run("does not overwrite explicit parent BaseURL", func(t *testing.T) {
+		t.Parallel()
+		parentURL := "https://parent-endpoint.example.com/v1"
+		childOpts := &RunOptions{BaseURL: parentURL}
+		applyChildModelOverrides(context.Background(), childOpts, bundle, "child")
+		if childOpts.BaseURL != parentURL {
+			t.Fatalf("BaseURL = %q, want parent URL %q", childOpts.BaseURL, parentURL)
+		}
+	})
 }
 
 func TestBuildTaskConfigChildBudgetDedicated(t *testing.T) {

--- a/runner/run.go
+++ b/runner/run.go
@@ -245,6 +245,9 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 			// Config default is supported by this agent — use it; provider is also set.
 			opts.Model = configMatch.Model
 			opts.Provider = configMatch.Provider
+			if opts.BaseURL == "" {
+				opts.BaseURL = configMatch.BaseURL
+			}
 			logging.InfoContext(ctx, "using config default model: %s (%s)", opts.Model, opts.Provider)
 			return ""
 
@@ -279,6 +282,11 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 			logging.InfoContext(ctx, "using config provider: %s", opts.ConfigProvider)
 		}
 	}
+
+	if opts.BaseURL == "" && bundle.BaseURL != "" {
+		opts.BaseURL = bundle.BaseURL
+	}
+
 	return warn
 }
 

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -290,6 +290,67 @@ func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	}
 }
 
+// TestResolveModelPrecedenceBaseURL verifies BaseURL propagation for the
+// openai-compat provider path, where a base URL must flow from either the
+// manifest bundle or a config-matched model preference into RunOptions.
+func TestResolveModelPrecedenceBaseURL(t *testing.T) {
+	t.Parallel()
+	const compatURL = "https://api.deepinfra.com/v1/openai"
+
+	t.Run("copies bundle BaseURL when opts has none", func(t *testing.T) {
+		t.Parallel()
+		opts := &RunOptions{}
+		bundle := &agent.Bundle{
+			Model:    "meta-llama/Meta-Llama-3-70B-Instruct",
+			Provider: "openai-compat",
+			BaseURL:  compatURL,
+		}
+		ResolveModelPrecedence(context.Background(), opts, bundle)
+		if opts.BaseURL != compatURL {
+			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
+		}
+	})
+
+	t.Run("does not overwrite explicit opts BaseURL", func(t *testing.T) {
+		t.Parallel()
+		const explicit = "https://my-endpoint.example.com/v1"
+		opts := &RunOptions{BaseURL: explicit}
+		bundle := &agent.Bundle{
+			Model:    "meta-llama/Meta-Llama-3-70B-Instruct",
+			Provider: "openai-compat",
+			BaseURL:  compatURL,
+		}
+		ResolveModelPrecedence(context.Background(), opts, bundle)
+		if opts.BaseURL != explicit {
+			t.Fatalf("BaseURL = %q, want explicit %q", opts.BaseURL, explicit)
+		}
+	})
+
+	t.Run("propagates BaseURL from config-matched model preference", func(t *testing.T) {
+		t.Parallel()
+		opts := &RunOptions{
+			ConfigProvider: "openai-compat",
+			ConfigModel:    "meta-llama/Meta-Llama-3-70B-Instruct",
+		}
+		bundle := &agent.Bundle{
+			Models: []agent.ModelPreference{
+				{
+					Provider: "openai-compat",
+					Model:    "meta-llama/Meta-Llama-3-70B-Instruct",
+					BaseURL:  compatURL,
+				},
+			},
+		}
+		ResolveModelPrecedence(context.Background(), opts, bundle)
+		if opts.BaseURL != compatURL {
+			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
+		}
+		if opts.Provider != "openai-compat" {
+			t.Fatalf("Provider = %q, want openai-compat", opts.Provider)
+		}
+	})
+}
+
 func runAndAssertBundle(t *testing.T, opts *RunOptions, wantModel, wantProvider string) {
 	t.Helper()
 	cmd := &cobra.Command{}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -308,15 +308,30 @@ func (e *EditEnforcer) ConfirmEdit(toolCalls []llms.ToolCall, results map[string
 
 // RunWithToolsConfig holds the configuration options for RunWithTools.
 type RunWithToolsConfig struct {
-	MaxIterations   int
-	EditDeadline    int
-	TaskCfg         *TaskConfig
-	Metrics         *metrics.Metrics
-	Executor        executor.Executor
+	// MaxIterations caps the number of model+tool-call cycles. Zero means
+	// the package default [MaxToolIterations] is used.
+	MaxIterations int
+	// EditDeadline is the iteration number after which read-only tools are
+	// blocked to force the model to commit pending edits. Zero disables the
+	// deadline.
+	EditDeadline int
+	// TaskCfg wires in the Task/TaskResult tools and child-agent dispatch.
+	// Nil disables the Task tool entirely.
+	TaskCfg *TaskConfig
+	// Metrics accumulates token counts and cost across all iterations.
+	// Nil is allowed; cost tracking and budget enforcement are skipped.
+	Metrics *metrics.Metrics
+	// Executor runs shell commands issued by the agent (Bash, Write, etc.).
+	Executor executor.Executor
+	// UseCacheControl wraps the system and user prompts with Anthropic's
+	// cache_control hint. Set this only for the Anthropic provider; other
+	// LangChain providers silently drop the wrapper.
 	UseCacheControl bool
 	// ForceFirstToolCall, when true, appends tool_choice:"required" to the
-	// call options for the first iteration only. Use this for openai-compat
-	// providers where the model defaults to skipping tool calls.
+	// call options for the first iteration only. Intended for openai-compat
+	// endpoints whose default tool_choice:"auto" lets the model skip tools and
+	// answer immediately. Not set for the regular openai provider, which relies
+	// on auto behavior.
 	ForceFirstToolCall bool
 }
 
@@ -348,7 +363,7 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	}
 
 	messages := buildInitialMessages(systemPrompt, userPrompt, cfg.UseCacheControl)
-	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg.EditDeadline, cfg.Metrics, callOpts, cfg.ForceFirstToolCall)
+	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg, callOpts)
 	if done {
 		return lastContent, nil
 	}
@@ -632,11 +647,12 @@ func trackPostExecution(ctx context.Context, messages []llms.MessageContent, mer
 	return postExecutionResult{newFilesRead: newFilesRead, stuck: loopDetector.Stuck()}
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter, editDeadline int, m *metrics.Metrics, callOpts []llms.CallOption, forceFirst bool) (string, []llms.MessageContent, error, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter int, cfg RunWithToolsConfig, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
+	m := cfg.Metrics
 	var lastContent string
 	var repeat RepeatTracker
 	var loopDetector LoopDetector
-	ctx, editEnforcer, phaseEnforcer := initToolLoopEnforcers(ctx, editDeadline)
+	ctx, editEnforcer, phaseEnforcer := initToolLoopEnforcers(ctx, cfg.EditDeadline)
 	budgetWarned := make([]bool, len(budgetWarningThresholds))
 	var grace graceState
 	ctx = setGraceState(ctx, &grace)
@@ -644,11 +660,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		SetIteration(ctx, i)
 		logIterationStart(ctx, i, maxIter, m)
 		iterStart := time.Now()
-		iterOpts := callOpts
-		if forceFirst && i == 0 {
-			iterOpts = append(append([]llms.CallOption{}, callOpts...), llms.WithToolChoice("required"))
-		}
-		response, err := retryGenerateContent(ctx, llm, messages, iterOpts)
+		response, err := retryGenerateContent(ctx, llm, messages, resolveIterOpts(callOpts, cfg.ForceFirstToolCall, i))
 		iterDuration := time.Since(iterStart)
 		if err := validateResponse(ctx, response, err, iterDuration); err != nil {
 			return lastContent, messages, err, false
@@ -690,10 +702,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		messages = appendToolCallMessage(messages, mergedContent, mergedToolCalls, ctx)
 
 		// Snapshot cache size before execution to detect new file reads.
-		cacheSizeBefore := 0
-		if rc := GetReadCache(ctx); rc != nil {
-			cacheSizeBefore = rc.Len()
-		}
+		cacheSizeBefore := readCacheSize(ctx)
 
 		messages = executeToolCalls(ctx, messages, mergedToolCalls, handlers)
 
@@ -893,6 +902,24 @@ func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.Message
 		return "", metrics.ErrBudgetExceeded
 	}
 	return "", fmt.Errorf("tool loop ended after %d iterations with no usable response", maxIter)
+}
+
+// resolveIterOpts returns the call options for iteration i, inserting
+// tool_choice:"required" on the first iteration when forceFirst is set.
+func resolveIterOpts(base []llms.CallOption, forceFirst bool, i int) []llms.CallOption {
+	if forceFirst && i == 0 {
+		return append(append([]llms.CallOption{}, base...), llms.WithToolChoice("required"))
+	}
+	return base
+}
+
+// readCacheSize returns the current number of entries in the read cache
+// stored on ctx, or 0 if no cache is present.
+func readCacheSize(ctx context.Context) int {
+	if rc := GetReadCache(ctx); rc != nil {
+		return rc.Len()
+	}
+	return 0
 }
 
 func buildInitialMessages(systemPrompt, userPrompt string, useCacheControl bool) []llms.MessageContent {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -306,11 +306,26 @@ func (e *EditEnforcer) ConfirmEdit(toolCalls []llms.ToolCall, results map[string
 	}
 }
 
+// RunWithToolsConfig holds the configuration options for RunWithTools.
+type RunWithToolsConfig struct {
+	MaxIterations   int
+	EditDeadline    int
+	TaskCfg         *TaskConfig
+	Metrics         *metrics.Metrics
+	Executor        executor.Executor
+	UseCacheControl bool
+	// ForceFirstToolCall, when true, appends tool_choice:"required" to the
+	// call options for the first iteration only. Use this for openai-compat
+	// providers where the model defaults to skipping tool calls.
+	ForceFirstToolCall bool
+}
+
 // RunWithTools drives the tool-calling loop for a LangChain-compatible LLM.
 // It initialises the read cache, file tracker, and enforcer machinery, then
 // iterates between model calls and tool executions until the model stops
 // calling tools, the iteration cap is hit, or a budget/loop error is raised.
-func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, maxIterations, editDeadline int, taskCfg *TaskConfig, m *metrics.Metrics, ex executor.Executor, callOpts ...llms.CallOption) (string, error) {
+func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt, workingDir string, cfg RunWithToolsConfig, callOpts ...llms.CallOption) (string, error) {
+	maxIterations := cfg.MaxIterations
 	ctx, span := telemetry.Tracer().Start(ctx, "tool.loop",
 		trace.WithAttributes(
 			attribute.Int("squad.tool_loop.max_iterations", maxIterations),
@@ -325,15 +340,15 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	ctx = InitFileTracker(ctx)
 	ctx = InitBgCommandRegistry(ctx)
 
-	handlers, toolDefs := BuildHandlers(workingDir, taskCfg, ex)
+	handlers, toolDefs := BuildHandlers(workingDir, cfg.TaskCfg, cfg.Executor)
 	callOpts = append(callOpts, llms.WithTools(toolDefs))
 
 	if maxIterations <= 0 {
 		maxIterations = MaxToolIterations
 	}
 
-	messages := buildInitialMessages(systemPrompt, userPrompt)
-	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, editDeadline, m, callOpts)
+	messages := buildInitialMessages(systemPrompt, userPrompt, cfg.UseCacheControl)
+	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg.EditDeadline, cfg.Metrics, callOpts, cfg.ForceFirstToolCall)
 	if done {
 		return lastContent, nil
 	}
@@ -346,7 +361,7 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		return lastContent, loopErr
 	}
 
-	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, m, callOpts)
+	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, cfg.Metrics, callOpts)
 }
 
 // logIterationStart logs the current iteration number with cost/token info if metrics are available.
@@ -617,7 +632,7 @@ func trackPostExecution(ctx context.Context, messages []llms.MessageContent, mer
 	return postExecutionResult{newFilesRead: newFilesRead, stuck: loopDetector.Stuck()}
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter, editDeadline int, m *metrics.Metrics, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter, editDeadline int, m *metrics.Metrics, callOpts []llms.CallOption, forceFirst bool) (string, []llms.MessageContent, error, bool) {
 	var lastContent string
 	var repeat RepeatTracker
 	var loopDetector LoopDetector
@@ -629,7 +644,11 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		SetIteration(ctx, i)
 		logIterationStart(ctx, i, maxIter, m)
 		iterStart := time.Now()
-		response, err := retryGenerateContent(ctx, llm, messages, callOpts)
+		iterOpts := callOpts
+		if forceFirst && i == 0 {
+			iterOpts = append(append([]llms.CallOption{}, callOpts...), llms.WithToolChoice("required"))
+		}
+		response, err := retryGenerateContent(ctx, llm, messages, iterOpts)
 		iterDuration := time.Since(iterStart)
 		if err := validateResponse(ctx, response, err, iterDuration); err != nil {
 			return lastContent, messages, err, false
@@ -715,8 +734,16 @@ func validateResponse(ctx context.Context, resp *llms.ContentResponse, err error
 		return fmt.Errorf("GenerateContent failed: %w", err)
 	}
 	if isEmptyResponse(resp) {
-		logging.InfoContext(ctx, "model returned empty response in %s", duration.Round(time.Millisecond))
-		return fmt.Errorf("model returned empty response")
+		reason := ""
+		if resp != nil && len(resp.Choices) > 0 {
+			if gi := resp.Choices[0].GenerationInfo; gi != nil {
+				if r, ok := gi["finish_reason"]; ok {
+					reason = fmt.Sprintf(" (finish_reason=%v)", r)
+				}
+			}
+		}
+		logging.InfoContext(ctx, "model returned empty response in %s%s", duration.Round(time.Millisecond), reason)
+		return fmt.Errorf("model returned empty response%s", reason)
 	}
 	return nil
 }
@@ -868,34 +895,23 @@ func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.Message
 	return "", fmt.Errorf("tool loop ended after %d iterations with no usable response", maxIter)
 }
 
-func buildInitialMessages(systemPrompt, userPrompt string) []llms.MessageContent {
+func buildInitialMessages(systemPrompt, userPrompt string, useCacheControl bool) []llms.MessageContent {
 	messages := []llms.MessageContent{}
+	wrap := func(p llms.ContentPart) llms.ContentPart {
+		if useCacheControl {
+			return llms.WithCacheControl(p, &llms.CacheControl{Type: "ephemeral"})
+		}
+		return p
+	}
 	if systemPrompt != "" {
-		// Mark the system prompt for caching.  Note: langchaingo v0.1.14's
-		// Anthropic provider serializes the system field as a plain string
-		// and silently drops cache_control.  We set it anyway so it takes
-		// effect once upstream is fixed.
 		messages = append(messages, llms.MessageContent{
-			Role: llms.ChatMessageTypeSystem,
-			Parts: []llms.ContentPart{
-				llms.WithCacheControl(
-					llms.TextPart(systemPrompt),
-					&llms.CacheControl{Type: "ephemeral"},
-				),
-			},
+			Role:  llms.ChatMessageTypeSystem,
+			Parts: []llms.ContentPart{wrap(llms.TextPart(systemPrompt))},
 		})
 	}
-	// Wrap the user prompt with cache_control as well.  The Anthropic
-	// provider correctly propagates CachedContent on human messages, so
-	// this is the path that actually enables prompt caching today.
 	messages = append(messages, llms.MessageContent{
-		Role: llms.ChatMessageTypeHuman,
-		Parts: []llms.ContentPart{
-			llms.WithCacheControl(
-				llms.TextPart(userPrompt),
-				&llms.CacheControl{Type: "ephemeral"},
-			),
-		},
+		Role:  llms.ChatMessageTypeHuman,
+		Parts: []llms.ContentPart{wrap(llms.TextPart(userPrompt))},
 	})
 	return messages
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1111,7 +1111,10 @@ func TestRunWithToolsLoop(t *testing.T) {
 		},
 	}}
 
-	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 2, 0, nil, nil, &executor.LocalExecutor{WorkingDir: dir})
+	out, err := RunWithTools(context.Background(), llm, "", "user", dir, RunWithToolsConfig{
+		MaxIterations: 2,
+		Executor:      &executor.LocalExecutor{WorkingDir: dir},
+	})
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
 	}
@@ -1153,7 +1156,10 @@ func TestRunWithToolsErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := t.TempDir()
-			_, err := RunWithTools(context.Background(), tt.llm, "", "user", td, 1, 0, nil, nil, &executor.LocalExecutor{WorkingDir: td})
+			_, err := RunWithTools(context.Background(), tt.llm, "", "user", td, RunWithToolsConfig{
+				MaxIterations: 1,
+				Executor:      &executor.LocalExecutor{WorkingDir: td},
+			})
 			if err == nil {
 				t.Fatalf("expected error")
 			}
@@ -1669,7 +1675,11 @@ func TestRunWithToolsWithMetrics(t *testing.T) {
 	}}
 
 	m := metrics.New("openai", "gpt-4o")
-	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 2, 0, nil, m, &executor.LocalExecutor{WorkingDir: dir})
+	out, err := RunWithTools(context.Background(), llm, "", "user", dir, RunWithToolsConfig{
+		MaxIterations: 2,
+		Metrics:       m,
+		Executor:      &executor.LocalExecutor{WorkingDir: dir},
+	})
 	if err != nil {
 		t.Fatalf("RunWithTools() error = %v", err)
 	}
@@ -1728,7 +1738,11 @@ func TestToolLoopBudgetExceeded(t *testing.T) {
 	// Pre-load tokens so budget is exceeded after the first tool call
 	m.AddTokens(1_000_000, 1_000_000)
 
-	out, err := RunWithTools(context.Background(), llm, "", "user", dir, 10, 0, nil, m, &executor.LocalExecutor{WorkingDir: dir})
+	out, err := RunWithTools(context.Background(), llm, "", "user", dir, RunWithToolsConfig{
+		MaxIterations: 10,
+		Metrics:       m,
+		Executor:      &executor.LocalExecutor{WorkingDir: dir},
+	})
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -2414,7 +2428,7 @@ func TestToolLoopBudgetWarnings(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, _ := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user"), handlers, 10, 0, m, nil)
+	_, _, loopErr, _ := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, 0, m, nil, false)
 	// Budget may be exceeded after iter 2 — that's fine, we just care that
 	// warnings were injected before that happened.
 	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) {
@@ -2476,7 +2490,7 @@ func TestToolLoopNoBudgetWarningsWithoutMaxCost(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, done := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user"), handlers, 10, 0, m, nil)
+	_, _, loopErr, done := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, 0, m, nil, false)
 	if loopErr != nil {
 		t.Fatalf("unexpected error: %v", loopErr)
 	}
@@ -3168,5 +3182,102 @@ func TestCompactMessagesPreservesEditRelatedMessages(t *testing.T) {
 	tokens := estimateTokens(msgs)
 	if tokens >= contextTokenThreshold && !foundCompactedUnrelated {
 		t.Log("conversation was large enough for compaction but unrelated result was not compacted — semantic scoring may have kept it")
+	}
+}
+
+func TestBuildInitialMessagesCacheControl(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		useCacheControl bool
+		wantCached      bool
+	}{
+		{"cache_off", false, false},
+		{"cache_on", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msgs := buildInitialMessages("sys", "user", tt.useCacheControl)
+			for _, msg := range msgs {
+				for _, part := range msg.Parts {
+					_, isCached := part.(llms.CachedContent)
+					if isCached != tt.wantCached {
+						t.Errorf("part type cached=%v, want %v (useCacheControl=%v)",
+							isCached, tt.wantCached, tt.useCacheControl)
+					}
+				}
+			}
+		})
+	}
+}
+
+// recordingLLM captures the resolved CallOptions for each GenerateContent call.
+type recordingLLM struct {
+	responses []*llms.ContentResponse
+	calls     int
+	opts      []llms.CallOptions
+}
+
+func (r *recordingLLM) GenerateContent(_ context.Context, _ []llms.MessageContent, callOpts ...llms.CallOption) (*llms.ContentResponse, error) {
+	var o llms.CallOptions
+	for _, opt := range callOpts {
+		opt(&o)
+	}
+	r.opts = append(r.opts, o)
+	if r.calls >= len(r.responses) {
+		return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "done"}}}, nil
+	}
+	resp := r.responses[r.calls]
+	r.calls++
+	return resp, nil
+}
+
+func (r *recordingLLM) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", nil
+}
+
+func TestForceFirstToolCallOption(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	llm := &recordingLLM{
+		responses: []*llms.ContentResponse{
+			// Iteration 0: one tool call to force the loop to continue.
+			{Choices: []*llms.ContentChoice{{
+				ToolCalls: []llms.ToolCall{{
+					ID:   "tc1",
+					Type: "function",
+					FunctionCall: &llms.FunctionCall{
+						Name:      "Glob",
+						Arguments: `{"pattern":"**/*.go"}`,
+					},
+				}},
+			}}},
+			// Iteration 1: no tool calls → loop ends normally.
+			{Choices: []*llms.ContentChoice{{Content: "done"}}},
+		},
+	}
+
+	cfg := RunWithToolsConfig{
+		MaxIterations:      5,
+		ForceFirstToolCall: true,
+	}
+	_, err := RunWithTools(context.Background(), llm, "sys", "user", dir, cfg)
+	if err != nil {
+		t.Fatalf("RunWithTools: %v", err)
+	}
+
+	if len(llm.opts) < 2 {
+		t.Fatalf("expected at least 2 GenerateContent calls, got %d", len(llm.opts))
+	}
+
+	// First iteration must carry tool_choice = "required".
+	if llm.opts[0].ToolChoice != "required" {
+		t.Errorf("iteration 0: want ToolChoice=%q, got %v", "required", llm.opts[0].ToolChoice)
+	}
+	// Subsequent iterations must NOT carry tool_choice = "required".
+	if llm.opts[1].ToolChoice == "required" {
+		t.Errorf("iteration 1: ToolChoice should not be %q", "required")
 	}
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -3201,7 +3201,7 @@ func TestBuildInitialMessagesCacheControl(t *testing.T) {
 			msgs := buildInitialMessages("sys", "user", tt.useCacheControl)
 			for _, msg := range msgs {
 				for _, part := range msg.Parts {
-					_, isCached := part.(llms.CachedContent)
+					isCached := fmt.Sprintf("%T", part) == "llms.CachedContent"
 					if isCached != tt.wantCached {
 						t.Errorf("part type cached=%v, want %v (useCacheControl=%v)",
 							isCached, tt.wantCached, tt.useCacheControl)

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2428,7 +2428,7 @@ func TestToolLoopBudgetWarnings(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, _ := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, 0, m, nil, false)
+	_, _, loopErr, _ := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
 	// Budget may be exceeded after iter 2 — that's fine, we just care that
 	// warnings were injected before that happened.
 	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) {
@@ -2490,7 +2490,7 @@ func TestToolLoopNoBudgetWarningsWithoutMaxCost(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, done := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, 0, m, nil, false)
+	_, _, loopErr, done := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
 	if loopErr != nil {
 		t.Fatalf("unexpected error: %v", loopErr)
 	}
@@ -3280,4 +3280,88 @@ func TestForceFirstToolCallOption(t *testing.T) {
 	if llm.opts[1].ToolChoice == "required" {
 		t.Errorf("iteration 1: ToolChoice should not be %q", "required")
 	}
+}
+
+// applyCallOpts resolves a slice of CallOption into a CallOptions struct.
+func applyCallOpts(opts []llms.CallOption) llms.CallOptions {
+	var o llms.CallOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// TestResolveIterOpts verifies resolveIterOpts inserts tool_choice:"required"
+// only on the first iteration when forceFirst is true, and never mutates the
+// base slice.
+func TestResolveIterOpts(t *testing.T) {
+	t.Parallel()
+	base := []llms.CallOption{llms.WithTemperature(0.5)}
+
+	tests := []struct {
+		name         string
+		forceFirst   bool
+		i            int
+		wantRequired bool
+	}{
+		{"force=false i=0", false, 0, false},
+		{"force=false i=1", false, 1, false},
+		{"force=true i=0", true, 0, true},
+		{"force=true i=1", true, 1, false},
+		{"force=true i=5", true, 5, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveIterOpts(base, tt.forceFirst, tt.i)
+			o := applyCallOpts(got)
+			if (o.ToolChoice == "required") != tt.wantRequired {
+				t.Errorf("ToolChoice required = %v, want %v (ToolChoice=%q)",
+					o.ToolChoice == "required", tt.wantRequired, o.ToolChoice)
+			}
+			// base options must always be preserved in the result
+			if o.Temperature != 0.5 {
+				t.Errorf("Temperature = %v, want 0.5 (base option lost)", o.Temperature)
+			}
+		})
+	}
+
+	// Verify the base slice itself is not mutated.
+	_ = resolveIterOpts(base, true, 0)
+	if len(base) != 1 {
+		t.Errorf("base slice mutated: len = %d, want 1", len(base))
+	}
+}
+
+// TestReadCacheSize verifies readCacheSize returns the ReadCache entry count
+// from ctx, or 0 when no cache is attached.
+func TestReadCacheSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no cache in context", func(t *testing.T) {
+		t.Parallel()
+		if got := readCacheSize(context.Background()); got != 0 {
+			t.Errorf("readCacheSize = %d, want 0", got)
+		}
+	})
+
+	t.Run("empty cache", func(t *testing.T) {
+		t.Parallel()
+		ctx := InitReadCache(context.Background())
+		if got := readCacheSize(ctx); got != 0 {
+			t.Errorf("readCacheSize = %d, want 0", got)
+		}
+	})
+
+	t.Run("three entries", func(t *testing.T) {
+		t.Parallel()
+		ctx := InitReadCache(context.Background())
+		rc := GetReadCache(ctx)
+		rc.Store("a.go", "h1", 10, 200, 0, "")
+		rc.Store("b.go", "h2", 20, 400, 1, "")
+		rc.Store("c.go", "h3", 30, 600, 2, "")
+		if got := readCacheSize(ctx); got != 3 {
+			t.Errorf("readCacheSize = %d, want 3", got)
+		}
+	})
 }


### PR DESCRIPTION
Key Changes:

  - Replaced separate nvidia and databricks providers with a unified openai-compat provider that works with any /v1/chat/completions endpoint (DeepInfra, Together AI, vLLM, LM
  Studio, Groq, and more)
  - Fixed a bug where CachedContent wrapping was applied to all providers, causing OpenAI-compatible backends to silently drop the system and user prompts
  - Propagated base_url through the full execution stack — manifests, bundles, routine manifests, child agent overrides, and ResolveModelPrecedence — so openai-compat agents are
  self-contained without requiring a --base-url flag at runtime
  - Refactored RunWithTools to accept a RunWithToolsConfig struct, adding UseCacheControl and ForceFirstToolCall flags to handle provider-specific behavior cleanly

  Added:

  - openai-compat as a first-class provider in SupportedProviders and the provider dispatch in runner/model.go — buildOpenAICompatLLM now validates that base_url is present and
  falls back to OPENAI_COMPAT_API_KEY env var before OPENAI_API_KEY
  - BaseURL field to ModelPreference, Bundle, Routine, and all propagation paths so manifests can encode their required endpoint without runtime flags
  - ForceFirstToolCall option in RunWithToolsConfig that injects tool_choice:"required" on the first iteration for openai-compat endpoints, preventing models from skipping tool
  exploration and answering immediately
  - resolveIterOpts and readCacheSize helpers extracted from toolLoop for clarity
  - Validation in Routine.Validate() that rejects provider: openai-compat without a base_url
  - TestCallLangChainLLMOpenAICompat, TestBuildOpenAICompatLLMEnvFallback, TestApplyChildModelOverridesBaseURL, TestResolveModelPrecedenceBaseURL, and
  TestBuildInitialMessagesCacheControl regression tests
  - README and docs/configuration.md expanded with full usage examples for DeepInfra, Together AI, LM Studio, vLLM, NVIDIA NIM, and Databricks; migration guide from legacy provider
   names; config file reference; and build-from-source / contribution sections

  Changed:

  - RunWithTools signature replaced positional maxIterations, editDeadline int, taskCfg, m, ex parameters with a RunWithToolsConfig struct; all callers updated
  - buildInitialMessages now takes a useCacheControl bool parameter — cache wrapping is applied only when true (i.e., only for the Anthropic provider)
  - nvidia and databricks provider cases in buildLLM converted to deprecated shims that log a warning and delegate to buildOpenAICompatLLM; buildNvidiaLLM and buildDatabricksLLM
  removed
  - SupportedProviders and providerMappings in metrics/metrics.go updated to replace nvidia/databricks entries with openai-compat; modelListingProviders drops both since
  openai-compat has no shared catalog
  - applyChildModelOverrides now propagates BaseURL from the child bundle to child options (without overwriting an explicit parent value) so openai-compat child agents dispatched
  via InvokeModel receive the required endpoint
  - validateResponse error message enriched with finish_reason when present, making empty-response failures easier to diagnose

  Removed:

  - Dedicated buildNvidiaLLM and buildDatabricksLLM functions consolidated into the generic buildOpenAICompatLLM path
  - Unconditional CachedContent wrapping from buildInitialMessages — the wrapping now only occurs when UseCacheControl: true is set in RunWithToolsConfig