### PR TITLE
feat: add date helpers to agent templates

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/cowdogmoo/squad/browser"
 	"github.com/cowdogmoo/squad/executor"
@@ -302,11 +303,24 @@ func resolveDisplayMode(mode string) string {
 // Templates can use {{if eq .Mode "edit"}}...{{end}} conditionals.
 // Templates can use {{include "hard-rules/universal.md"}} to include shared content.
 // Templates can use {{.Var "KEY"}} or {{.Default "KEY" "default"}} for custom variables.
+// Templates can use {{now "Monday 2006-01-02"}} for the current local date/time
+// formatted via Go's reference layout, or {{today}} as a shortcut for
+// "Monday 2006-01-02".
 func processTemplate(name, content, agentsDir string, data TemplateData) (string, error) {
 	data.Mode = resolveDisplayMode(data.Mode)
 
 	funcMap := template.FuncMap{
 		"include": makeIncludeFunc(agentsDir),
+		"now": func(layouts ...string) string {
+			layout := time.RFC3339
+			if len(layouts) > 0 && layouts[0] != "" {
+				layout = layouts[0]
+			}
+			return time.Now().Format(layout)
+		},
+		"today": func() string {
+			return time.Now().Format("Monday 2006-01-02")
+		},
 	}
 
 	tmpl, err := template.New(name).Funcs(funcMap).Parse(content)

--- a/agent/template_test.go
+++ b/agent/template_test.go
@@ -69,6 +69,48 @@ func TestTemplateEnvEmptyWhenUnsetAndNoFallback(t *testing.T) {
 	}
 }
 
+func TestTemplateNowWithLayout(t *testing.T) {
+	out, err := processTemplate("inline", `d={{now "2006"}}`, t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	// 4-digit year — covers the explicit-layout branch.
+	if len(out) != len("d=YYYY") {
+		t.Fatalf("got %q, want 6-char d=YYYY format", out)
+	}
+}
+
+func TestTemplateNowDefaultLayout(t *testing.T) {
+	// No layout argument → RFC3339 fallback branch.
+	out, err := processTemplate("inline", `d={{now}}`, t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	// RFC3339 is "2006-01-02T15:04:05Z07:00" — at minimum contains a 'T'.
+	if !strings.Contains(out, "T") {
+		t.Fatalf("expected RFC3339 output containing 'T', got %q", out)
+	}
+}
+
+func TestTemplateToday(t *testing.T) {
+	out, err := processTemplate("inline", `d={{today}}`, t.TempDir(), TemplateData{})
+	if err != nil {
+		t.Fatalf("processTemplate: %v", err)
+	}
+	got := strings.TrimPrefix(out, "d=")
+	weekdays := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+	matched := false
+	for _, day := range weekdays {
+		if strings.HasPrefix(got, day+" ") {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Fatalf("expected output to start with a weekday name, got %q", out)
+	}
+}
+
 func TestTemplateBrowserProfileRejectsInvalid(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)


### PR DESCRIPTION
**Key Changes:**

- Added template helpers for rendering current date and time values
- Added default RFC3339 formatting for timestamp rendering when no layout is provided
- Added test coverage for custom layouts, default timestamp output, and weekday date formatting

**Added:**

- Date/time template helpers - Added now and today functions to processTemplate in agent/bundle.go so templates can render current local timestamps with optional Go layouts
- Template helper coverage - Added tests in agent/template_test.go for explicit now layouts, default RFC3339 output, and today weekday formatting

**Changed:**

- Template author guidance - Updated processTemplate comments to document date helper usage and the today shortcut format