### PR TITLE
feat: add environment variable template helper

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -227,6 +227,30 @@ func (td TemplateData) Default(key, defaultVal string) string {
 	return defaultVal
 }
 
+// Env returns the value of an OS environment variable, or the first
+// non-empty fallback when unset. Distinct from Var/Default which read
+// from squad's --var / cfg.Vars map. Usage in templates:
+//
+//	env:
+//	  - "GOOGLE_TOKEN={{.Env \"GOOGLE_TOKEN\"}}"
+//	  - "API_BASE={{.Env \"API_BASE\" \"https://api.example.com\"}}"
+//
+// Squad's `--var KEY=VAL` flags shadow OS env when both name the same
+// key — author your manifest to call `.Env` for ambient credentials
+// (refresh tokens, machine-local secrets) and `.Default` / `.Var` for
+// runtime knobs the caller is expected to set explicitly.
+func (td TemplateData) Env(key string, fallbacks ...string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	for _, f := range fallbacks {
+		if f != "" {
+			return f
+		}
+	}
+	return ""
+}
+
 // BrowserProfile returns the absolute path to the named browser profile
 // dir, creating it lazily if missing. Usage in templates:
 //

--- a/agent/template_test.go
+++ b/agent/template_test.go
@@ -32,6 +32,43 @@ func TestTemplateBrowserProfile(t *testing.T) {
 	}
 }
 
+func TestTemplateEnvReadsOSEnv(t *testing.T) {
+	t.Setenv("SQUAD_TEMPLATE_ENV_TEST", "hello")
+	out, err := processTemplate("inline", `value={{.Env "SQUAD_TEMPLATE_ENV_TEST"}}`, t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	if out != "value=hello" {
+		t.Fatalf("got %q, want %q", out, "value=hello")
+	}
+}
+
+func TestTemplateEnvFallback(t *testing.T) {
+	t.Setenv("SQUAD_TEMPLATE_ENV_UNSET", "")
+	out, err := processTemplate("inline",
+		`value={{.Env "SQUAD_TEMPLATE_ENV_UNSET" "fallback"}}`,
+		t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	if out != "value=fallback" {
+		t.Fatalf("got %q, want %q", out, "value=fallback")
+	}
+}
+
+func TestTemplateEnvEmptyWhenUnsetAndNoFallback(t *testing.T) {
+	t.Setenv("SQUAD_TEMPLATE_ENV_BARE", "")
+	out, err := processTemplate("inline",
+		`value={{.Env "SQUAD_TEMPLATE_ENV_BARE"}}`,
+		t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	if out != "value=" {
+		t.Fatalf("got %q, want %q", out, "value=")
+	}
+}
+
 func TestTemplateBrowserProfileRejectsInvalid(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)


### PR DESCRIPTION
**Key Changes:**

- Introduced a template helper for reading OS environment variables directly from manifests
- Added fallback support so templates can provide defaults when environment values are unset
- Covered environment lookup, fallback, and empty-value behavior with focused template tests

**Added:**

- Environment variable template access - Added `TemplateData.Env` to read ambient OS environment variables with optional non-empty fallbacks, keeping credential-style inputs separate from explicit `--var`/config values
- Template helper documentation - Documented `.Env` usage examples and clarified when to use it versus `.Var` or `.Default`
- Environment helper tests - Added coverage for reading set OS environment variables, using fallback values, and returning an empty string when no value or fallback is available