### PR TITLE
feat: add chrome devtools mcp preflight checks

### DIFF
--- a/mcp/preflight.go
+++ b/mcp/preflight.go
@@ -15,10 +15,11 @@ import (
 // versioned specifiers like "chrome-devtools-mcp@latest".
 const chromeDevToolsPackage = "chrome-devtools-mcp"
 
-// cdpDefaultEndpoint is the standard Chrome remote-debugging endpoint
+// cdpEndpoint is the standard Chrome remote-debugging endpoint
 // chrome-devtools-mcp falls back to when Chrome's built-in permission API
-// (Chrome 144+) isn't available or hasn't been granted.
-const cdpDefaultEndpoint = "http://127.0.0.1:9222/json/version"
+// (Chrome 144+) isn't available or hasn't been granted. var so tests can
+// redirect the probe at an httptest server.
+var cdpEndpoint = "http://127.0.0.1:9222/json/version"
 
 // cdpProbeTimeout caps the pre-flight probe. Fast enough that a missing
 // Chrome doesn't measurably delay agent startup; long enough that a loaded
@@ -59,7 +60,7 @@ func chromeUsesAutoConnect(cfg ServerConfig) bool {
 func cdpReachable(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, cdpProbeTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, cdpDefaultEndpoint, nil)
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, cdpEndpoint, nil)
 	if err != nil {
 		return false
 	}
@@ -89,7 +90,7 @@ func PreflightServer(ctx context.Context, cfg ServerConfig) {
 		return
 	}
 	if cdpReachable(ctx) {
-		logging.InfoContext(ctx, "chrome MCP pre-flight: CDP endpoint reachable at %s", cdpDefaultEndpoint)
+		logging.InfoContext(ctx, "chrome MCP pre-flight: CDP endpoint reachable at %s", cdpEndpoint)
 		return
 	}
 	if chromeUsesAutoConnect(cfg) {
@@ -98,11 +99,11 @@ func PreflightServer(ctx context.Context, cfg ServerConfig) {
 			"If chrome tool calls fail with \"Could not find DevToolsActivePort\": (1) ensure Chrome 144+ "+
 			"and grant access via chrome://inspect/#remote-debugging → \"Allow remote debugging\" "+
 			"(persists for the life of the Chrome process), OR (2) quit Chrome and relaunch with "+
-			"--remote-debugging-port=9222 so the legacy attach path works.", cdpDefaultEndpoint)
+			"--remote-debugging-port=9222 so the legacy attach path works.", cdpEndpoint)
 		return
 	}
 	logging.Warn("chrome MCP pre-flight: CDP endpoint %s unreachable and --autoConnect is not set. "+
 		"chrome-devtools-mcp will launch its own Chrome instance with a dedicated profile; "+
 		"your existing browser session (cookies, logins) will not be available to the agent. "+
-		"Add --autoConnect to attach to your running Chrome instead.", cdpDefaultEndpoint)
+		"Add --autoConnect to attach to your running Chrome instead.", cdpEndpoint)
 }

--- a/mcp/preflight.go
+++ b/mcp/preflight.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cowdogmoo/squad/logging"
+)
+
+// chromeDevToolsPackage identifies the chrome-devtools-mcp package in a
+// server's command/args. Matching is substring-based so it works with
+// versioned specifiers like "chrome-devtools-mcp@latest".
+const chromeDevToolsPackage = "chrome-devtools-mcp"
+
+// cdpDefaultEndpoint is the standard Chrome remote-debugging endpoint
+// chrome-devtools-mcp falls back to when Chrome's built-in permission API
+// (Chrome 144+) isn't available or hasn't been granted.
+const cdpDefaultEndpoint = "http://127.0.0.1:9222/json/version"
+
+// cdpProbeTimeout caps the pre-flight probe. Fast enough that a missing
+// Chrome doesn't measurably delay agent startup; long enough that a loaded
+// machine still gets a response.
+const cdpProbeTimeout = 750 * time.Millisecond
+
+// isChromeDevToolsMCP reports whether cfg launches chrome-devtools-mcp.
+// Detection covers both `npx chrome-devtools-mcp@latest` and direct
+// invocations like `chrome-devtools-mcp --autoConnect`.
+func isChromeDevToolsMCP(cfg ServerConfig) bool {
+	if strings.Contains(cfg.Command, chromeDevToolsPackage) {
+		return true
+	}
+	for _, a := range cfg.Args {
+		if strings.Contains(a, chromeDevToolsPackage) {
+			return true
+		}
+	}
+	return false
+}
+
+// chromeUsesAutoConnect reports whether the server invocation passes
+// --autoConnect (with or without an `=value`).
+func chromeUsesAutoConnect(cfg ServerConfig) bool {
+	for _, a := range cfg.Args {
+		if a == "--autoConnect" || strings.HasPrefix(a, "--autoConnect=") {
+			return true
+		}
+	}
+	return false
+}
+
+// cdpReachable performs a quick HEAD against the standard CDP endpoint.
+// A 200 response means Chrome was launched with --remote-debugging-port.
+// Any other outcome (timeout, refused, non-2xx) means the legacy file-based
+// attach path won't work; the connection then depends entirely on Chrome's
+// 144+ permission API being available and granted.
+func cdpReachable(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, cdpProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, cdpDefaultEndpoint, nil)
+	if err != nil {
+		return false
+	}
+	client := &http.Client{
+		Timeout: cdpProbeTimeout,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{Timeout: cdpProbeTimeout}).DialContext,
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		logging.Warn("CDP probe: close response body: %v", cerr)
+	}
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// PreflightServer runs server-specific readiness checks before the MCP
+// subprocess is spawned. It never returns an error — the goal is to surface
+// an actionable hint when a known fragile setup looks misconfigured, while
+// still letting the MCP attempt its own connection (Chrome's 144+
+// permission API may succeed even when the legacy CDP port is closed).
+func PreflightServer(ctx context.Context, cfg ServerConfig) {
+	if !isChromeDevToolsMCP(cfg) {
+		return
+	}
+	if cdpReachable(ctx) {
+		logging.InfoContext(ctx, "chrome MCP pre-flight: CDP endpoint reachable at %s", cdpDefaultEndpoint)
+		return
+	}
+	if chromeUsesAutoConnect(cfg) {
+		logging.Warn("chrome MCP pre-flight: CDP endpoint %s unreachable. "+
+			"--autoConnect will rely on Chrome 144+'s built-in remote-debugging permission API. "+
+			"If chrome tool calls fail with \"Could not find DevToolsActivePort\": (1) ensure Chrome 144+ "+
+			"and grant access via chrome://inspect/#remote-debugging → \"Allow remote debugging\" "+
+			"(persists for the life of the Chrome process), OR (2) quit Chrome and relaunch with "+
+			"--remote-debugging-port=9222 so the legacy attach path works.", cdpDefaultEndpoint)
+		return
+	}
+	logging.Warn("chrome MCP pre-flight: CDP endpoint %s unreachable and --autoConnect is not set. "+
+		"chrome-devtools-mcp will launch its own Chrome instance with a dedicated profile; "+
+		"your existing browser session (cookies, logins) will not be available to the agent. "+
+		"Add --autoConnect to attach to your running Chrome instead.", cdpDefaultEndpoint)
+}

--- a/mcp/preflight_test.go
+++ b/mcp/preflight_test.go
@@ -1,6 +1,11 @@
 package mcp
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestIsChromeDevToolsMCP(t *testing.T) {
 	t.Parallel()
@@ -65,6 +70,103 @@ func TestChromeUsesAutoConnect(t *testing.T) {
 			if got := chromeUsesAutoConnect(cfg); got != tt.want {
 				t.Errorf("chromeUsesAutoConnect() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+// withEndpoint temporarily redirects cdpEndpoint for the duration of a test.
+// Not t.Parallel safe — the helper mutates a package-level var.
+func withEndpoint(t *testing.T, url string) {
+	t.Helper()
+	prev := cdpEndpoint
+	cdpEndpoint = url
+	t.Cleanup(func() { cdpEndpoint = prev })
+}
+
+func TestCDPReachable(t *testing.T) {
+	t.Run("200 response means reachable", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+		withEndpoint(t, srv.URL)
+		if !cdpReachable(context.Background()) {
+			t.Fatal("expected reachable=true for 200 response")
+		}
+	})
+
+	t.Run("non-2xx response means unreachable", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		withEndpoint(t, srv.URL)
+		if cdpReachable(context.Background()) {
+			t.Fatal("expected reachable=false for 500 response")
+		}
+	})
+
+	t.Run("connection refused means unreachable", func(t *testing.T) {
+		// Bind, capture address, then close — guarantees nothing is listening.
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+		withEndpoint(t, url)
+		if cdpReachable(context.Background()) {
+			t.Fatal("expected reachable=false when nothing is listening")
+		}
+	})
+
+	t.Run("invalid URL means unreachable", func(t *testing.T) {
+		withEndpoint(t, "://not a url")
+		if cdpReachable(context.Background()) {
+			t.Fatal("expected reachable=false for malformed URL")
+		}
+	})
+}
+
+func TestPreflightServer(t *testing.T) {
+	reachable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(reachable.Close)
+
+	unreachableSrv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	unreachableURL := unreachableSrv.URL
+	unreachableSrv.Close()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		cfg      ServerConfig
+	}{
+		{
+			name:     "not chrome MCP is a no-op",
+			endpoint: unreachableURL,
+			cfg:      ServerConfig{Command: "npx", Args: []string{"some-other-mcp"}},
+		},
+		{
+			name:     "chrome MCP with reachable CDP logs info",
+			endpoint: reachable.URL,
+			cfg:      ServerConfig{Command: "npx", Args: []string{"chrome-devtools-mcp", "--autoConnect"}},
+		},
+		{
+			name:     "chrome MCP with autoConnect and unreachable CDP warns about permission API",
+			endpoint: unreachableURL,
+			cfg:      ServerConfig{Command: "npx", Args: []string{"chrome-devtools-mcp", "--autoConnect"}},
+		},
+		{
+			name:     "chrome MCP without autoConnect and unreachable CDP warns about dedicated profile",
+			endpoint: unreachableURL,
+			cfg:      ServerConfig{Command: "npx", Args: []string{"chrome-devtools-mcp"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withEndpoint(t, tt.endpoint)
+			// PreflightServer never returns; assertion is that it doesn't panic
+			// and that each branch executes (verified via coverage).
+			PreflightServer(context.Background(), tt.cfg)
 		})
 	}
 }

--- a/mcp/preflight_test.go
+++ b/mcp/preflight_test.go
@@ -1,0 +1,70 @@
+package mcp
+
+import "testing"
+
+func TestIsChromeDevToolsMCP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  ServerConfig
+		want bool
+	}{
+		{
+			name: "npx with versioned package",
+			cfg:  ServerConfig{Command: "npx", Args: []string{"chrome-devtools-mcp@latest", "--autoConnect"}},
+			want: true,
+		},
+		{
+			name: "npx with -y and package",
+			cfg:  ServerConfig{Command: "npx", Args: []string{"-y", "chrome-devtools-mcp", "--autoConnect"}},
+			want: true,
+		},
+		{
+			name: "direct command",
+			cfg:  ServerConfig{Command: "/usr/local/bin/chrome-devtools-mcp", Args: []string{"--autoConnect"}},
+			want: true,
+		},
+		{
+			name: "unrelated stdio server",
+			cfg:  ServerConfig{Command: "npx", Args: []string{"some-other-mcp@latest"}},
+			want: false,
+		},
+		{
+			name: "empty config",
+			cfg:  ServerConfig{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isChromeDevToolsMCP(tt.cfg); got != tt.want {
+				t.Errorf("isChromeDevToolsMCP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChromeUsesAutoConnect(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "bare flag", args: []string{"chrome-devtools-mcp@latest", "--autoConnect"}, want: true},
+		{name: "flag with value", args: []string{"chrome-devtools-mcp@latest", "--autoConnect=true"}, want: true},
+		{name: "no autoConnect", args: []string{"chrome-devtools-mcp@latest"}, want: false},
+		{name: "substring only does not match", args: []string{"--no-autoConnect"}, want: false},
+		{name: "empty args", args: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := ServerConfig{Command: "npx", Args: tt.args}
+			if got := chromeUsesAutoConnect(cfg); got != tt.want {
+				t.Errorf("chromeUsesAutoConnect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runner/model.go
+++ b/runner/model.go
@@ -543,6 +543,7 @@ func convertMCPHandlers(handlers []mcp.ToolHandler) []tools.Handler {
 func connectMCPServers(ctx context.Context, servers []mcp.ServerConfig) ([]*mcp.Client, error) {
 	var clients []*mcp.Client
 	for _, cfg := range servers {
+		mcp.PreflightServer(ctx, cfg)
 		logging.InfoContext(ctx, "connecting MCP server %q (%s)", cfg.Name, cfg.ConnectString())
 		c, err := mcp.Connect(ctx, cfg)
 		if err != nil {


### PR DESCRIPTION
**Key Changes:**

- Added preflight detection for chrome-devtools-mcp configurations before MCP subprocess startup
- Introduced a fast CDP endpoint probe to warn when Chrome remote debugging is unavailable
- Surfaced actionable guidance for --autoConnect and non-autoConnect Chrome MCP setups
- Covered Chrome MCP package and --autoConnect detection with unit tests

**Added:**

- Chrome MCP preflight readiness checks - Added ServerConfig detection, --autoConnect parsing, CDP reachability probing, and contextual warnings in mcp/preflight.go so known Chrome attachment issues are reported before connection attempts
- Preflight unit coverage - Added tests for versioned npx invocations, direct chrome-devtools-mcp commands, unrelated MCP servers, and valid --autoConnect flag forms in mcp/preflight_test.go

**Changed:**

- MCP connection flow - Invokes PreflightServer before each MCP server connection in runner/model.go, preserving normal connection behavior while adding early diagnostics for fragile Chrome DevTools setups