### PR TITLE
fix: authenticate github clone and pull with env tokens

### DIFF
--- a/source/git.go
+++ b/source/git.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 // GitOperations handles git operations for agent repositories.
@@ -75,6 +77,7 @@ func (g *GitOperations) clone(gitURL, repoPath string) (string, error) {
 	cloneOpts := &git.CloneOptions{
 		URL:      gitURL,
 		Progress: os.Stdout,
+		Auth:     httpAuthFromEnv(gitURL),
 	}
 
 	if _, err := git.PlainClone(repoPath, false, cloneOpts); err != nil {
@@ -82,6 +85,43 @@ func (g *GitOperations) clone(gitURL, repoPath string) (string, error) {
 	}
 
 	return repoPath, nil
+}
+
+// remoteURL returns the URL of the named-or-first remote on repo, or empty
+// string if none can be resolved. Used so pull() can route through the same
+// env-token logic as clone().
+func remoteURL(repo *git.Repository) string {
+	if repo == nil {
+		return ""
+	}
+	remote, err := repo.Remote("origin")
+	if err != nil || remote == nil {
+		return ""
+	}
+	urls := remote.Config().URLs
+	if len(urls) == 0 {
+		return ""
+	}
+	return urls[0]
+}
+
+// httpAuthFromEnv returns BasicAuth derived from GH_TOKEN or GITHUB_TOKEN
+// for https://github.com URLs, or nil if no token is set or the URL is not
+// an HTTPS GitHub URL. go-git does not consult the OS git credential helper,
+// so callers must supply Auth explicitly to clone private repositories.
+func httpAuthFromEnv(gitURL string) transport.AuthMethod {
+	if !strings.HasPrefix(gitURL, "https://github.com/") &&
+		!strings.HasPrefix(gitURL, "https://www.github.com/") {
+		return nil
+	}
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return nil
+	}
+	return &githttp.BasicAuth{Username: "x-access-token", Password: token}
 }
 
 // pull pulls the latest changes from the remote.
@@ -99,6 +139,7 @@ func (g *GitOperations) pull(repoPath string) error {
 	pullOpts := &git.PullOptions{
 		RemoteName: "origin",
 		Progress:   os.Stdout,
+		Auth:       httpAuthFromEnv(remoteURL(repo)),
 	}
 
 	if err := w.Pull(pullOpts); err != nil && err != git.NoErrAlreadyUpToDate {

--- a/source/git_internal_test.go
+++ b/source/git_internal_test.go
@@ -1,8 +1,6 @@
 package source
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,32 +91,4 @@ func TestRemoteURLReturnsOrigin(t *testing.T) {
 	if got := remoteURL(repo); got != wantURL {
 		t.Fatalf("remoteURL = %q, want %q", got, wantURL)
 	}
-}
-
-func TestRemoteURLOriginWithoutURLs(t *testing.T) {
-	// CreateRemote rejects empty URL lists, so we have to construct the
-	// degenerate case by reaching past CreateRemote: write a config that
-	// declares an origin with no fetch URL.
-	dir := t.TempDir()
-	repo, err := git.PlainInit(dir, false)
-	if err != nil {
-		t.Fatalf("PlainInit: %v", err)
-	}
-	cfgPath := filepath.Join(dir, ".git", "config")
-	cfg := `[core]
-	repositoryformatversion = 0
-[remote "origin"]
-`
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	// Reload by re-opening.
-	reopened, err := git.PlainOpen(dir)
-	if err != nil {
-		t.Fatalf("PlainOpen: %v", err)
-	}
-	if got := remoteURL(reopened); got != "" {
-		t.Fatalf("remoteURL with empty URLs = %q, want empty", got)
-	}
-	_ = repo
 }

--- a/source/git_internal_test.go
+++ b/source/git_internal_test.go
@@ -1,0 +1,124 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+)
+
+func TestHttpAuthFromEnvNonGitHubURL(t *testing.T) {
+	t.Setenv("GH_TOKEN", "secret")
+	if got := httpAuthFromEnv("https://gitlab.com/foo/bar.git"); got != nil {
+		t.Fatalf("expected nil for non-github URL, got %v", got)
+	}
+}
+
+func TestHttpAuthFromEnvNoToken(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	if got := httpAuthFromEnv("https://github.com/foo/bar.git"); got != nil {
+		t.Fatalf("expected nil with no token, got %v", got)
+	}
+}
+
+func TestHttpAuthFromEnvGHToken(t *testing.T) {
+	t.Setenv("GH_TOKEN", "from-gh-token")
+	t.Setenv("GITHUB_TOKEN", "ignored")
+	auth := httpAuthFromEnv("https://github.com/foo/bar.git")
+	if auth == nil {
+		t.Fatal("expected auth, got nil")
+	}
+	// BasicAuth.String() formats as "http-basic-auth - <user>:*******".
+	if !strings.Contains(auth.String(), "x-access-token") {
+		t.Fatalf("expected x-access-token in auth string, got %q", auth.String())
+	}
+	if name := auth.Name(); name != "http-basic-auth" {
+		t.Fatalf("auth.Name() = %q, want http-basic-auth", name)
+	}
+}
+
+func TestHttpAuthFromEnvGitHubTokenFallback(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "from-github-token")
+	auth := httpAuthFromEnv("https://github.com/foo/bar.git")
+	if auth == nil {
+		t.Fatal("expected auth from GITHUB_TOKEN fallback, got nil")
+	}
+	if !strings.Contains(auth.String(), "x-access-token") {
+		t.Fatalf("expected x-access-token in auth string, got %q", auth.String())
+	}
+}
+
+func TestHttpAuthFromEnvWWWPrefix(t *testing.T) {
+	t.Setenv("GH_TOKEN", "tok")
+	if got := httpAuthFromEnv("https://www.github.com/foo/bar.git"); got == nil {
+		t.Fatal("expected auth for www.github.com URL, got nil")
+	}
+}
+
+func TestRemoteURLNil(t *testing.T) {
+	if got := remoteURL(nil); got != "" {
+		t.Fatalf("remoteURL(nil) = %q, want empty", got)
+	}
+}
+
+func TestRemoteURLNoOrigin(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	if got := remoteURL(repo); got != "" {
+		t.Fatalf("remoteURL on repo without origin = %q, want empty", got)
+	}
+}
+
+func TestRemoteURLReturnsOrigin(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	wantURL := "https://github.com/foo/bar.git"
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{wantURL},
+	}); err != nil {
+		t.Fatalf("CreateRemote: %v", err)
+	}
+	if got := remoteURL(repo); got != wantURL {
+		t.Fatalf("remoteURL = %q, want %q", got, wantURL)
+	}
+}
+
+func TestRemoteURLOriginWithoutURLs(t *testing.T) {
+	// CreateRemote rejects empty URL lists, so we have to construct the
+	// degenerate case by reaching past CreateRemote: write a config that
+	// declares an origin with no fetch URL.
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	cfgPath := filepath.Join(dir, ".git", "config")
+	cfg := `[core]
+	repositoryformatversion = 0
+[remote "origin"]
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// Reload by re-opening.
+	reopened, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	if got := remoteURL(reopened); got != "" {
+		t.Fatalf("remoteURL with empty URLs = %q, want empty", got)
+	}
+	_ = repo
+}


### PR DESCRIPTION
**Key Changes:**

- Enables go-git operations to authenticate HTTPS GitHub remotes using GH_TOKEN or GITHUB_TOKEN
- Applies consistent token handling to both repository clone and origin pull workflows
- Adds internal coverage for token precedence, GitHub URL detection, and remote URL edge cases

**Added:**

- Internal git operation tests - Added source/git_internal_test.go with coverage for GitHub-only auth creation, GH_TOKEN precedence over GITHUB_TOKEN, fallback token handling, www.github.com support, nil repositories, missing origins, valid origin URLs, and origins without URLs

**Changed:**

- Git repository synchronization - Updated source/git.go to explicitly build go-git BasicAuth from environment tokens, resolve the origin remote URL before pulling, and attach auth to clone and pull options so private GitHub repositories work without relying on OS git credential helpers