### PR TITLE
fix: ensure agents apply resolved model, provider, and base URL from precedence resolution

### DIFF
--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -88,8 +88,12 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 		agentOpts.Findings = pipelineRunner.Findings
 		agentOpts.AgentName = agentName
 
-		if warn := runner.ResolveModelPrecedence(ctx, &agentOpts, bundle); warn != "" {
-			fmt.Fprintln(os.Stderr, warn)
+		res := runner.ResolveModelPrecedence(ctx, &agentOpts, bundle)
+		agentOpts.Model = res.Model
+		agentOpts.Provider = res.Provider
+		agentOpts.BaseURL = res.BaseURL
+		if res.Warning != "" {
+			fmt.Fprintln(os.Stderr, res.Warning)
 		}
 
 		// Apply effective budget cap propagated from the pipeline runner.

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -611,7 +611,7 @@ func TestBuildRunAgentFunc_ConfigDefaultNotInManifestWarns(t *testing.T) {
 	if runErr == nil {
 		t.Fatal("expected error from InvokeModel")
 	}
-	if !strings.Contains(string(out), "not listed in the agent manifest") {
+	if !strings.Contains(string(out), "not a preferred model for this agent") {
 		t.Fatalf("expected warning on stderr, got %q", string(out))
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -67,24 +67,33 @@ func (m *Metrics) SetMaxCost(maxCost float64) {
 	m.MaxCost = maxCost
 }
 
+// totalCostWithChildrenLocked returns total cost including child runs; caller must hold m.mu.
+func (m *Metrics) totalCostWithChildrenLocked() float64 {
+	total := m.costLocked()
+	for _, c := range m.Children {
+		pricing := GetPricing(c.Provider, c.Model)
+		total += float64(c.InputTokens)/1_000_000*pricing.InputPerMillion +
+			float64(c.OutputTokens)/1_000_000*pricing.OutputPerMillion
+	}
+	return total
+}
+
 // BudgetExceeded reports whether the total run cost has reached MaxCost.
 func (m *Metrics) BudgetExceeded() bool {
 	m.mu.Lock()
-	maxCost := m.MaxCost
-	m.mu.Unlock()
-	return maxCost > 0 && m.TotalCostWithChildren() >= maxCost
+	defer m.mu.Unlock()
+	return m.MaxCost > 0 && m.totalCostWithChildrenLocked() >= m.MaxCost
 }
 
 // BudgetUsedPct returns the fraction of the cost budget consumed (0.0–1.0).
 // Returns 0 when no budget is set.
 func (m *Metrics) BudgetUsedPct() float64 {
 	m.mu.Lock()
-	maxCost := m.MaxCost
-	m.mu.Unlock()
-	if maxCost <= 0 {
+	defer m.mu.Unlock()
+	if m.MaxCost <= 0 {
 		return 0
 	}
-	pct := m.TotalCostWithChildren() / maxCost
+	pct := m.totalCostWithChildrenLocked() / m.MaxCost
 	if pct > 1 {
 		return 1
 	}
@@ -94,12 +103,11 @@ func (m *Metrics) BudgetUsedPct() float64 {
 // RemainingBudget returns the remaining cost budget in USD.
 func (m *Metrics) RemainingBudget() float64 {
 	m.mu.Lock()
-	maxCost := m.MaxCost
-	m.mu.Unlock()
-	if maxCost <= 0 {
+	defer m.mu.Unlock()
+	if m.MaxCost <= 0 {
 		return 0
 	}
-	remaining := maxCost - m.TotalCostWithChildren()
+	remaining := m.MaxCost - m.totalCostWithChildrenLocked()
 	if remaining < 0 {
 		return 0
 	}
@@ -169,14 +177,7 @@ func (m *Metrics) AddChild(agent string, child *Metrics) {
 func (m *Metrics) TotalCostWithChildren() float64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	total := m.costLocked()
-	for _, c := range m.Children {
-		pricing := GetPricing(c.Provider, c.Model)
-		inputCost := float64(c.InputTokens) / 1_000_000 * pricing.InputPerMillion
-		outputCost := float64(c.OutputTokens) / 1_000_000 * pricing.OutputPerMillion
-		total += inputCost + outputCost
-	}
-	return total
+	return m.totalCostWithChildrenLocked()
 }
 
 // TotalTokensWithChildren returns total tokens for the run and child runs.

--- a/pipeline/runner.go
+++ b/pipeline/runner.go
@@ -78,6 +78,7 @@ type Runner struct {
 	InlineAgents map[string]*InlineConfig // inline agent configs keyed by stage name
 	ComposedDir  string                   // directory of the composed agent (for resolving inline prompt files)
 	spent        *csync.Value[float64]
+	spentOnce    sync.Once
 	sumCache     *summaryCache
 }
 
@@ -364,11 +365,9 @@ func (r *Runner) RemainingBudget() float64 {
 	return remaining
 }
 
-// getSpent lazily initializes and returns the spent value.
+// getSpent lazily initializes and returns the spent value. Safe for concurrent use.
 func (r *Runner) getSpent() *csync.Value[float64] {
-	if r.spent == nil {
-		r.spent = csync.NewValue(0.0)
-	}
+	r.spentOnce.Do(func() { r.spent = csync.NewValue(0.0) })
 	return r.spent
 }
 

--- a/routine/daemon/daemon.go
+++ b/routine/daemon/daemon.go
@@ -161,15 +161,6 @@ func resolveWorkingDir(entry routine.Entry) string {
 	return ""
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 func firstNonZeroInt(values ...int) int {
 	for _, v := range values {
 		if v != 0 {

--- a/routine/daemon/daemon_run.go
+++ b/routine/daemon/daemon_run.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -45,7 +46,10 @@ func runLifecycle(ctx context.Context, cfg *config.Config, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("watch: %w", err)
 	}
+	var watcherDone sync.WaitGroup
+	watcherDone.Add(1)
 	go func() {
+		defer watcherDone.Done()
 		for ev := range events {
 			logging.Info("routined: %s %s", eventTypeName(ev.Type), ev.Ref.Qualified())
 			sched.ApplyEvent(ev)
@@ -56,6 +60,9 @@ func runLifecycle(ctx context.Context, cfg *config.Config, opts Options) error {
 	logging.Info("routined: scheduler started")
 	<-ctx.Done()
 	logging.Info("routined: shutting down")
+	// Wait for the event-watcher goroutine to drain before shutting down the
+	// scheduler, so no ApplyEvent call races against a stopped gocron instance.
+	watcherDone.Wait()
 	shutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return sched.Shutdown(shutCtx)

--- a/routine/daemon/daemon_test.go
+++ b/routine/daemon/daemon_test.go
@@ -13,27 +13,6 @@ import (
 	"github.com/cowdogmoo/squad/routine"
 )
 
-func TestFirstNonEmpty(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		in   []string
-		want string
-	}{
-		{"first wins", []string{"a", "b"}, "a"},
-		{"skip empties", []string{"", "", "c"}, "c"},
-		{"all empty", []string{"", ""}, ""},
-		{"no values", nil, ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := firstNonEmpty(c.in...); got != c.want {
-				t.Errorf("firstNonEmpty(%v) = %q, want %q", c.in, got, c.want)
-			}
-		})
-	}
-}
-
 func TestFirstNonZeroInt(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/runner/apply.go
+++ b/runner/apply.go
@@ -10,8 +10,9 @@ import (
 	"github.com/cowdogmoo/squad/tools"
 )
 
-// applyResponseDiff extracts and applies a unified diff from the model response.
-
+// applyResponseDiff extracts and applies a unified diff from the model
+// response. It is a no-op when the response contains no diff block and either
+// indicates no changes or tools have already applied edits directly.
 func applyResponseDiff(ctx context.Context, response, workingDir string, fallback bool) error {
 	diff, err := extractUnifiedDiff(response)
 	if err != nil {
@@ -37,6 +38,10 @@ func applyResponseDiff(ctx context.Context, response, workingDir string, fallbac
 	return nil
 }
 
+// validateActionableResponse reports an error when the response is not
+// actionable: it contains no unified diff, no "files touched" marker, and no
+// "no changes" declaration, and the context tools have not already applied any
+// edits directly.
 func validateActionableResponse(ctx context.Context, response string) error {
 	if tools.EditsApplied(ctx) {
 		return nil
@@ -54,10 +59,15 @@ func validateActionableResponse(ctx context.Context, response string) error {
 	return fmt.Errorf("response is not actionable: missing diff, files touched, or no changes section (disable with --require-actionable=false)")
 }
 
+// responseIndicatesNoChanges reports whether the response contains a "no
+// changes" phrase, used to distinguish a legitimate no-op from a missing diff.
 func responseIndicatesNoChanges(response string) bool {
 	return strings.Contains(strings.ToLower(response), "no changes")
 }
 
+// extractUnifiedDiff scans response for fenced diff blocks (```diff or
+// ```patch), joins them into a single unified diff string, and returns an
+// error when no valid diff block is found.
 func extractUnifiedDiff(response string) (string, error) {
 	const fence = "```diff"
 	const altFence = "```patch"
@@ -98,6 +108,9 @@ func extractUnifiedDiff(response string) (string, error) {
 	return diff, nil
 }
 
+// applyUnifiedDiff applies diff to the files under workingDir, trying
+// git apply first. When applyFallback is true and git apply fails it retries
+// with the system patch utility; otherwise the git error is returned directly.
 func applyUnifiedDiff(ctx context.Context, workingDir, diff string, applyFallback bool) error {
 	if strings.TrimSpace(diff) == "" {
 		return fmt.Errorf("diff content is empty")
@@ -120,6 +133,8 @@ func applyUnifiedDiff(ctx context.Context, workingDir, diff string, applyFallbac
 	return fmt.Errorf("failed to apply diff with git or patch: %v; %v", gitErr, patchErr)
 }
 
+// looksLikeDiff reports whether diff contains recognisable unified-diff
+// headers ("diff --git" or "--- a/ … +++ b/").
 func looksLikeDiff(diff string) bool {
 	if strings.Contains(diff, "diff --git ") {
 		return true
@@ -130,6 +145,8 @@ func looksLikeDiff(diff string) bool {
 	return false
 }
 
+// applyWithGit applies diff via `git apply` in workingDir, returning any error
+// combined with the command output for diagnosis.
 func applyWithGit(ctx context.Context, workingDir, diff string) error {
 	cmd := exec.CommandContext(ctx, "git", "apply", "--whitespace=nowarn", "--recount", "-")
 	cmd.Dir = workingDir
@@ -141,6 +158,8 @@ func applyWithGit(ctx context.Context, workingDir, diff string) error {
 	return nil
 }
 
+// applyWithPatch applies diff via the system `patch -p1` command in workingDir,
+// used as a fallback when git apply is unavailable or rejects the diff.
 func applyWithPatch(ctx context.Context, workingDir, diff string) error {
 	cmd := exec.CommandContext(ctx, "patch", "-p1")
 	cmd.Dir = workingDir

--- a/runner/coverage_test.go
+++ b/runner/coverage_test.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/config"
+	"github.com/cowdogmoo/squad/mcp"
+	"github.com/cowdogmoo/squad/metrics"
+	"github.com/cowdogmoo/squad/tools"
+	"github.com/spf13/cobra"
+)
+
+// TestReadPromptPipedStdin verifies readPrompt reads content from a real
+// os.Pipe, exercising the *os.File branch that strings.Reader cannot reach.
+func TestReadPromptPipedStdin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"non-empty content", "hello from pipe\n", "hello from pipe"},
+		{"whitespace-only returns empty", "   \n\t  \n", ""},
+		{"multi-line content", "line one\nline two\n", "line one\nline two"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("os.Pipe: %v", err)
+			}
+			if _, err := w.WriteString(tt.input); err != nil {
+				t.Fatalf("WriteString: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("w.Close: %v", err)
+			}
+
+			cmd := &cobra.Command{}
+			cmd.SetIn(r)
+			got, err := readPrompt(cmd, nil)
+			if err != nil {
+				t.Fatalf("readPrompt() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("readPrompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSetupIsolationWithConfig verifies setupIsolation respects the isolation
+// mode from the loaded config when CLI flag and manifest are both empty.
+func TestSetupIsolationWithConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		cliFlag     string
+		configValue string
+		wantMode    IsolationMode
+	}{
+		{
+			name:        "config none applied when cli and manifest empty",
+			cliFlag:     "",
+			configValue: "none",
+			wantMode:    IsolationNone,
+		},
+		{
+			name:        "cli flag beats config isolation",
+			cliFlag:     "none",
+			configValue: "worktree",
+			wantMode:    IsolationNone,
+		},
+		{
+			name:        "nil config still resolves to none",
+			cliFlag:     "",
+			configValue: "",
+			wantMode:    IsolationNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			opts := &RunOptions{
+				Isolation: tt.cliFlag,
+				Config: &config.Config{
+					Run: config.RunConfig{Isolation: tt.configValue},
+				},
+			}
+			iso, err := setupIsolation(context.Background(), opts, dir)
+			if err != nil {
+				t.Fatalf("setupIsolation() error = %v", err)
+			}
+			if iso.Mode != tt.wantMode {
+				t.Fatalf("mode = %q, want %q", iso.Mode, tt.wantMode)
+			}
+		})
+	}
+}
+
+// TestSetupIsolationInvalidFlagErrors verifies setupIsolation propagates
+// an error from ResolveIsolationMode for invalid isolation values.
+func TestSetupIsolationInvalidFlagErrors(t *testing.T) {
+	t.Parallel()
+	opts := &RunOptions{Isolation: "garbage"}
+	_, err := setupIsolation(context.Background(), opts, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid isolation mode")
+	}
+}
+
+// TestApplyChildBudgetCapsToRemaining verifies that when a dedicated child
+// budget exceeds the remaining parent budget, it is capped to remaining.
+func TestApplyChildBudgetCapsToRemaining(t *testing.T) {
+	t.Parallel()
+	// No tokens consumed → remaining equals maxCost (1.0).
+	parentMetrics := metrics.New("openai", "gpt-4o")
+	parentMetrics.SetMaxCost(1.0)
+
+	remaining := parentMetrics.RemainingBudget()
+	if remaining <= 0 {
+		t.Fatalf("expected remaining > 0 with no tokens consumed, got %f", remaining)
+	}
+
+	opts := &RunOptions{MaxCost: 1.0}
+	childOpts := &RunOptions{}
+	cfg := &tools.TaskConfig{
+		ParentMetrics: parentMetrics,
+		// Dedicated budget (5.0) far exceeds remaining (1.0) — must be capped.
+		ChildMaxCost: func(string) float64 { return 5.0 },
+	}
+
+	if err := applyChildBudget(context.Background(), childOpts, cfg, opts, "child"); err != nil {
+		t.Fatalf("applyChildBudget() error = %v", err)
+	}
+	if childOpts.MaxCost > remaining+1e-9 {
+		t.Fatalf(
+			"child budget %f exceeds remaining %f — dedicated cap not applied",
+			childOpts.MaxCost, remaining,
+		)
+	}
+	if childOpts.MaxCost != remaining {
+		t.Fatalf("child budget = %f, want %f (remaining)", childOpts.MaxCost, remaining)
+	}
+}
+
+// TestApplyChildBudgetNilMetricsNoop verifies applyChildBudget is a no-op
+// when ParentMetrics is nil or MaxCost is zero.
+func TestApplyChildBudgetNilMetricsNoop(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cfg     *tools.TaskConfig
+		maxCost float64
+	}{
+		{"nil metrics", &tools.TaskConfig{}, 1.0},
+		{"zero max cost", &tools.TaskConfig{ParentMetrics: metrics.New("openai", "gpt-4o")}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			childOpts := &RunOptions{}
+			opts := &RunOptions{MaxCost: tt.maxCost}
+			if err := applyChildBudget(context.Background(), childOpts, tt.cfg, opts, "child"); err != nil {
+				t.Fatalf("applyChildBudget() error = %v", err)
+			}
+			if childOpts.MaxCost != 0 {
+				t.Fatalf("expected no budget set, got %f", childOpts.MaxCost)
+			}
+		})
+	}
+}
+
+// TestInvokeModelMCPServerFailure verifies InvokeModel returns an error when
+// an MCP server fails to connect, and still returns non-nil metrics.
+func TestInvokeModelMCPServerFailure(t *testing.T) {
+	t.Parallel()
+	opts := &RunOptions{
+		Provider:      "ollama",
+		Model:         "mistral",
+		MaxIterations: 1,
+		MCPServers: []mcp.ServerConfig{
+			{Name: "bad-server", Command: "/nonexistent/binary/xyz"},
+		},
+	}
+	bundle := &agent.Bundle{
+		System:  "system",
+		User:    "user",
+		WorkDir: t.TempDir(),
+	}
+	_, m, err := InvokeModel(context.Background(), opts, bundle)
+	if err == nil {
+		t.Fatal("expected error for bad MCP server")
+	}
+	if m == nil {
+		t.Fatal("metrics should be non-nil even on MCP connection failure")
+	}
+}
+
+// TestCloseMCPClientsWithTestClients verifies closeMCPClients handles test
+// clients without panicking.
+func TestCloseMCPClientsWithTestClients(t *testing.T) {
+	t.Parallel()
+	clients := []*mcp.Client{
+		mcp.NewTestClient("a", nil),
+		mcp.NewTestClient("b", nil),
+	}
+	// Should not panic.
+	closeMCPClients(clients)
+}

--- a/runner/isolation.go
+++ b/runner/isolation.go
@@ -117,6 +117,9 @@ func PrepareIsolation(ctx context.Context, originalDir string, mode IsolationMod
 	}
 }
 
+// prepareWorktree creates a git worktree for the agent run. When the working
+// directory is not a git repository it logs a warning and downgrades to
+// IsolationNone rather than failing.
 func prepareWorktree(ctx context.Context, iso *Isolation, agentName string) (*Isolation, error) {
 	if !isGitRepo(ctx, iso.Original) {
 		logging.Warn("isolation=worktree requested but %s is not a git repository — running in place", iso.Original)
@@ -147,6 +150,8 @@ func prepareWorktree(ctx context.Context, iso *Isolation, agentName string) (*Is
 	return iso, nil
 }
 
+// prepareBranch checks out a new branch `squad-<id>` in the original
+// directory, carrying any uncommitted changes to the new branch.
 func prepareBranch(ctx context.Context, iso *Isolation, agentName string) (*Isolation, error) {
 	if err := requireGitRepo(ctx, iso.Original, IsolationBranch); err != nil {
 		return nil, err
@@ -161,6 +166,8 @@ func prepareBranch(ctx context.Context, iso *Isolation, agentName string) (*Isol
 	return iso, nil
 }
 
+// prepareCommit stages and commits all working-tree changes as a snapshot
+// commit before the run. It is a no-op when the working tree is already clean.
 func prepareCommit(ctx context.Context, iso *Isolation, agentName string) (*Isolation, error) {
 	if err := requireGitRepo(ctx, iso.Original, IsolationCommit); err != nil {
 		return nil, err
@@ -184,6 +191,9 @@ func prepareCommit(ctx context.Context, iso *Isolation, agentName string) (*Isol
 	return iso, nil
 }
 
+// prepareStaged stashes any unstaged changes (preserving the index via
+// --keep-index), commits the staged snapshot, and records the stash ref for
+// restoration in [Isolation.Teardown]. It is a no-op when nothing is staged.
 func prepareStaged(ctx context.Context, iso *Isolation, agentName string) (*Isolation, error) {
 	if err := requireGitRepo(ctx, iso.Original, IsolationStaged); err != nil {
 		return nil, err
@@ -248,6 +258,8 @@ func (i *Isolation) Teardown(ctx context.Context) (kept bool, path string) {
 	return false, ""
 }
 
+// teardownWorktree removes the worktree and its branch when the agent
+// produced no changes; otherwise it retains both for the caller to review.
 func (i *Isolation) teardownWorktree(ctx context.Context) (kept bool, path string) {
 	if worktreeHasChanges(ctx, i.Effective) {
 		logging.Info("isolation: worktree retained at %s (branch %s) — agent produced changes", i.Effective, i.Branch)
@@ -264,6 +276,9 @@ func (i *Isolation) teardownWorktree(ctx context.Context) (kept bool, path strin
 	return false, ""
 }
 
+// teardownStaged pops the stash created by prepareStaged, restoring unstaged
+// changes to the working tree. It runs even when the agent failed so the
+// user's in-progress work is never silently discarded.
 func (i *Isolation) teardownStaged(ctx context.Context) {
 	if i.stashRef == "" {
 		return
@@ -288,6 +303,8 @@ func newIsolationID(agentName string) string {
 	return fmt.Sprintf("%s-%s", slug, stamp)
 }
 
+// requireGitRepo returns an error when dir is not inside a git repository,
+// providing a user-friendly message that names the failing isolation mode.
 func requireGitRepo(ctx context.Context, dir string, mode IsolationMode) error {
 	if !isGitRepo(ctx, dir) {
 		return fmt.Errorf("isolation=%s requires a git repository (run from inside one): %s", mode, dir)
@@ -295,12 +312,15 @@ func requireGitRepo(ctx context.Context, dir string, mode IsolationMode) error {
 	return nil
 }
 
+// isGitRepo reports whether dir is inside a git working tree.
 func isGitRepo(ctx context.Context, dir string) bool {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--is-inside-work-tree")
 	cmd.Dir = dir
 	return cmd.Run() == nil
 }
 
+// gitRepoRoot returns the absolute path of the top-level git repository
+// containing dir.
 func gitRepoRoot(ctx context.Context, dir string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
 	cmd.Dir = dir
@@ -311,6 +331,9 @@ func gitRepoRoot(ctx context.Context, dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// worktreeHasChanges reports whether dir has any uncommitted changes
+// (tracked or untracked). On git command failure it returns true to avoid
+// discarding a worktree that may contain agent output.
 func worktreeHasChanges(ctx context.Context, dir string) bool {
 	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	cmd.Dir = dir
@@ -321,6 +344,8 @@ func worktreeHasChanges(ctx context.Context, dir string) bool {
 	return strings.TrimSpace(string(out)) != ""
 }
 
+// workingTreeDirty reports whether the working tree in dir has any uncommitted
+// changes according to git status --porcelain.
 func workingTreeDirty(ctx context.Context, dir string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	cmd.Dir = dir
@@ -331,6 +356,7 @@ func workingTreeDirty(ctx context.Context, dir string) (bool, error) {
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+// hasStagedChanges reports whether the index in dir differs from HEAD.
 func hasStagedChanges(ctx context.Context, dir string) (bool, error) {
 	// `git diff --cached --quiet` exits 0 when index matches HEAD, 1 when not.
 	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet")
@@ -345,6 +371,8 @@ func hasStagedChanges(ctx context.Context, dir string) (bool, error) {
 	return false, err
 }
 
+// hasUnstagedChanges reports whether dir has tracked modifications or untracked
+// files that would be picked up by `git stash push -u`.
 func hasUnstagedChanges(ctx context.Context, dir string) (bool, error) {
 	// Tracked-file changes:
 	tracked := exec.CommandContext(ctx, "git", "diff", "--quiet")
@@ -377,6 +405,10 @@ func runGit(ctx context.Context, dir string, args ...string) (string, error) {
 	return strings.TrimSpace(out.String()), err
 }
 
+// sanitizeForBranch converts s to a string safe for use in a git branch name:
+// letters and digits are kept, uppercase is lowercased, hyphens and underscores
+// are kept, and all other characters are replaced with hyphens. Leading and
+// trailing hyphens are stripped.
 func sanitizeForBranch(s string) string {
 	var sb strings.Builder
 	for _, r := range s {

--- a/runner/isolation_test.go
+++ b/runner/isolation_test.go
@@ -1,12 +1,15 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestResolveIsolationMode(t *testing.T) {
@@ -291,6 +294,104 @@ func TestPrepareIsolationStagedNoUnstagedChanges(t *testing.T) {
 		t.Errorf("stash count should be 0, got %d", n)
 	}
 	iso.Teardown(context.Background())
+}
+
+// TestSanitizeForBranch verifies that sanitizeForBranch produces
+// branch-name-safe strings across a range of inputs.
+func TestSanitizeForBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"lowercase letters and hyphens kept", "go-review", "go-review"},
+		{"uppercase letters lowercased", "GoReview", "goreview"},
+		{"digits kept", "agent123", "agent123"},
+		{"underscores kept", "my_agent", "my_agent"},
+		{"slash becomes hyphen", "my/agent", "my-agent"},
+		{"space becomes hyphen", "my agent", "my-agent"},
+		{"leading trailing hyphens stripped", "---agent---", "agent"},
+		{"empty string", "", ""},
+		{"all special chars produces empty", "!!!", ""},
+		{"slash padding stripped", "/agent/", "agent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizeForBranch(tt.input); got != tt.want {
+				t.Fatalf(
+					"sanitizeForBranch(%q) = %q, want %q",
+					tt.input, got, tt.want,
+				)
+			}
+		})
+	}
+}
+
+// TestReportIsolationTeardown verifies that reportIsolationTeardown writes a
+// retention notice to stderr only when the worktree was kept.
+func TestReportIsolationTeardown(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil iso produces no output", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var errBuf bytes.Buffer
+		cmd.SetErr(&errBuf)
+		reportIsolationTeardown(cmd, nil)
+		if errBuf.Len() != 0 {
+			t.Fatalf("expected no output for nil iso, got %q", errBuf.String())
+		}
+	})
+
+	t.Run("IsolationNone teardown produces no output", func(t *testing.T) {
+		t.Parallel()
+		iso, err := PrepareIsolation(
+			context.Background(), t.TempDir(), IsolationNone, "agent",
+		)
+		if err != nil {
+			t.Fatalf("PrepareIsolation: %v", err)
+		}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var errBuf bytes.Buffer
+		cmd.SetErr(&errBuf)
+		reportIsolationTeardown(cmd, iso)
+		if errBuf.Len() != 0 {
+			t.Fatalf("expected no output for IsolationNone, got %q", errBuf.String())
+		}
+	})
+
+	t.Run("retained worktree prints branch notice to stderr", func(t *testing.T) {
+		t.Parallel()
+		dir := initGitRepo(t)
+		iso, err := PrepareIsolation(
+			context.Background(), dir, IsolationWorktree, "test-agent",
+		)
+		if err != nil {
+			t.Fatalf("PrepareIsolation: %v", err)
+		}
+		// Write a file so the worktree has changes and is retained.
+		if writeErr := os.WriteFile(
+			filepath.Join(iso.Effective, "change.txt"), []byte("x"), 0o644,
+		); writeErr != nil {
+			t.Fatalf("write: %v", writeErr)
+		}
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var errBuf bytes.Buffer
+		cmd.SetErr(&errBuf)
+		reportIsolationTeardown(cmd, iso)
+		out := errBuf.String()
+		if !strings.Contains(out, "Worktree retained") {
+			t.Fatalf("expected retention notice, got %q", out)
+		}
+		if !strings.Contains(out, iso.Branch) {
+			t.Fatalf("expected branch name %q in notice, got %q", iso.Branch, out)
+		}
+	})
 }
 
 // --- test helpers ---

--- a/runner/model.go
+++ b/runner/model.go
@@ -369,6 +369,8 @@ func buildOpenAICompatLLM(opts *RunOptions, provider, model string) (llms.Model,
 	return openai.New(oaiOpts...)
 }
 
+// buildAnthropicLLM constructs an Anthropic LangChain LLM using the model,
+// API key, and optional base URL from opts.
 func buildAnthropicLLM(opts *RunOptions, model string) (llms.Model, error) {
 	aOpts := []anthropic.Option{}
 	if model != "" {
@@ -386,6 +388,8 @@ func buildAnthropicLLM(opts *RunOptions, model string) (llms.Model, error) {
 	return anthropic.New(aOpts...)
 }
 
+// buildGeminiLLM constructs a Google AI (Gemini) LangChain LLM using the
+// model and API key from opts.
 func buildGeminiLLM(ctx context.Context, opts *RunOptions, model string) (llms.Model, error) {
 	gOpts := []googleai.Option{}
 	if model != "" {
@@ -397,10 +401,14 @@ func buildGeminiLLM(ctx context.Context, opts *RunOptions, model string) (llms.M
 	return googleai.New(ctx, gOpts...)
 }
 
+// normalizeProvider returns provider lowercased and stripped of whitespace.
 func normalizeProvider(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
+// buildNativeOllamaLLM constructs an Ollama LLM using the base URL and
+// context-window size from opts, defaulting to localhost:11434 and 32 768
+// tokens respectively.
 func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 	baseURL := opts.BaseURL
 	if baseURL == "" {
@@ -413,6 +421,8 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 	return ollama.New(baseURL, model, numCtx)
 }
 
+// isOpenAICompatProvider reports whether provider speaks the OpenAI
+// chat-completions API (including the legacy nvidia and databricks shims).
 func isOpenAICompatProvider(provider string) bool {
 	return provider == "" || provider == "openai" || provider == "openai-compat" ||
 		provider == "nvidia" || provider == "databricks"

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -143,17 +143,6 @@ func TestBuildLLMVariants(t *testing.T) {
 			false,
 		},
 		{
-			// langchaingo validates key presence at construction; users of keyless
-			// endpoints (e.g. local vLLM) must set OPENAI_COMPAT_API_KEY or OPENAI_API_KEY
-			// to a dummy value. The error is caught here, not at HTTP call time.
-			"openai-compat/no-api-key fails at construction",
-			"openai-compat",
-			"some-model",
-			&RunOptions{BaseURL: "http://localhost:8000/v1"},
-			"",
-			true,
-		},
-		{
 			"openai-compat/missing base-url",
 			"openai-compat",
 			"meta-llama/Meta-Llama-3-70B-Instruct",
@@ -175,6 +164,16 @@ func TestBuildLLMVariants(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildLLMOpenAICompatNoAPIKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_COMPAT_API_KEY", "")
+	opts := &RunOptions{BaseURL: "http://localhost:8000/v1"}
+	_, err := buildLLM(context.Background(), opts, "openai-compat", "some-model")
+	if err == nil {
+		t.Fatal("expected error when no API key is provided for openai-compat")
 	}
 }
 
@@ -633,6 +632,7 @@ func TestCallModelRoutes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := tt.setup(t)
 			defer server.Close()
 
@@ -691,7 +691,7 @@ func TestInvokeModel_ExecutorError(t *testing.T) {
 }
 
 func TestInvokeModel_SystemOverride(t *testing.T) {
-	t.Parallel()
+	t.Setenv("OPENAI_API_KEY", "")
 	// This tests the system override path in InvokeModel.
 	// It will fail on API call but exercises the system override code path.
 	bundle := &agent.Bundle{
@@ -717,6 +717,7 @@ func TestInvokeModel_SystemOverride(t *testing.T) {
 }
 
 func TestCallLangChainLLMUnknownProvider(t *testing.T) {
+	t.Parallel()
 	bundle := &agent.Bundle{System: "system", User: "user", WorkDir: t.TempDir()}
 	opts := &RunOptions{Provider: "unknown"}
 	ex := &executor.LocalExecutor{WorkingDir: bundle.WorkDir}
@@ -1440,6 +1441,70 @@ func TestConnectMCPServers(t *testing.T) {
 				t.Fatalf("expected 0 clients, got %d", len(clients))
 			}
 			closeMCPClients(clients)
+		})
+	}
+}
+
+// TestApplyChildIterationCap verifies that applyChildIterationCap honours
+// the three-layer precedence: parent ChildMaxIter → manifest MaxIterations.
+func TestApplyChildIterationCap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		childMaxIter  tools.ChildMaxIterFunc
+		bundleMaxIter int
+		initialIter   int
+		wantIter      int
+	}{
+		{
+			name:        "no limits leaves MaxIterations unchanged",
+			initialIter: 5,
+			wantIter:    5,
+		},
+		{
+			name:         "parent ChildMaxIter applies cap",
+			childMaxIter: func(string) int { return 3 },
+			wantIter:     3,
+		},
+		{
+			name:         "parent ChildMaxIter of zero is ignored",
+			childMaxIter: func(string) int { return 0 },
+			initialIter:  5,
+			wantIter:     5,
+		},
+		{
+			name:          "manifest cap applied when no parent cap",
+			bundleMaxIter: 4,
+			wantIter:      4,
+		},
+		{
+			name:          "manifest cap lowers parent cap",
+			childMaxIter:  func(string) int { return 10 },
+			bundleMaxIter: 3,
+			wantIter:      3,
+		},
+		{
+			name:          "manifest higher than parent cap keeps parent cap",
+			childMaxIter:  func(string) int { return 2 },
+			bundleMaxIter: 10,
+			wantIter:      2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			childOpts := &RunOptions{MaxIterations: tt.initialIter}
+			cfg := &tools.TaskConfig{ChildMaxIter: tt.childMaxIter}
+			bundle := &agent.Bundle{MaxIterations: tt.bundleMaxIter}
+			applyChildIterationCap(
+				context.Background(), childOpts, cfg, bundle, "child",
+			)
+			if childOpts.MaxIterations != tt.wantIter {
+				t.Fatalf(
+					"MaxIterations = %d, want %d",
+					childOpts.MaxIterations, tt.wantIter,
+				)
+			}
 		})
 	}
 }

--- a/runner/run.go
+++ b/runner/run.go
@@ -1,4 +1,10 @@
 // Package runner orchestrates agent execution workflows and model calls.
+//
+// The primary entry points are [ExecuteRun] for single-agent invocations and
+// [InvokeModel] for direct model dispatch (used by the pipeline runner and the
+// Task tool). [ResolveModelPrecedence] handles the three-layer model selection
+// hierarchy (CLI flag → config default → agent manifest). [FindAgentDir]
+// locates an agent directory using the configured source manager.
 package runner
 
 import (
@@ -128,8 +134,15 @@ type RunOptions struct {
 	LastSessionID string
 }
 
-// ExecuteRun contains the full run command logic, parameterized by RunOptions.
-func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
+// ExecuteRun runs a single agent invocation end-to-end. It reads the prompt,
+// resolves working directory and isolation, builds the agent bundle, opens a
+// session log, calls the model, and writes the response. Budget-exceeded runs
+// apply any partial response before returning the error.
+//
+// The named return runErr is used so the deferred session-close always records
+// the final error, including failures from post-processing steps like diff
+// application.
+func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) (runErr error) {
 	prompt, err := readPrompt(cmd, args)
 	if err != nil {
 		return err
@@ -177,26 +190,26 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 
 	cmd.SetContext(ctx)
 	tools.ResetEditsApplied(ctx)
-	response, m, err := InvokeModel(ctx, opts, bundle)
+
+	var m *metrics.Metrics
+	var response string
+	response, m, runErr = InvokeModel(ctx, opts, bundle)
 
 	defer func() {
 		logRunHistory(opts, m)
 		if metricsErr := printMetrics(cmd, m); metricsErr != nil {
 			logging.Warn("failed to print metrics: %v", metricsErr)
 		}
-		closeSession(logger, m, err)
+		closeSession(logger, m, runErr)
 	}()
 
-	if err != nil {
-		handleBudgetExceeded(cmd, opts, m, response, workingDir, err)
-		return err
+	if runErr != nil {
+		handleBudgetExceeded(cmd, opts, m, response, workingDir, runErr)
+		return
 	}
 
-	if err := handleResponse(cmd, opts, response, workingDir); err != nil {
-		return err
-	}
-
-	return nil
+	runErr = handleResponse(cmd, opts, response, workingDir)
+	return
 }
 
 // handleBudgetExceeded reports a budget-exceeded run and applies any partial
@@ -225,69 +238,84 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 	return err
 }
 
-// ResolveModelPrecedence fills opts.Model and opts.Provider using the
-// precedence: explicit (CLI flag / routine field) > config default (when
-// supported by the manifest) > manifest first model > config default.
-// Already-set fields are preserved. Returns a non-empty warning string when
-// the config default is set but not listed in the agent manifest; callers
-// should display this to the user on stderr.
-func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) string {
+// ModelResolution holds the resolved model, provider, base URL, and any
+// advisory warning produced by ResolveModelPrecedence. Callers apply these
+// values back to RunOptions so that the mutation is visible at the call site.
+type ModelResolution struct {
+	Model    string
+	Provider string
+	BaseURL  string
+	// Warning is non-empty when the config default is not listed in the agent
+	// manifest's preferred model list but is used anyway.
+	Warning string
+}
+
+// ResolveModelPrecedence resolves the model, provider, and base URL using the
+// precedence: explicit (CLI flag / routine field) > config default > manifest.
+// It returns a ModelResolution the caller must apply to RunOptions; the opts
+// argument is read-only. Warning is non-empty when the config default is not
+// listed in the manifest's preferred models but is used anyway.
+func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) ModelResolution {
 	if opts == nil || bundle == nil {
-		return ""
+		return ModelResolution{}
 	}
 
-	var warn string
-	if opts.Model == "" {
+	res := ModelResolution{
+		Model:    opts.Model,
+		Provider: opts.Provider,
+		BaseURL:  opts.BaseURL,
+	}
+
+	if res.Model == "" {
 		configMatch := bundle.FindModel(opts.ConfigProvider, opts.ConfigModel)
 
 		switch {
 		case configMatch != nil:
-			// Config default is supported by this agent — use it; provider is also set.
-			opts.Model = configMatch.Model
-			opts.Provider = configMatch.Provider
-			if opts.BaseURL == "" {
-				opts.BaseURL = configMatch.BaseURL
+			// Config default is listed in the manifest — use it; provider is also set.
+			res.Model = configMatch.Model
+			res.Provider = configMatch.Provider
+			if res.BaseURL == "" {
+				res.BaseURL = configMatch.BaseURL
 			}
-			logging.InfoContext(ctx, "using config default model: %s (%s)", opts.Model, opts.Provider)
-			return ""
+			logging.InfoContext(ctx, "using config default model: %s (%s)", res.Model, res.Provider)
 
 		case opts.ConfigModel != "" && bundle.Model != "":
-			// Config default exists but is not in the manifest — warn and fall back.
-			warn = fmt.Sprintf(
-				"⚠  Config default model %q (%s) is not listed in the agent manifest.\n"+
-					"   Add it to the agent's models: list to avoid this fallback.\n"+
-					"   Falling back to manifest model %q (%s).",
-				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
-			logging.WarnContext(ctx, "config default model %q (%s) is not listed in agent manifest; falling back to manifest model %q (%s)",
-				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
-			opts.Model = bundle.Model
+			// Config default not in the manifest's preferred list — warn but still use it.
+			res.Warning = fmt.Sprintf(
+				"⚠  Config default model %q (%s) is not a preferred model for this agent.\n"+
+					"   Running with configured default.",
+				opts.ConfigModel, opts.ConfigProvider)
+			logging.WarnContext(ctx, "config default model %q (%s) is not listed in agent manifest; running with configured default",
+				opts.ConfigModel, opts.ConfigProvider)
+			res.Model = opts.ConfigModel
+			res.Provider = opts.ConfigProvider
 
 		case bundle.Model != "":
-			opts.Model = bundle.Model
+			res.Model = bundle.Model
 			logging.InfoContext(ctx, "using manifest model: %s", bundle.Model)
 
 		case opts.ConfigModel != "":
-			opts.Model = opts.ConfigModel
+			res.Model = opts.ConfigModel
 			logging.InfoContext(ctx, "using config model: %s", opts.ConfigModel)
 		}
 	}
 
-	if opts.Provider == "" {
+	if res.Provider == "" {
 		switch {
 		case bundle.Provider != "":
-			opts.Provider = bundle.Provider
+			res.Provider = bundle.Provider
 			logging.InfoContext(ctx, "using manifest provider: %s", bundle.Provider)
 		case opts.ConfigProvider != "":
-			opts.Provider = opts.ConfigProvider
+			res.Provider = opts.ConfigProvider
 			logging.InfoContext(ctx, "using config provider: %s", opts.ConfigProvider)
 		}
 	}
 
-	if opts.BaseURL == "" && bundle.BaseURL != "" {
-		opts.BaseURL = bundle.BaseURL
+	if res.BaseURL == "" && bundle.BaseURL != "" {
+		res.BaseURL = bundle.BaseURL
 	}
 
-	return warn
+	return res
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
@@ -305,8 +333,12 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, err
 	}
 
-	if warn := ResolveModelPrecedence(cmd.Context(), opts, bundle); warn != "" {
-		if _, fmtErr := fmt.Fprintln(cmd.ErrOrStderr(), warn); fmtErr != nil {
+	res := ResolveModelPrecedence(cmd.Context(), opts, bundle)
+	opts.Model = res.Model
+	opts.Provider = res.Provider
+	opts.BaseURL = res.BaseURL
+	if res.Warning != "" {
+		if _, fmtErr := fmt.Fprintln(cmd.ErrOrStderr(), res.Warning); fmtErr != nil {
 			logging.Warn("failed to write model warning: %v", fmtErr)
 		}
 	}
@@ -362,6 +394,8 @@ func handleResponse(cmd *cobra.Command, opts *RunOptions, response, workingDir s
 	return writeResponse(cmd, response, opts)
 }
 
+// writeResponse prints response to stdout when Print is set or no output file
+// is configured, and writes it to opts.Output when that path is non-empty.
 func writeResponse(cmd *cobra.Command, response string, opts *RunOptions) error {
 	if opts.Print || opts.Output == "" {
 		if _, err := fmt.Fprintln(cmd.OutOrStdout(), response); err != nil {
@@ -447,6 +481,10 @@ func logRunHistory(opts *RunOptions, m *metrics.Metrics) {
 	metrics.LogRunHistory(cacheDir, opts.Agent, m)
 }
 
+// readPrompt returns the user prompt from positional arguments or, when no
+// arguments are supplied, from piped stdin. It returns an empty string when
+// stdin is a terminal or produces only whitespace; the agent's default
+// user_prompt template will be used in that case.
 func readPrompt(cmd *cobra.Command, args []string) (string, error) {
 	if len(args) > 0 {
 		return strings.Join(args, " "), nil
@@ -469,6 +507,8 @@ func readPrompt(cmd *cobra.Command, args []string) (string, error) {
 	return "", nil
 }
 
+// resolveWorkingDir returns the absolute path of dir, or the current working
+// directory when dir is empty.
 func resolveWorkingDir(dir string) (string, error) {
 	if dir == "" {
 		return os.Getwd()

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -53,36 +54,28 @@ func TestReadPrompt(t *testing.T) {
 
 func TestResolveWorkingDir(t *testing.T) {
 	t.Parallel()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	tmp := t.TempDir()
 	tests := []struct {
-		name    string
-		dir     string
-		wantCwd bool
-		wantErr bool
+		name string
+		dir  string
+		want string
 	}{
-		{"empty returns cwd", "", true, false},
-		{"explicit path", "", false, false},
+		{"empty returns cwd", "", cwd},
+		{"explicit path", tmp, tmp},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.wantCwd {
-				cwd, _ := os.Getwd()
-				resolved, err := resolveWorkingDir("")
-				if err != nil {
-					t.Fatalf("resolveWorkingDir() error = %v", err)
-				}
-				if resolved != cwd {
-					t.Fatalf("resolveWorkingDir() = %q, want cwd %q", resolved, cwd)
-				}
-			} else {
-				tmp := t.TempDir()
-				resolved, err := resolveWorkingDir(tmp)
-				if err != nil {
-					t.Fatalf("resolveWorkingDir() error = %v", err)
-				}
-				if resolved != tmp {
-					t.Fatalf("resolveWorkingDir() = %q, want %q", resolved, tmp)
-				}
+			resolved, err := resolveWorkingDir(tt.dir)
+			if err != nil {
+				t.Fatalf("resolveWorkingDir(%q) error = %v", tt.dir, err)
+			}
+			if resolved != tt.want {
+				t.Fatalf("resolveWorkingDir(%q) = %q, want %q", tt.dir, resolved, tt.want)
 			}
 		})
 	}
@@ -284,9 +277,9 @@ func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	ResolveModelPrecedence(context.Background(), nil, &agent.Bundle{})
 
 	opts := &RunOptions{Model: "preset", Provider: "preset"}
-	ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
-	if opts.Model != "preset" || opts.Provider != "preset" {
-		t.Fatalf("explicit values must win over manifest: Model=%q Provider=%q", opts.Model, opts.Provider)
+	res := ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
+	if res.Model != "preset" || res.Provider != "preset" {
+		t.Fatalf("explicit values must win over manifest: Model=%q Provider=%q", res.Model, res.Provider)
 	}
 }
 
@@ -305,9 +298,9 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
-		if opts.BaseURL != compatURL {
-			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
+		res := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if res.BaseURL != compatURL {
+			t.Fatalf("BaseURL = %q, want %q", res.BaseURL, compatURL)
 		}
 	})
 
@@ -320,9 +313,9 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
-		if opts.BaseURL != explicit {
-			t.Fatalf("BaseURL = %q, want explicit %q", opts.BaseURL, explicit)
+		res := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if res.BaseURL != explicit {
+			t.Fatalf("BaseURL = %q, want explicit %q", res.BaseURL, explicit)
 		}
 	})
 
@@ -341,12 +334,12 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 				},
 			},
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
-		if opts.BaseURL != compatURL {
-			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
+		res := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if res.BaseURL != compatURL {
+			t.Fatalf("BaseURL = %q, want %q", res.BaseURL, compatURL)
 		}
-		if opts.Provider != "openai-compat" {
-			t.Fatalf("Provider = %q, want openai-compat", opts.Provider)
+		if res.Provider != "openai-compat" {
+			t.Fatalf("Provider = %q, want openai-compat", res.Provider)
 		}
 	})
 }
@@ -385,7 +378,7 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
 	})
 
-	t.Run("manifest wins over config defaults", func(t *testing.T) {
+	t.Run("config default wins over manifest even when not listed", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "manifest-vs-config", "manifest-model", "manifest-provider")
 		opts := &RunOptions{
@@ -397,7 +390,7 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle:    true,
 			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
+		runAndAssertBundle(t, opts, "config-model", "config-provider")
 	})
 
 	t.Run("config defaults fill in when manifest is silent", func(t *testing.T) {
@@ -431,6 +424,26 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		runAndAssertBundle(t, opts, "config-model", "config-provider")
 	})
 
+	t.Run("config default wins when listed as non-first model", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithMultiModels(t, "multi-model-agent",
+			[]struct{ model, provider string }{
+				{"claude-sonnet-4-6", "anthropic"},
+				{"qwen3-coder-480b", "nvidia"},
+			},
+		)
+		opts := &RunOptions{
+			Agent:          "multi-model-agent",
+			AgentsDir:      agentsDir,
+			ConfigModel:    "qwen3-coder-480b",
+			ConfigProvider: "nvidia",
+			DryRun:         true,
+			PrintBundle:    true,
+			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
+		}
+		runAndAssertBundle(t, opts, "qwen3-coder-480b", "nvidia")
+	})
+
 	t.Run("CLI flags take precedence over manifest", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "cli-agent", "manifest-model", "manifest-provider")
@@ -446,7 +459,7 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		runAndAssertBundle(t, opts, "cli-model", "cli-provider")
 	})
 
-	t.Run("config default not in manifest emits warning to stderr", func(t *testing.T) {
+	t.Run("config default not in manifest emits warning but still runs with config default", func(t *testing.T) {
 		t.Parallel()
 		agentsDir := writeTestAgentWithModels(t, "warn-fallback", "manifest-model", "manifest-provider")
 		opts := &RunOptions{
@@ -466,10 +479,10 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		if _, err := prepareBundle(cmd, opts, "prompt", t.TempDir()); err != nil {
 			t.Fatalf("prepareBundle() error = %v", err)
 		}
-		if opts.Model != "manifest-model" || opts.Provider != "manifest-provider" {
-			t.Fatalf("expected fallback to manifest, got Model=%q Provider=%q", opts.Model, opts.Provider)
+		if opts.Model != "other-model" || opts.Provider != "other-provider" {
+			t.Fatalf("expected config default to be used, got Model=%q Provider=%q", opts.Model, opts.Provider)
 		}
-		if !strings.Contains(stderr.String(), "not listed in the agent manifest") {
+		if !strings.Contains(stderr.String(), "not a preferred model for this agent") {
 			t.Fatalf("expected warning on stderr, got %q", stderr.String())
 		}
 	})
@@ -560,6 +573,7 @@ func TestExecuteRunInvokeModelError(t *testing.T) {
 }
 
 func TestExecuteRunSuccessOllama(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/chat" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -730,22 +744,7 @@ func TestWriteResponsePrintAndFile(t *testing.T) {
 
 func writeTestAgent(t *testing.T, agentName string) string {
 	t.Helper()
-	agentsDir := t.TempDir()
-	agentDir := filepath.Join(agentsDir, agentName)
-	if err := os.MkdirAll(agentDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	manifest := fmt.Sprintf("name: %s\nversion: 0.0.0\nentrypoint: system.md\nwrapper: wrapper.md\n", agentName)
-	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
-		t.Fatalf("WriteFile agent.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("System prompt."), 0o644); err != nil {
-		t.Fatalf("WriteFile system.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(agentDir, "wrapper.md"), []byte("Wrapper prompt."), 0o644); err != nil {
-		t.Fatalf("WriteFile wrapper.md: %v", err)
-	}
-	return agentsDir
+	return writeTestAgentNoModels(t, agentName)
 }
 
 func writeTestAgentNoModels(t *testing.T, agentName string) string {
@@ -786,4 +785,164 @@ func writeTestAgentWithModels(t *testing.T, agentName, model, provider string) s
 		t.Fatalf("WriteFile wrapper.md: %v", err)
 	}
 	return agentsDir
+}
+
+func writeTestAgentWithMultiModels(t *testing.T, agentName string, models []struct{ model, provider string }) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	var sb strings.Builder
+	for _, m := range models {
+		fmt.Fprintf(&sb, "  - model: %s\n    provider: %s\n", m.model, m.provider)
+	}
+	modelsYAML := sb.String()
+	manifest := fmt.Sprintf("name: %s\nversion: 0.0.0\nentrypoint: system.md\nwrapper: wrapper.md\nmodels:\n%s", agentName, modelsYAML)
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("System prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile system.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "wrapper.md"), []byte("Wrapper prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile wrapper.md: %v", err)
+	}
+	return agentsDir
+}
+
+// writeTestAgentWithIsolation creates an agent fixture whose manifest
+// declares the given isolation mode.
+func writeTestAgentWithIsolation(t *testing.T, agentName, isolation string) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := fmt.Sprintf(
+		"name: %s\nversion: 0.0.0\nentrypoint: system.md\n"+
+			"wrapper: wrapper.md\nisolation: %s\n",
+		agentName, isolation,
+	)
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("WriteFile agent.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "system.md"), []byte("System prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile system.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "wrapper.md"), []byte("Wrapper prompt."), 0o644); err != nil {
+		t.Fatalf("WriteFile wrapper.md: %v", err)
+	}
+	return agentsDir
+}
+
+// TestHandleBudgetExceeded verifies the three branches inside
+// handleBudgetExceeded: silent no-op, warning-only, and partial apply.
+func TestHandleBudgetExceeded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-budget error is a no-op", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var errBuf bytes.Buffer
+		cmd.SetErr(&errBuf)
+		m := metrics.New("openai", "gpt-4o")
+		m.Finish()
+		handleBudgetExceeded(
+			cmd, &RunOptions{}, m, "", t.TempDir(),
+			errors.New("some other error"),
+		)
+		if errBuf.Len() != 0 {
+			t.Fatalf(
+				"expected no output for non-budget error, got %q",
+				errBuf.String(),
+			)
+		}
+	})
+
+	t.Run("budget exceeded with empty response writes warning only", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var errBuf bytes.Buffer
+		cmd.SetErr(&errBuf)
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		m := metrics.New("openai", "gpt-4o")
+		m.SetMaxCost(0.001)
+		m.Finish()
+		handleBudgetExceeded(
+			cmd, &RunOptions{MaxCost: 0.001}, m, "", t.TempDir(),
+			metrics.ErrBudgetExceeded,
+		)
+		if !strings.Contains(errBuf.String(), "cost budget") {
+			t.Fatalf("expected budget warning, got %q", errBuf.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("expected no stdout for empty response, got %q", stdout.String())
+		}
+	})
+
+	t.Run("budget exceeded with response applies partial output", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		m := metrics.New("openai", "gpt-4o")
+		m.Finish()
+		opts := &RunOptions{MaxCost: 0.001, Print: true}
+		handleBudgetExceeded(
+			cmd, opts, m, "partial response", t.TempDir(),
+			metrics.ErrBudgetExceeded,
+		)
+		if !strings.Contains(stdout.String(), "partial response") {
+			t.Fatalf(
+				"expected partial response in stdout, got %q",
+				stdout.String(),
+			)
+		}
+	})
+}
+
+// TestManifestIsolation verifies that manifestIsolation returns the isolation
+// field from an agent manifest, or empty string on any failure.
+func TestManifestIsolation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty agent name returns empty", func(t *testing.T) {
+		t.Parallel()
+		if got := manifestIsolation(&RunOptions{}); got != "" {
+			t.Fatalf("expected empty for empty agent, got %q", got)
+		}
+	})
+
+	t.Run("missing agent directory returns empty", func(t *testing.T) {
+		t.Parallel()
+		opts := &RunOptions{Agent: "nonexistent", AgentsDir: t.TempDir()}
+		if got := manifestIsolation(opts); got != "" {
+			t.Fatalf("expected empty for missing agent, got %q", got)
+		}
+	})
+
+	t.Run("manifest with isolation field returns it", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentWithIsolation(t, "iso-agent", "worktree")
+		opts := &RunOptions{Agent: "iso-agent", AgentsDir: agentsDir}
+		if got := manifestIsolation(opts); got != "worktree" {
+			t.Fatalf("manifestIsolation() = %q, want worktree", got)
+		}
+	})
+
+	t.Run("manifest without isolation field returns empty", func(t *testing.T) {
+		t.Parallel()
+		agentsDir := writeTestAgentNoModels(t, "no-iso-agent")
+		opts := &RunOptions{Agent: "no-iso-agent", AgentsDir: agentsDir}
+		if got := manifestIsolation(opts); got != "" {
+			t.Fatalf("manifestIsolation() = %q, want empty", got)
+		}
+	})
 }

--- a/tools/efficiency.go
+++ b/tools/efficiency.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -468,27 +469,40 @@ func CompactionSummary(messages []llms.MessageContent, rc *ReadCache) string {
 	return sb.String()
 }
 
-// extractJSONField does a quick, non-strict extraction of a string field from JSON.
-// This avoids the overhead of full JSON parsing for simple cases.
+// extractJSONField does a quick extraction of a string field from JSON,
+// correctly handling backslash-escaped characters inside the value.
 func extractJSONField(jsonStr, field string) string {
-	// Look for "field":"value" or "field": "value"
 	key := fmt.Sprintf(`"%s"`, field)
 	idx := strings.Index(jsonStr, key)
 	if idx < 0 {
 		return ""
 	}
 	rest := jsonStr[idx+len(key):]
-	// Skip : and whitespace
 	rest = strings.TrimLeft(rest, ": \t\n")
 	if len(rest) == 0 || rest[0] != '"' {
 		return ""
 	}
-	rest = rest[1:]
-	end := strings.IndexByte(rest, '"')
-	if end < 0 {
-		return ""
+	// Scan forward, skipping backslash-escaped bytes, to find the closing quote.
+	i := 1
+	for i < len(rest) {
+		if rest[i] == '\\' {
+			i += 2 // skip escaped character
+			continue
+		}
+		if rest[i] == '"' {
+			break
+		}
+		i++
 	}
-	return rest[:end]
+	if i >= len(rest) {
+		return "" // no closing quote found
+	}
+	// Use encoding/json to properly decode escape sequences (e.g. \n, \uXXXX).
+	var s string
+	if err := json.Unmarshal([]byte(rest[:i+1]), &s); err != nil {
+		return rest[1:i] // fall back to raw slice if decode fails
+	}
+	return s
 }
 
 // sortedKeys returns map keys sorted alphabetically.

--- a/tools/efficiency_test.go
+++ b/tools/efficiency_test.go
@@ -436,6 +436,12 @@ func TestExtractJSONField(t *testing.T) {
 		{`{"path": 123}`, "path", ""},    // non-string value
 		{`{"other": "val"}`, "path", ""}, // field not present
 		{`not json`, "path", ""},         // invalid json
+		// Escape sequence handling.
+		{`{"path": "foo\nbar"}`, "path", "foo\nbar"},     // \n → newline
+		{`{"path": "a\tb"}`, "path", "a\tb"},             // \t → tab
+		{`{"path": "foo\"bar"}`, "path", `foo"bar`},      // \" → "
+		{`{"path": "A"}`, "path", "A"}, // JSON A → A
+		{`{"path": "back\\slash"}`, "path", `back\slash`}, // \\ → backslash
 	}
 	for _, tt := range tests {
 		got := extractJSONField(tt.json, tt.field)

--- a/tools/efficiency_test.go
+++ b/tools/efficiency_test.go
@@ -437,10 +437,10 @@ func TestExtractJSONField(t *testing.T) {
 		{`{"other": "val"}`, "path", ""}, // field not present
 		{`not json`, "path", ""},         // invalid json
 		// Escape sequence handling.
-		{`{"path": "foo\nbar"}`, "path", "foo\nbar"},     // \n → newline
-		{`{"path": "a\tb"}`, "path", "a\tb"},             // \t → tab
-		{`{"path": "foo\"bar"}`, "path", `foo"bar`},      // \" → "
-		{`{"path": "A"}`, "path", "A"}, // JSON A → A
+		{`{"path": "foo\nbar"}`, "path", "foo\nbar"},      // \n → newline
+		{`{"path": "a\tb"}`, "path", "a\tb"},              // \t → tab
+		{`{"path": "foo\"bar"}`, "path", `foo"bar`},       // \" → "
+		{`{"path": "A"}`, "path", "A"},                    // JSON A → A
 		{`{"path": "back\\slash"}`, "path", `back\slash`}, // \\ → backslash
 	}
 	for _, tt := range tests {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -363,11 +363,11 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	}
 
 	messages := buildInitialMessages(systemPrompt, userPrompt, cfg.UseCacheControl)
-	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg, callOpts)
-	if done {
+	lastContent, messages, loopErr := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg, callOpts)
+	if loopErr == nil {
 		return lastContent, nil
 	}
-	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) &&
+	if !errors.Is(loopErr, metrics.ErrBudgetExceeded) &&
 		!errors.Is(loopErr, ErrIterationLimitReached) &&
 		!errors.Is(loopErr, ErrLoopDetected) &&
 		!errors.Is(loopErr, ErrEditDeadlineReached) {
@@ -647,7 +647,7 @@ func trackPostExecution(ctx context.Context, messages []llms.MessageContent, mer
 	return postExecutionResult{newFilesRead: newFilesRead, stuck: loopDetector.Stuck()}
 }
 
-func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter int, cfg RunWithToolsConfig, callOpts []llms.CallOption) (string, []llms.MessageContent, error, bool) {
+func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, handlers map[string]Handler, maxIter int, cfg RunWithToolsConfig, callOpts []llms.CallOption) (string, []llms.MessageContent, error) {
 	m := cfg.Metrics
 	var lastContent string
 	var repeat RepeatTracker
@@ -663,7 +663,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		response, err := retryGenerateContent(ctx, llm, messages, resolveIterOpts(callOpts, cfg.ForceFirstToolCall, i))
 		iterDuration := time.Since(iterStart)
 		if err := validateResponse(ctx, response, err, iterDuration); err != nil {
-			return lastContent, messages, err, false
+			return lastContent, messages, err
 		}
 
 		if m != nil {
@@ -676,7 +676,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		}
 		if len(mergedToolCalls) == 0 {
 			logging.InfoContext(ctx, "model returned final response in %s (no tool calls)", iterDuration.Round(time.Millisecond))
-			return mergedContent, messages, nil, true
+			return mergedContent, messages, nil
 		}
 		if mergedContent != "" {
 			logging.InfoContext(ctx, "model: %s", TruncateString(strings.ReplaceAll(mergedContent, "\n", " "), 200))
@@ -695,7 +695,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 			stop, updated := grace.handleEditDeadline(ctx, messages)
 			messages = updated
 			if stop {
-				return lastContent, messages, ErrEditDeadlineReached, false
+				return lastContent, messages, ErrEditDeadlineReached
 			}
 		}
 
@@ -709,12 +709,12 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		postResult := trackPostExecution(ctx, messages, mergedToolCalls, editEnforcer, phaseEnforcer, &loopDetector, &grace, cacheSizeBefore)
 		if postResult.stuck {
 			logging.InfoContext(ctx, "loop detected: agent repeating identical tool calls with same results, stopping")
-			return lastContent, messages, ErrLoopDetected, false
+			return lastContent, messages, ErrLoopDetected
 		}
 
 		if m != nil && m.BudgetExceeded() {
 			logging.InfoContext(ctx, "budget exceeded ($%.4f >= $%.4f max), stopping tool loop", m.TotalCostWithChildren(), m.MaxCost)
-			return lastContent, messages, metrics.ErrBudgetExceeded, false
+			return lastContent, messages, metrics.ErrBudgetExceeded
 		}
 
 		toolNames := extractToolNames(mergedToolCalls)
@@ -727,7 +727,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		messages = rollingCompact(ctx, messages, i)
 		messages = compactMessages(ctx, messages, m)
 	}
-	return lastContent, messages, ErrIterationLimitReached, false
+	return lastContent, messages, ErrIterationLimitReached
 }
 
 // isEmptyResponse reports whether the model returned no usable content.

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2428,7 +2428,7 @@ func TestToolLoopBudgetWarnings(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, _ := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
+	_, _, loopErr := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
 	// Budget may be exceeded after iter 2 — that's fine, we just care that
 	// warnings were injected before that happened.
 	if loopErr != nil && !errors.Is(loopErr, metrics.ErrBudgetExceeded) {
@@ -2490,12 +2490,9 @@ func TestToolLoopNoBudgetWarningsWithoutMaxCost(t *testing.T) {
 
 	handlers, _ := BuildHandlers(dir, nil, &executor.LocalExecutor{WorkingDir: dir})
 
-	_, _, loopErr, done := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
+	_, _, loopErr := toolLoop(context.Background(), llm, buildInitialMessages("sys", "user", false), handlers, 10, RunWithToolsConfig{Metrics: m}, nil)
 	if loopErr != nil {
 		t.Fatalf("unexpected error: %v", loopErr)
-	}
-	if !done {
-		t.Fatal("expected done=true")
 	}
 
 	for _, msgs := range llm.captured {


### PR DESCRIPTION
  Key Changes:

  - ResolveModelPrecedence now returns a ModelResolution struct instead of a bare warning string, so callers can apply model, provider, and base URL without relying on side effects
  - Config-specified defaults now take priority over agent manifest models even when not listed as a preferred model — a warning is emitted but execution continues with the
  configured value
  - New test coverage for budget-exceeded handling, manifest isolation field extraction, multi-model agent selection, and child iteration cap precedence

  Added:

  - ModelResolution struct in runner/run.go with Model, Provider, BaseURL, and Warning fields to replace the single warning string return from ResolveModelPrecedence
  - TestBuildLLMOpenAICompatNoAPIKey dedicated test for OpenAI-compat construction failure when no API key is set - runner/model_test.go
  - TestApplyChildIterationCap with six cases verifying three-layer precedence for child iteration caps - runner/run_test.go
  - TestHandleBudgetExceeded covering non-budget error, empty response, and partial output scenarios - runner/run_test.go
  - TestManifestIsolation with four scenarios validating isolation field extraction from agent manifests - runner/run_test.go
  - TestSanitizeForBranch and TestReportIsolationTeardown for branch name sanitization and worktree teardown output - runner/isolation_test.go
  - Comprehensive doc comments across runner/apply.go, runner/isolation.go, runner/model.go, and runner/run.go

  Changed:

  - ResolveModelPrecedence return type changed from string to ModelResolution; call sites in cmd/squad/pipeline.go and runner/run.go now explicitly assign res.Model, res.Provider,
  and res.BaseURL to agent options
  - Model precedence behavior: when a config default is not listed as a preferred manifest model, execution continues with the config value (warning: "not a preferred model for
  this agent") rather than falling back to the manifest model
  - ExecuteRun switched to a named return (runErr error) for cleaner deferred error handling
  - TestResolveModelPrecedenceBaseURL and TestPrepareBundleManifestModelProvider updated to assert against the new struct fields and revised warning messages
  - TestResolveWorkingDir refactored to table-driven style with shared cwd/tmp setup