### PR TITLE
fix: make model selection credential-aware

### DIFF
--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -88,7 +88,11 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 		agentOpts.Findings = pipelineRunner.Findings
 		agentOpts.AgentName = agentName
 
-		if warn := runner.ResolveModelPrecedence(ctx, &agentOpts, bundle); warn != "" {
+		warn, resolveErr := runner.ResolveModelPrecedence(ctx, &agentOpts, bundle)
+		if resolveErr != nil {
+			return "", nil, resolveErr
+		}
+		if warn != "" {
 			fmt.Fprintln(os.Stderr, warn)
 		}
 

--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -39,10 +39,6 @@ var providerAPIKeyEnv = map[string][]string{
 	"openai-compat":    {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
 	"anthropic":        {"ANTHROPIC_API_KEY"},
 	"gemini":           {"GOOGLE_API_KEY"},
-	// Deprecated shims (see runner/model.go): both redirect to openai-compat
-	// and use the same env-var fallback chain.
-	"nvidia":     {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
-	"databricks": {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
 }
 
 // KeyStatus mirrors provider token precedence used by the runner: an

--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -30,18 +30,24 @@ type APIKeyStatus struct {
 	Source APIKeySource
 }
 
-var providerAPIKeyEnv = map[string]string{
-	"openai":           "OPENAI_API_KEY",
-	"openai-responses": "OPENAI_API_KEY",
-	"anthropic":        "ANTHROPIC_API_KEY",
-	"gemini":           "GOOGLE_API_KEY",
-	"nvidia":           "NVIDIA_API_KEY",
-	"databricks":       "DATABRICKS_TOKEN",
+// providerAPIKeyEnv lists env vars checked for each provider, in the same
+// order the runner consults them (see runner/model.go). The first entry is
+// the canonical name reported back to callers for display.
+var providerAPIKeyEnv = map[string][]string{
+	"openai":           {"OPENAI_API_KEY"},
+	"openai-responses": {"OPENAI_API_KEY"},
+	"openai-compat":    {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
+	"anthropic":        {"ANTHROPIC_API_KEY"},
+	"gemini":           {"GOOGLE_API_KEY"},
+	// Deprecated shims (see runner/model.go): both redirect to openai-compat
+	// and use the same env-var fallback chain.
+	"nvidia":     {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
+	"databricks": {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
 }
 
 // KeyStatus mirrors provider token precedence used by the runner: an
-// explicitly resolved provider.token wins, then the provider-specific env var.
-// Ollama is local and does not need an API key.
+// explicitly resolved provider.token wins, then the provider-specific env
+// var(s). Ollama is local and does not need an API key.
 func KeyStatus(provider, providerToken string) APIKeyStatus {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	if provider == "" {
@@ -50,15 +56,18 @@ func KeyStatus(provider, providerToken string) APIKeyStatus {
 	if provider == "ollama" {
 		return APIKeyStatus{State: APIKeyNotNeeded, Source: APIKeySourceNone}
 	}
-	envVar, ok := providerAPIKeyEnv[provider]
-	if !ok {
+	envVars, ok := providerAPIKeyEnv[provider]
+	if !ok || len(envVars) == 0 {
 		return APIKeyStatus{State: APIKeyNotNeeded, Source: APIKeySourceNone}
 	}
+	canonical := envVars[0]
 	if strings.TrimSpace(providerToken) != "" {
-		return APIKeyStatus{State: APIKeyOK, EnvVar: envVar, Source: APIKeySourceConfig}
+		return APIKeyStatus{State: APIKeyOK, EnvVar: canonical, Source: APIKeySourceConfig}
 	}
-	if os.Getenv(envVar) != "" {
-		return APIKeyStatus{State: APIKeyOK, EnvVar: envVar, Source: APIKeySourceEnv}
+	for _, env := range envVars {
+		if os.Getenv(env) != "" {
+			return APIKeyStatus{State: APIKeyOK, EnvVar: env, Source: APIKeySourceEnv}
+		}
 	}
-	return APIKeyStatus{State: APIKeyMissing, EnvVar: envVar, Source: APIKeySourceNone}
+	return APIKeyStatus{State: APIKeyMissing, EnvVar: canonical, Source: APIKeySourceNone}
 }

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -13,10 +13,6 @@ func TestKeyStatusProviderEnvTable(t *testing.T) {
 		{"openai-compat", "OPENAI_COMPAT_API_KEY"},
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"gemini", "GOOGLE_API_KEY"},
-		// Deprecated shims redirect to openai-compat and report its
-		// canonical env var, since that is the var actually consulted.
-		{"nvidia", "OPENAI_COMPAT_API_KEY"},
-		{"databricks", "OPENAI_COMPAT_API_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.provider, func(t *testing.T) {

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -10,19 +10,42 @@ func TestKeyStatusProviderEnvTable(t *testing.T) {
 		{"", "OPENAI_API_KEY"},
 		{"openai", "OPENAI_API_KEY"},
 		{"openai-responses", "OPENAI_API_KEY"},
+		{"openai-compat", "OPENAI_COMPAT_API_KEY"},
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"gemini", "GOOGLE_API_KEY"},
-		{"nvidia", "NVIDIA_API_KEY"},
-		{"databricks", "DATABRICKS_TOKEN"},
+		// Deprecated shims redirect to openai-compat and report its
+		// canonical env var, since that is the var actually consulted.
+		{"nvidia", "OPENAI_COMPAT_API_KEY"},
+		{"databricks", "OPENAI_COMPAT_API_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.provider, func(t *testing.T) {
-			t.Setenv(tc.envVar, "")
+			t.Setenv("OPENAI_API_KEY", "")
+			t.Setenv("OPENAI_COMPAT_API_KEY", "")
+			t.Setenv("ANTHROPIC_API_KEY", "")
+			t.Setenv("GOOGLE_API_KEY", "")
 			got := KeyStatus(tc.provider, "")
 			if got.State != APIKeyMissing || got.EnvVar != tc.envVar || got.Source != APIKeySourceNone {
 				t.Fatalf("KeyStatus(%q) = %+v, want missing %s from none", tc.provider, got, tc.envVar)
 			}
 		})
+	}
+}
+
+func TestKeyStatusOpenAICompatFallback(t *testing.T) {
+	// Compat-specific var wins when both are set.
+	t.Setenv("OPENAI_COMPAT_API_KEY", "compat-token")
+	t.Setenv("OPENAI_API_KEY", "openai-token")
+	got := KeyStatus("openai-compat", "")
+	if got.State != APIKeyOK || got.EnvVar != "OPENAI_COMPAT_API_KEY" || got.Source != APIKeySourceEnv {
+		t.Fatalf("compat-specific env should win: got %+v", got)
+	}
+
+	// Falls back to OPENAI_API_KEY when compat-specific is unset.
+	t.Setenv("OPENAI_COMPAT_API_KEY", "")
+	got = KeyStatus("openai-compat", "")
+	if got.State != APIKeyOK || got.EnvVar != "OPENAI_API_KEY" || got.Source != APIKeySourceEnv {
+		t.Fatalf("fallback to OPENAI_API_KEY: got %+v", got)
 	}
 }
 

--- a/runner/isolation_test.go
+++ b/runner/isolation_test.go
@@ -46,6 +46,7 @@ func TestResolveIsolationMode(t *testing.T) {
 }
 
 func TestPrepareIsolationNonGitFallsBack(t *testing.T) {
+	scrubGitEnv(t)
 	dir := t.TempDir()
 	iso, err := PrepareIsolation(context.Background(), dir, IsolationWorktree, "agent")
 	if err != nil {
@@ -363,9 +364,40 @@ func stashCount(t *testing.T, dir string) int {
 	return strings.Count(s, "\n") + 1
 }
 
+// scrubGitEnv unsets GIT_* environment variables for the duration of the
+// test. When the test suite runs inside an outer git operation (notably
+// `pre-commit run` during `git commit`), git sets GIT_INDEX_FILE / GIT_DIR /
+// etc. to point at the parent repo. Child git invocations inside these tests
+// inherit those values and fail with confusing errors like
+// `.git/index: index file open failed: Not a directory`.
+func scrubGitEnv(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		"GIT_INDEX_FILE",
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_PREFIX",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_COMMON_DIR",
+	}
+	saved := make(map[string]string, len(vars))
+	for _, k := range vars {
+		if v, ok := os.LookupEnv(k); ok {
+			saved[k] = v
+			_ = os.Unsetenv(k)
+		}
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			_ = os.Setenv(k, v)
+		}
+	})
+}
+
 // initGitRepo creates a fresh git repo with one commit and returns its path.
 func initGitRepo(t *testing.T) string {
 	t.Helper()
+	scrubGitEnv(t)
 	dir := t.TempDir()
 	run := func(args ...string) {
 		cmd := exec.Command(args[0], args[1:]...)

--- a/runner/run.go
+++ b/runner/run.go
@@ -233,69 +233,219 @@ func printMetrics(cmd *cobra.Command, m *metrics.Metrics) error {
 	return err
 }
 
-// ResolveModelPrecedence fills opts.Model and opts.Provider using the
-// precedence: explicit (CLI flag / routine field) > config default (when
-// supported by the manifest) > manifest first model > config default.
-// Already-set fields are preserved. Returns a non-empty warning string when
-// the config default is set but not listed in the agent manifest; callers
-// should display this to the user on stderr.
-func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) string {
+// ResolveModelPrecedence selects the model/provider for this run by walking,
+// in order:
+//
+//  1. Explicit caller intent (opts.Model from a CLI flag or routine field).
+//     Always wins.
+//  2. Config default (opts.ConfigModel / opts.ConfigProvider) when the user
+//     has credentials for that provider. The config model may sit outside the
+//     agent manifest's models: list — that earns a warning, but the user's
+//     explicit intent is honoured because credentials, cost ceilings, and
+//     provider routing only live in the user's config.
+//  3. Manifest models walked in ranked order: the first entry with
+//     credentials wins. Skipping the top-ranked entry due to a missing key
+//     also earns a warning so the user knows they fell off the preferred
+//     path.
+//  4. As a last resort, the config default is used without credentials (with
+//     a strong warning that the call will likely fail). If even that is
+//     unavailable, a non-nil error is returned listing the env vars that
+//     would unblock the run.
+//
+// Returns (warning, error). Callers should display the warning on stderr when
+// non-empty and abort on a non-nil error.
+func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (string, error) {
 	if opts == nil || bundle == nil {
-		return ""
+		return "", nil
 	}
+	if opts.Model != "" {
+		applyExplicitModel(opts, bundle)
+		return "", nil
+	}
+	if warn, ok := applyConfigDefault(ctx, opts, bundle); ok {
+		return warn, nil
+	}
+	warn, picked, skipped := walkManifestForCreds(ctx, opts, bundle)
+	if picked {
+		return warn, nil
+	}
+	if opts.ConfigModel != "" {
+		return applyConfigDefaultUnauthenticated(ctx, opts, bundle), nil
+	}
+	if err := noCredentialsError(skipped); err != nil {
+		return "", err
+	}
+	applyLegacyBundleFallback(opts, bundle)
+	return "", nil
+}
 
-	var warn string
-	if opts.Model == "" {
-		configMatch := bundle.FindModel(opts.ConfigProvider, opts.ConfigModel)
-
-		switch {
-		case configMatch != nil:
-			// Config default is supported by this agent — use it; provider is also set.
-			opts.Model = configMatch.Model
-			opts.Provider = configMatch.Provider
-			if opts.BaseURL == "" {
-				opts.BaseURL = configMatch.BaseURL
+// applyExplicitModel handles rule 1: opts.Model was set explicitly. Fill in
+// Provider and BaseURL from the manifest match (preferred), bundle primary,
+// or config, without overriding values the caller already set.
+func applyExplicitModel(opts *RunOptions, bundle *agent.Bundle) {
+	if opts.Provider == "" {
+		for i := range bundle.Models {
+			if bundle.Models[i].Model != opts.Model {
+				continue
 			}
-			logging.InfoContext(ctx, "using config default model: %s (%s)", opts.Model, opts.Provider)
-			return ""
-
-		case opts.ConfigModel != "" && bundle.Model != "":
-			// Config default exists but is not in the manifest — warn and fall back.
-			warn = fmt.Sprintf(
-				"⚠  Config default model %q (%s) is not listed in the agent manifest.\n"+
-					"   Add it to the agent's models: list to avoid this fallback.\n"+
-					"   Falling back to manifest model %q (%s).",
-				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
-			logging.WarnContext(ctx, "config default model %q (%s) is not listed in agent manifest; falling back to manifest model %q (%s)",
-				opts.ConfigModel, opts.ConfigProvider, bundle.Model, bundle.Provider)
-			opts.Model = bundle.Model
-
-		case bundle.Model != "":
-			opts.Model = bundle.Model
-			logging.InfoContext(ctx, "using manifest model: %s", bundle.Model)
-
-		case opts.ConfigModel != "":
-			opts.Model = opts.ConfigModel
-			logging.InfoContext(ctx, "using config model: %s", opts.ConfigModel)
+			opts.Provider = bundle.Models[i].Provider
+			if opts.BaseURL == "" {
+				opts.BaseURL = bundle.Models[i].BaseURL
+			}
+			break
 		}
 	}
-
 	if opts.Provider == "" {
 		switch {
 		case bundle.Provider != "":
 			opts.Provider = bundle.Provider
-			logging.InfoContext(ctx, "using manifest provider: %s", bundle.Provider)
 		case opts.ConfigProvider != "":
 			opts.Provider = opts.ConfigProvider
-			logging.InfoContext(ctx, "using config provider: %s", opts.ConfigProvider)
 		}
 	}
-
 	if opts.BaseURL == "" && bundle.BaseURL != "" {
 		opts.BaseURL = bundle.BaseURL
 	}
+}
 
-	return warn
+// applyConfigDefault handles rule 2: use the config default when its provider
+// has detected credentials. Returns (warn, true) when the config default was
+// applied; (",", false) when caller should fall through to manifest walk.
+func applyConfigDefault(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (string, bool) {
+	if opts.ConfigModel == "" {
+		return "", false
+	}
+	if metrics.KeyStatus(opts.ConfigProvider, opts.APIKey).State == metrics.APIKeyMissing {
+		return "", false
+	}
+	opts.Model = opts.ConfigModel
+	if opts.Provider == "" {
+		opts.Provider = opts.ConfigProvider
+	}
+	match := bundle.FindModel(opts.Provider, opts.Model)
+	fillBaseURL(opts, match, bundle)
+	if match == nil && len(bundle.Models) > 0 {
+		logging.WarnContext(ctx, "config default model %q (%s) is not listed in agent manifest; proceeding with config default", opts.Model, opts.Provider)
+		warn := fmt.Sprintf(
+			"⚠  Config default model %q (%s) is not listed in the agent manifest's models: list.\n"+
+				"   Proceeding with the config default; add it to the manifest's models: list to silence this warning.",
+			opts.Model, opts.Provider)
+		return warn, true
+	}
+	logging.InfoContext(ctx, "using config default model: %s (%s)", opts.Model, opts.Provider)
+	return "", true
+}
+
+// walkManifestForCreds handles rule 3: scan manifest models in rank order and
+// pick the first one whose provider has detected credentials. Returns
+// (warning, picked, skipped). When picked is false, skipped contains every
+// manifest entry that lacked credentials so the caller can build an error.
+func walkManifestForCreds(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (string, bool, []agent.ModelPreference) {
+	var skipped []agent.ModelPreference
+	for i := range bundle.Models {
+		candidate := bundle.Models[i]
+		if metrics.KeyStatus(candidate.Provider, opts.APIKey).State == metrics.APIKeyMissing {
+			skipped = append(skipped, candidate)
+			continue
+		}
+		opts.Model = candidate.Model
+		if opts.Provider == "" {
+			opts.Provider = candidate.Provider
+		}
+		if opts.BaseURL == "" {
+			opts.BaseURL = candidate.BaseURL
+		}
+		if opts.BaseURL == "" && bundle.BaseURL != "" {
+			opts.BaseURL = bundle.BaseURL
+		}
+		if len(skipped) == 0 {
+			logging.InfoContext(ctx, "using manifest model: %s (%s)", opts.Model, opts.Provider)
+			return "", true, nil
+		}
+		top := skipped[0]
+		topEnv := metrics.KeyStatus(top.Provider, "").EnvVar
+		logging.WarnContext(ctx, "manifest top model %q (%s) lacks credentials; using %q (%s) instead", top.Model, top.Provider, opts.Model, opts.Provider)
+		warn := fmt.Sprintf(
+			"⚠  Manifest's preferred model %q (%s) has no detected credentials; using %q (%s) instead.\n"+
+				"   Set %s to use the agent's preferred model.",
+			top.Model, top.Provider, opts.Model, opts.Provider, topEnv)
+		return warn, true, nil
+	}
+	return "", false, skipped
+}
+
+// applyConfigDefaultUnauthenticated handles rule 4a: nothing in the manifest
+// had credentials, but a config default exists — proceed with it so the user
+// sees a clear "auth will fail" warning rather than a silent override.
+func applyConfigDefaultUnauthenticated(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) string {
+	opts.Model = opts.ConfigModel
+	if opts.Provider == "" {
+		opts.Provider = opts.ConfigProvider
+	}
+	match := bundle.FindModel(opts.Provider, opts.Model)
+	fillBaseURL(opts, match, bundle)
+	logging.WarnContext(ctx, "no provider has detected credentials; proceeding with config default %q (%s)", opts.Model, opts.Provider)
+	return fmt.Sprintf(
+		"⚠  No provider has detected credentials. Proceeding with config default %q (%s);\n"+
+			"   the model call will likely fail authentication. Set the relevant API key to fix.",
+		opts.Model, opts.Provider)
+}
+
+// noCredentialsError handles rule 4b: manifest had entries but none had
+// credentials, and there is no config default. Returns an error listing the
+// env vars that would unblock the run, or nil if there is nothing to report.
+func noCredentialsError(skipped []agent.ModelPreference) error {
+	if len(skipped) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	envs := make([]string, 0, len(skipped))
+	for _, m := range skipped {
+		env := metrics.KeyStatus(m.Provider, "").EnvVar
+		if env == "" || seen[env] {
+			continue
+		}
+		seen[env] = true
+		envs = append(envs, env)
+	}
+	if len(envs) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"no provider in agent manifest has credentials configured; set one of: %s",
+		strings.Join(envs, ", "))
+}
+
+// applyLegacyBundleFallback preserves the pre-credential-aware behaviour for
+// the edge case of an empty manifest where the bundle still has Model /
+// Provider / BaseURL populated directly. Production bundles built by
+// BuildBundle always co-populate Models, so this only triggers on synthetic
+// bundles used by early-exit / dry-run callers and tests.
+func applyLegacyBundleFallback(opts *RunOptions, bundle *agent.Bundle) {
+	if opts.Model == "" && bundle.Model != "" {
+		opts.Model = bundle.Model
+	}
+	if opts.Provider == "" && bundle.Provider != "" {
+		opts.Provider = bundle.Provider
+	}
+	if opts.BaseURL == "" && bundle.BaseURL != "" {
+		opts.BaseURL = bundle.BaseURL
+	}
+}
+
+// fillBaseURL sets opts.BaseURL from the manifest match (preferred) or the
+// bundle's primary BaseURL, leaving an explicit caller-set BaseURL alone.
+func fillBaseURL(opts *RunOptions, match *agent.ModelPreference, bundle *agent.Bundle) {
+	if opts.BaseURL != "" {
+		return
+	}
+	if match != nil && match.BaseURL != "" {
+		opts.BaseURL = match.BaseURL
+		return
+	}
+	if bundle.BaseURL != "" {
+		opts.BaseURL = bundle.BaseURL
+	}
 }
 
 // prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
@@ -313,7 +463,11 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, err
 	}
 
-	if warn := ResolveModelPrecedence(cmd.Context(), opts, bundle); warn != "" {
+	warn, resolveErr := ResolveModelPrecedence(cmd.Context(), opts, bundle)
+	if resolveErr != nil {
+		return nil, resolveErr
+	}
+	if warn != "" {
 		if _, fmtErr := fmt.Fprintln(cmd.ErrOrStderr(), warn); fmtErr != nil {
 			logging.Warn("failed to write model warning: %v", fmtErr)
 		}

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -415,12 +415,12 @@ func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	t.Parallel()
 	// Calling with either argument nil must be a no-op rather than a panic;
 	// pipeline code passes a bundle that may be nil on early-exit paths.
-	ResolveModelPrecedence(context.Background(), nil, nil)
-	ResolveModelPrecedence(context.Background(), &RunOptions{}, nil)
-	ResolveModelPrecedence(context.Background(), nil, &agent.Bundle{})
+	_, _ = ResolveModelPrecedence(context.Background(), nil, nil)
+	_, _ = ResolveModelPrecedence(context.Background(), &RunOptions{}, nil)
+	_, _ = ResolveModelPrecedence(context.Background(), nil, &agent.Bundle{})
 
 	opts := &RunOptions{Model: "preset", Provider: "preset"}
-	ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
+	_, _ = ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
 	if opts.Model != "preset" || opts.Provider != "preset" {
 		t.Fatalf("explicit values must win over manifest: Model=%q Provider=%q", opts.Model, opts.Provider)
 	}
@@ -441,7 +441,7 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
+		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
 		if opts.BaseURL != compatURL {
 			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
 		}
@@ -456,7 +456,7 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
+		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
 		if opts.BaseURL != explicit {
 			t.Fatalf("BaseURL = %q, want explicit %q", opts.BaseURL, explicit)
 		}
@@ -477,12 +477,100 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 				},
 			},
 		}
-		ResolveModelPrecedence(context.Background(), opts, bundle)
+		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
 		if opts.BaseURL != compatURL {
 			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
 		}
 		if opts.Provider != "openai-compat" {
 			t.Fatalf("Provider = %q, want openai-compat", opts.Provider)
+		}
+	})
+}
+
+// TestResolveModelPrecedenceCredentialAware exercises the credential-aware
+// manifest walk: when the manifest's top-ranked entry lacks credentials, the
+// resolver walks down the ranked list and surfaces a warning. When nothing
+// has credentials, it returns an error listing env vars that would unblock.
+//
+// These tests cannot run in parallel because they mutate process env vars.
+func TestResolveModelPrecedenceCredentialAware(t *testing.T) {
+	t.Run("walks past uncredentialed top to next ranked entry", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("GOOGLE_API_KEY", "gemini-key")
+		t.Setenv("OPENAI_API_KEY", "")
+		opts := &RunOptions{}
+		bundle := &agent.Bundle{
+			Model:    "claude-sonnet-4-6",
+			Provider: "anthropic",
+			Models: []agent.ModelPreference{
+				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+				{Model: "gemini-2.5-flash", Provider: "gemini"},
+				{Model: "gpt-4.1-mini", Provider: "openai"},
+			},
+		}
+		warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Model != "gemini-2.5-flash" || opts.Provider != "gemini" {
+			t.Fatalf("expected gemini-2.5-flash/gemini, got %q/%q", opts.Model, opts.Provider)
+		}
+		if !strings.Contains(warn, "ANTHROPIC_API_KEY") {
+			t.Fatalf("expected warning to name ANTHROPIC_API_KEY, got %q", warn)
+		}
+	})
+
+	t.Run("errors when no manifest provider has credentials", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("GOOGLE_API_KEY", "")
+		t.Setenv("OPENAI_API_KEY", "")
+		opts := &RunOptions{}
+		bundle := &agent.Bundle{
+			Model:    "claude-sonnet-4-6",
+			Provider: "anthropic",
+			Models: []agent.ModelPreference{
+				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+				{Model: "gpt-4.1-mini", Provider: "openai"},
+			},
+		}
+		_, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if err == nil {
+			t.Fatal("expected error when no provider has credentials")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "ANTHROPIC_API_KEY") || !strings.Contains(msg, "OPENAI_API_KEY") {
+			t.Fatalf("expected error to list missing env vars, got %q", msg)
+		}
+	})
+
+	t.Run("config default with provider token wins over manifest top", func(t *testing.T) {
+		// The user's primary use case: openai-compat with a custom hosted
+		// model (e.g. Qwen via Together AI). The model is not in the agent
+		// manifest, but the user has expressed explicit intent in config
+		// and supplied a token. Config wins; warning is emitted.
+		t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+		opts := &RunOptions{
+			APIKey:         "compat-token",
+			ConfigProvider: "openai-compat",
+			ConfigModel:    "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
+			BaseURL:        "https://api.together.xyz/v1",
+		}
+		bundle := &agent.Bundle{
+			Model:    "claude-sonnet-4-6",
+			Provider: "anthropic",
+			Models: []agent.ModelPreference{
+				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			},
+		}
+		warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Model != "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo" || opts.Provider != "openai-compat" {
+			t.Fatalf("expected config default to win, got %q (%q)", opts.Model, opts.Provider)
+		}
+		if !strings.Contains(warn, "not listed in the agent manifest") {
+			t.Fatalf("expected outside-manifest warning, got %q", warn)
 		}
 	})
 }
@@ -521,8 +609,12 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
 	})
 
-	t.Run("manifest wins over config defaults", func(t *testing.T) {
+	t.Run("config default wins over manifest when it has credentials", func(t *testing.T) {
 		t.Parallel()
+		// Config default expresses explicit user intent (where keys, cost
+		// ceilings, and provider routing actually live), so it beats the
+		// manifest's preferred model. The unknown "config-provider" is
+		// treated as not-missing by KeyStatus, satisfying the creds gate.
 		agentsDir := writeTestAgentWithModels(t, "manifest-vs-config", "manifest-model", "manifest-provider")
 		opts := &RunOptions{
 			Agent:          "manifest-vs-config",
@@ -533,7 +625,7 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 			PrintBundle:    true,
 			BundleOut:      filepath.Join(t.TempDir(), "bundle.txt"),
 		}
-		runAndAssertBundle(t, opts, "manifest-model", "manifest-provider")
+		runAndAssertBundle(t, opts, "config-model", "config-provider")
 	})
 
 	t.Run("config defaults fill in when manifest is silent", func(t *testing.T) {
@@ -582,8 +674,11 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		runAndAssertBundle(t, opts, "cli-model", "cli-provider")
 	})
 
-	t.Run("config default not in manifest emits warning to stderr", func(t *testing.T) {
+	t.Run("config default outside manifest proceeds with warning", func(t *testing.T) {
 		t.Parallel()
+		// Config default is outside the manifest's models: list. The user's
+		// explicit intent wins — we proceed with the config model and warn
+		// rather than overriding the user's choice with the manifest.
 		agentsDir := writeTestAgentWithModels(t, "warn-fallback", "manifest-model", "manifest-provider")
 		opts := &RunOptions{
 			Agent:          "warn-fallback",
@@ -602,8 +697,8 @@ func TestPrepareBundleManifestModelProvider(t *testing.T) {
 		if _, err := prepareBundle(cmd, opts, "prompt", t.TempDir()); err != nil {
 			t.Fatalf("prepareBundle() error = %v", err)
 		}
-		if opts.Model != "manifest-model" || opts.Provider != "manifest-provider" {
-			t.Fatalf("expected fallback to manifest, got Model=%q Provider=%q", opts.Model, opts.Provider)
+		if opts.Model != "other-model" || opts.Provider != "other-provider" {
+			t.Fatalf("expected config default to win, got Model=%q Provider=%q", opts.Model, opts.Provider)
 		}
 		if !strings.Contains(stderr.String(), "not listed in the agent manifest") {
 			t.Fatalf("expected warning on stderr, got %q", stderr.String())

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -487,92 +487,204 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 	})
 }
 
-// TestResolveModelPrecedenceCredentialAware exercises the credential-aware
-// manifest walk: when the manifest's top-ranked entry lacks credentials, the
-// resolver walks down the ranked list and surfaces a warning. When nothing
-// has credentials, it returns an error listing env vars that would unblock.
-//
-// These tests cannot run in parallel because they mutate process env vars.
-func TestResolveModelPrecedenceCredentialAware(t *testing.T) {
-	t.Run("walks past uncredentialed top to next ranked entry", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_API_KEY", "")
-		t.Setenv("GOOGLE_API_KEY", "gemini-key")
-		t.Setenv("OPENAI_API_KEY", "")
-		opts := &RunOptions{}
-		bundle := &agent.Bundle{
-			Model:    "claude-sonnet-4-6",
-			Provider: "anthropic",
-			Models: []agent.ModelPreference{
-				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
-				{Model: "gemini-2.5-flash", Provider: "gemini"},
-				{Model: "gpt-4.1-mini", Provider: "openai"},
-			},
-		}
-		warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if opts.Model != "gemini-2.5-flash" || opts.Provider != "gemini" {
-			t.Fatalf("expected gemini-2.5-flash/gemini, got %q/%q", opts.Model, opts.Provider)
-		}
-		if !strings.Contains(warn, "ANTHROPIC_API_KEY") {
-			t.Fatalf("expected warning to name ANTHROPIC_API_KEY, got %q", warn)
-		}
-	})
+// The TestResolveModelPrecedence_* family exercises the credential-aware
+// resolver: a missing API key on the manifest's top-ranked entry should make
+// the resolver walk down the list, surfacing a warning. When nothing has
+// credentials, the resolver returns an error naming the env vars that would
+// unblock the run. These tests mutate process env vars and therefore do not
+// run in parallel.
 
-	t.Run("errors when no manifest provider has credentials", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_API_KEY", "")
-		t.Setenv("GOOGLE_API_KEY", "")
-		t.Setenv("OPENAI_API_KEY", "")
-		opts := &RunOptions{}
-		bundle := &agent.Bundle{
-			Model:    "claude-sonnet-4-6",
-			Provider: "anthropic",
-			Models: []agent.ModelPreference{
-				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
-				{Model: "gpt-4.1-mini", Provider: "openai"},
-			},
-		}
-		_, err := ResolveModelPrecedence(context.Background(), opts, bundle)
-		if err == nil {
-			t.Fatal("expected error when no provider has credentials")
-		}
-		msg := err.Error()
-		if !strings.Contains(msg, "ANTHROPIC_API_KEY") || !strings.Contains(msg, "OPENAI_API_KEY") {
-			t.Fatalf("expected error to list missing env vars, got %q", msg)
-		}
-	})
+func TestResolveModelPrecedence_WalksPastUncredentialedTop(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "gemini-key")
+	t.Setenv("OPENAI_API_KEY", "")
+	opts := &RunOptions{}
+	bundle := &agent.Bundle{
+		Model:    "claude-sonnet-4-6",
+		Provider: "anthropic",
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			{Model: "gemini-2.5-flash", Provider: "gemini"},
+			{Model: "gpt-4.1-mini", Provider: "openai"},
+		},
+	}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Model != "gemini-2.5-flash" || opts.Provider != "gemini" {
+		t.Fatalf("expected gemini-2.5-flash/gemini, got %q/%q", opts.Model, opts.Provider)
+	}
+	if !strings.Contains(warn, "ANTHROPIC_API_KEY") {
+		t.Fatalf("expected warning to name ANTHROPIC_API_KEY, got %q", warn)
+	}
+}
 
-	t.Run("config default with provider token wins over manifest top", func(t *testing.T) {
-		// The user's primary use case: openai-compat with a custom hosted
-		// model (e.g. Qwen via Together AI). The model is not in the agent
-		// manifest, but the user has expressed explicit intent in config
-		// and supplied a token. Config wins; warning is emitted.
-		t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
-		opts := &RunOptions{
-			APIKey:         "compat-token",
-			ConfigProvider: "openai-compat",
-			ConfigModel:    "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
-			BaseURL:        "https://api.together.xyz/v1",
-		}
-		bundle := &agent.Bundle{
-			Model:    "claude-sonnet-4-6",
-			Provider: "anthropic",
-			Models: []agent.ModelPreference{
-				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
-			},
-		}
-		warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if opts.Model != "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo" || opts.Provider != "openai-compat" {
-			t.Fatalf("expected config default to win, got %q (%q)", opts.Model, opts.Provider)
-		}
-		if !strings.Contains(warn, "not listed in the agent manifest") {
-			t.Fatalf("expected outside-manifest warning, got %q", warn)
-		}
-	})
+func TestResolveModelPrecedence_ErrorsWhenNoManifestProviderHasCreds(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	opts := &RunOptions{}
+	bundle := &agent.Bundle{
+		Model:    "claude-sonnet-4-6",
+		Provider: "anthropic",
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			{Model: "gpt-4.1-mini", Provider: "openai"},
+		},
+	}
+	_, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err == nil {
+		t.Fatal("expected error when no provider has credentials")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ANTHROPIC_API_KEY") || !strings.Contains(msg, "OPENAI_API_KEY") {
+		t.Fatalf("expected error to list missing env vars, got %q", msg)
+	}
+}
+
+func TestResolveModelPrecedence_ExplicitModelFillsFromManifestMatch(t *testing.T) {
+	opts := &RunOptions{Model: "gemini-2.5-flash"}
+	bundle := &agent.Bundle{
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+			{Model: "gemini-2.5-flash", Provider: "gemini", BaseURL: "https://gemini.example/v1"},
+		},
+	}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil || warn != "" {
+		t.Fatalf("unexpected warn=%q err=%v", warn, err)
+	}
+	if opts.Provider != "gemini" {
+		t.Fatalf("Provider = %q, want gemini", opts.Provider)
+	}
+	if opts.BaseURL != "https://gemini.example/v1" {
+		t.Fatalf("BaseURL = %q, want propagated from manifest match", opts.BaseURL)
+	}
+}
+
+// Bundle has no matching Models entry — Provider should come from
+// bundle.Provider, and only fall back to ConfigProvider when the bundle has
+// nothing either.
+func TestResolveModelPrecedence_ExplicitModelFallsBackToBundleProvider(t *testing.T) {
+	opts := &RunOptions{Model: "custom-model", ConfigProvider: "fallback-config"}
+	bundle := &agent.Bundle{Provider: "bundle-primary", BaseURL: "https://bundle.example/v1"}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil || warn != "" {
+		t.Fatalf("unexpected warn=%q err=%v", warn, err)
+	}
+	if opts.Provider != "bundle-primary" {
+		t.Fatalf("Provider = %q, want bundle-primary (bundle.Provider wins over config)", opts.Provider)
+	}
+	if opts.BaseURL != "https://bundle.example/v1" {
+		t.Fatalf("BaseURL = %q, want propagated from bundle.BaseURL", opts.BaseURL)
+	}
+}
+
+func TestResolveModelPrecedence_ExplicitModelFallsBackToConfigProvider(t *testing.T) {
+	opts := &RunOptions{Model: "custom-model", ConfigProvider: "fallback-config"}
+	bundle := &agent.Bundle{} // empty bundle
+	if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Provider != "fallback-config" {
+		t.Fatalf("Provider = %q, want fallback-config (config last-resort)", opts.Provider)
+	}
+}
+
+// Config default with creds, model not in manifest, bundle has a primary
+// BaseURL — fillBaseURL should propagate that BaseURL.
+func TestResolveModelPrecedence_ConfigOutsideManifestInheritsBundleBaseURL(t *testing.T) {
+	t.Setenv("OPENAI_COMPAT_API_KEY", "compat-token")
+	opts := &RunOptions{
+		ConfigProvider: "openai-compat",
+		ConfigModel:    "outside-manifest-model",
+	}
+	bundle := &agent.Bundle{
+		BaseURL: "https://primary.example/v1",
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+	}
+	if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.BaseURL != "https://primary.example/v1" {
+		t.Fatalf("BaseURL = %q, want bundle primary fallback", opts.BaseURL)
+	}
+}
+
+// Picked manifest entry has no BaseURL of its own — bundle.BaseURL should
+// fill it in.
+func TestResolveModelPrecedence_ManifestWalkInheritsBundleBaseURL(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "openai-key")
+	opts := &RunOptions{}
+	bundle := &agent.Bundle{
+		BaseURL: "https://primary.example/v1",
+		Models: []agent.ModelPreference{
+			{Model: "gpt-4.1-mini", Provider: "openai"},
+		},
+	}
+	if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.BaseURL != "https://primary.example/v1" {
+		t.Fatalf("BaseURL = %q, want primary fallback", opts.BaseURL)
+	}
+}
+
+// Two manifest entries share OPENAI_API_KEY; with no key set, the error
+// message must list it exactly once.
+func TestResolveModelPrecedence_NoCredsErrorDedupesEnvVars(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	opts := &RunOptions{}
+	bundle := &agent.Bundle{
+		Models: []agent.ModelPreference{
+			{Model: "gpt-4.1-mini", Provider: "openai"},
+			{Model: "gpt-4.1-nano", Provider: "openai"},
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+	}
+	_, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err == nil {
+		t.Fatal("expected error when no provider has credentials")
+	}
+	msg := err.Error()
+	if strings.Count(msg, "OPENAI_API_KEY") != 1 {
+		t.Fatalf("expected OPENAI_API_KEY listed exactly once, got %q", msg)
+	}
+}
+
+// The user's primary use case: openai-compat with a custom hosted model
+// (e.g. Qwen via Together AI). The model is not in the agent manifest, but
+// the user has expressed explicit intent in config and supplied a token.
+// Config wins and the resolver emits a warning.
+func TestResolveModelPrecedence_ConfigTokenWinsOverManifestTop(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	opts := &RunOptions{
+		APIKey:         "compat-token",
+		ConfigProvider: "openai-compat",
+		ConfigModel:    "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
+		BaseURL:        "https://api.together.xyz/v1",
+	}
+	bundle := &agent.Bundle{
+		Model:    "claude-sonnet-4-6",
+		Provider: "anthropic",
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+	}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Model != "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo" || opts.Provider != "openai-compat" {
+		t.Fatalf("expected config default to win, got %q (%q)", opts.Model, opts.Provider)
+	}
+	if !strings.Contains(warn, "not listed in the agent manifest") {
+		t.Fatalf("expected outside-manifest warning, got %q", warn)
+	}
 }
 
 func runAndAssertBundle(t *testing.T, opts *RunOptions, wantModel, wantProvider string) {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -413,14 +413,37 @@ func TestPrepareBundle(t *testing.T) {
 
 func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	t.Parallel()
-	// Calling with either argument nil must be a no-op rather than a panic;
-	// pipeline code passes a bundle that may be nil on early-exit paths.
-	_, _ = ResolveModelPrecedence(context.Background(), nil, nil)
-	_, _ = ResolveModelPrecedence(context.Background(), &RunOptions{}, nil)
-	_, _ = ResolveModelPrecedence(context.Background(), nil, &agent.Bundle{})
+	// Calling with either argument nil must be a silent no-op rather than a
+	// panic; pipeline code passes a bundle that may be nil on early-exit
+	// paths. The function must not emit a warning or an error in any of
+	// these shapes.
+	nilCases := []struct {
+		name   string
+		opts   *RunOptions
+		bundle *agent.Bundle
+	}{
+		{"both nil", nil, nil},
+		{"nil bundle", &RunOptions{}, nil},
+		{"nil opts", nil, &agent.Bundle{}},
+	}
+	for _, tc := range nilCases {
+		warn, err := ResolveModelPrecedence(context.Background(), tc.opts, tc.bundle)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if warn != "" {
+			t.Fatalf("%s: unexpected warning: %q", tc.name, warn)
+		}
+	}
 
 	opts := &RunOptions{Model: "preset", Provider: "preset"}
-	_, _ = ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
+	warn, err := ResolveModelPrecedence(context.Background(), opts, &agent.Bundle{Model: "manifest", Provider: "manifest"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warn != "" {
+		t.Fatalf("unexpected warning: %q", warn)
+	}
 	if opts.Model != "preset" || opts.Provider != "preset" {
 		t.Fatalf("explicit values must win over manifest: Model=%q Provider=%q", opts.Model, opts.Provider)
 	}
@@ -441,7 +464,9 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
+		if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if opts.BaseURL != compatURL {
 			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
 		}
@@ -456,7 +481,9 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 			Provider: "openai-compat",
 			BaseURL:  compatURL,
 		}
-		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
+		if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if opts.BaseURL != explicit {
 			t.Fatalf("BaseURL = %q, want explicit %q", opts.BaseURL, explicit)
 		}
@@ -477,7 +504,9 @@ func TestResolveModelPrecedenceBaseURL(t *testing.T) {
 				},
 			},
 		}
-		_, _ = ResolveModelPrecedence(context.Background(), opts, bundle)
+		if _, err := ResolveModelPrecedence(context.Background(), opts, bundle); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if opts.BaseURL != compatURL {
 			t.Fatalf("BaseURL = %q, want %q", opts.BaseURL, compatURL)
 		}


### PR DESCRIPTION
**Key Changes:**

- Made model precedence credential-aware so runs prefer configured defaults with credentials, then manifest-ranked models with available API keys
- Added explicit errors when no manifest provider has credentials, including the env vars needed to unblock the run
- Updated API key detection to support `openai-compat` and its `OPENAI_COMPAT_API_KEY` to `OPENAI_API_KEY` fallback chain
- Preserved user intent by proceeding with configured models outside the manifest while warning instead of silently falling back

**Added:**

- Credential-aware model resolution paths - Added helper flows for explicit model selection, credentialed config defaults, manifest credential walking, unauthenticated config fallback, missing-credential errors, and legacy bundle fallback
- OpenAI-compatible API key support - Added `openai-compat` detection with ordered env var fallback from `OPENAI_COMPAT_API_KEY` to `OPENAI_API_KEY`
- Regression coverage - Added tests for manifest fallback by credential availability, missing credential errors, config default precedence, and OpenAI-compatible env var fallback behavior

**Changed:**

- Model precedence behavior - `ResolveModelPrecedence` now returns both a warning and an error, allowing callers to abort when no usable credentials are available instead of continuing with an invalid provider
- Config default handling - Configured models now win when their provider has credentials, even if not listed in the manifest, because provider routing and cost controls are user configuration concerns
- Manifest model selection - Ranked manifest models are now scanned until a provider with credentials is found, with warnings when the preferred model is skipped
- Runner and pipeline callers - Updated call sites to handle resolver errors before printing any warnings

**Removed:**

- Legacy direct credential checks - Removed `NVIDIA_API_KEY` and `DATABRICKS_TOKEN` as active key sources for deprecated shims, aligning them with the OpenAI-compatible provider fallback chain