### PR TITLE
refactor: remove deprecated nvidia and databricks provider shims

### DIFF
--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -194,7 +194,7 @@ func TestBuildComposedRunOptsConfigDefaultsBucket(t *testing.T) {
 	cmd := newRunCmd()
 	ctx := context.Background()
 	v := viper.New()
-	v.Set("provider.default", "nvidia")
+	v.Set("provider.default", "openai-compat")
 	v.Set("model.default", "qwen/qwen3-coder")
 	ctx = withViper(ctx, v)
 	cmd.SetContext(ctx)
@@ -205,8 +205,8 @@ func TestBuildComposedRunOptsConfigDefaultsBucket(t *testing.T) {
 	if opts.Model != "" {
 		t.Fatalf("config default leaked into explicit Model: %q", opts.Model)
 	}
-	if opts.ConfigProvider != "nvidia" {
-		t.Fatalf("ConfigProvider=%q, want nvidia", opts.ConfigProvider)
+	if opts.ConfigProvider != "openai-compat" {
+		t.Fatalf("ConfigProvider=%q, want openai-compat", opts.ConfigProvider)
 	}
 	if opts.ConfigModel != "qwen/qwen3-coder" {
 		t.Fatalf("ConfigModel=%q, want qwen/qwen3-coder", opts.ConfigModel)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,13 +362,6 @@ models:
 Only `--api-key` (or the env var) is still required at runtime; keys are never
 stored in manifests.
 
-> **Migration from `nvidia` or `databricks` provider**
->
-> Replace `provider: nvidia` or `provider: databricks` with
-> `provider: openai-compat` and add an explicit `base_url`. For NVIDIA use
-> `https://integrate.api.nvidia.com/v1`; for Databricks use your
-> `https://<id>.ai-gateway.cloud.databricks.com/mlflow/v1` URL.
-
 ### Ollama
 
 Use `--num-ctx` (or `SQUAD_PROVIDER_NUM_CTX`) to control the context window size.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -253,10 +253,6 @@ var (
 // SupportedProviders is the canonical, ordered list of provider names
 // squad recognizes for the --provider flag and the TUI launch form.
 // Keep this in sync with the provider dispatch in runner/model.go.
-//
-// Note: "nvidia" and "databricks" are still accepted by the runner as
-// deprecated shims that redirect to "openai-compat". They are intentionally
-// omitted here so completion and UI forms guide users toward the replacement.
 var SupportedProviders = []string{
 	"openai",
 	"openai-responses",

--- a/runner/model.go
+++ b/runner/model.go
@@ -299,23 +299,6 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildGeminiLLM(ctx, opts, model)
 	case "openai-compat":
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
-	case "nvidia":
-		// Deprecated: use provider: openai-compat with base_url: https://integrate.api.nvidia.com/v1
-		logging.WarnContext(ctx, "provider 'nvidia' is deprecated; use 'openai-compat' with base_url: https://integrate.api.nvidia.com/v1")
-		if opts.BaseURL == "" {
-			opts.BaseURL = "https://integrate.api.nvidia.com/v1"
-		}
-		return buildOpenAICompatLLM(opts, "openai-compat", model)
-	case "databricks":
-		// Deprecated: use provider: openai-compat with base_url pointing to your Databricks AI Gateway
-		logging.WarnContext(ctx, "provider 'databricks' is deprecated; use 'openai-compat' with base_url and api_key set")
-		if opts.BaseURL == "" {
-			return nil, fmt.Errorf(
-				"databricks provider requires --base-url " +
-					"(e.g. https://<workspace>.ai-gateway.cloud.databricks.com/mlflow/v1)",
-			)
-		}
-		return buildOpenAICompatLLM(opts, "openai-compat", model)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -414,8 +397,7 @@ func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {
 }
 
 func isOpenAICompatProvider(provider string) bool {
-	return provider == "" || provider == "openai" || provider == "openai-compat" ||
-		provider == "nvidia" || provider == "databricks"
+	return provider == "" || provider == "openai" || provider == "openai-compat"
 }
 
 // reasoningPrefixes returns the configured reasoning model prefixes,

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -56,8 +56,8 @@ func TestIsOpenAICompatProvider(t *testing.T) {
 		{"ollama", "ollama", false},
 		{"anthropic", "anthropic", false},
 		{"openai-compat", "openai-compat", true},
-		{"nvidia", "nvidia", true},
-		{"databricks", "databricks", true},
+		{"nvidia", "nvidia", false},
+		{"databricks", "databricks", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,9 +117,6 @@ func TestBuildLLMVariants(t *testing.T) {
 		{"anthropic", "anthropic", "claude-3", &RunOptions{APIKey: "token"}, "*anthropic.LLM", false},
 		{"gemini", "gemini", "gemini-2.0-flash", &RunOptions{APIKey: "token"}, "*googleai.GoogleAI", false},
 		{"unknown provider", "unknown", "model", &RunOptions{}, "", true},
-		// nvidia/databricks are deprecated shims that redirect to openai-compat with a warning
-		{"nvidia deprecated shim", "nvidia", "meta/llama-3.1-8b-instruct", &RunOptions{APIKey: "nvapi-test-key"}, "*openai.LLM", false},
-		{"databricks deprecated shim", "databricks", "databricks-gpt-5-5-pro", &RunOptions{APIKey: "dapi-test-token", BaseURL: "https://example.com"}, "*openai.LLM", false},
 		{
 			"openai-compat/deepinfra",
 			"openai-compat",


### PR DESCRIPTION
**Key Changes:**

- Removed legacy `nvidia` and `databricks` provider aliases from model construction
- Stopped treating deprecated provider names as OpenAI-compatible providers
- Dropped provider-specific API key environment mappings for removed aliases
- Updated tests and configuration expectations to use `openai-compat` directly

**Changed:**

- Configuration default behavior tests now expect `openai-compat` as the provider default while keeping explicit model defaults separate
- Provider compatibility tests now verify that `nvidia` and `databricks` are no longer classified as OpenAI-compatible providers
- LLM variant tests now cover supported providers only, with deprecated shim cases removed

**Removed:**

- Deprecated `nvidia` and `databricks` provider dispatch paths, including automatic base URL defaults and warning redirects to `openai-compat`
- API key environment lookup entries for `NVIDIA_API_KEY` and `DATABRICKS_TOKEN`
- Documentation migration note for replacing deprecated providers, since the aliases are no longer supported
- Metrics provider comment describing deprecated shim behavior that no longer exists