### PR TITLE
feat: add configurable llm retry attempts

### DIFF
--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -93,6 +93,11 @@ func newRunOptions(cmd *cobra.Command) *runner.RunOptions {
 		maxCost = 0
 	}
 
+	maxRetries := v.GetInt("run.max_retries")
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+
 	cfg := configFromContext(cmd)
 
 	// Split provider/model into explicit (CLI flag) vs config-default
@@ -141,6 +146,7 @@ func newRunOptions(cmd *cobra.Command) *runner.RunOptions {
 		NumCtx:             v.GetInt("provider.num_ctx"),
 		MaxIterations:      maxIter,
 		MaxCost:            maxCost,
+		MaxRetries:         maxRetries,
 		Mode:               mode,
 		Vars:               vars,
 		ConfigAvailable:    cfg != nil,
@@ -211,6 +217,7 @@ func bindRunFlags(cmd *cobra.Command, v *viper.Viper) error {
 		{"run.mode", "mode"},
 		{"run.max_iterations", "max-iterations"},
 		{"run.max_cost", "max-cost"},
+		{"run.max_retries", "max-retries"},
 		{"run.stream", "stream"},
 		{"run.max_concurrent_tasks", "max-concurrent-tasks"},
 		{"run.resume", "resume"},
@@ -294,6 +301,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	cmd.Flags().String("mode", "", "Agent mode override (e.g. readonly)")
 	cmd.Flags().Int("max-iterations", 100, "Maximum tool-calling iterations (range: 10-1000)")
 	cmd.Flags().Float64("max-cost", 5, "Maximum cost budget in USD (0 = unlimited)")
+	cmd.Flags().Int("max-retries", 3, "LLM retry attempts for transient errors (total calls = max-retries + 1)")
 	cmd.Flags().StringArray("var", nil, "Template variable in KEY=VALUE format (can be repeated)")
 	cmd.Flags().StringArray("mcp-server", nil, "MCP server: stdio NAME:COMMAND[:ARG1,ARG2,...], SSE NAME:sse:URL, or Streamable HTTP NAME:http:URL (can be repeated)")
 	cmd.Flags().Bool("stream", false, "Stream model output tokens to stderr as they arrive")

--- a/cmd/squad/run_test.go
+++ b/cmd/squad/run_test.go
@@ -395,6 +395,47 @@ func TestNewRunOptions(t *testing.T) {
 	}
 }
 
+func TestNewRunOptionsMaxRetries(t *testing.T) {
+	tests := []struct {
+		name       string
+		setRetries int
+		want       int
+	}{
+		{"default", 3, 3},
+		{"custom value", 7, 7},
+		{"negative clamped to zero", -1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.Set("run.max_retries", tt.setRetries)
+
+			cmd := commandWithViper(v)
+			ctx := withConfig(cmd.Context(), config.Defaults())
+			cmd.SetContext(ctx)
+
+			opts := newRunOptions(cmd)
+			if opts.MaxRetries != tt.want {
+				t.Fatalf("MaxRetries = %d, want %d", opts.MaxRetries, tt.want)
+			}
+		})
+	}
+}
+
+func TestBindRunFlagsMaxRetries(t *testing.T) {
+	cmd := newRunCmd()
+	v := viper.New()
+	if err := bindRunFlags(cmd, v); err != nil {
+		t.Fatalf("bindRunFlags: %v", err)
+	}
+	if err := cmd.Flags().Set("max-retries", "9"); err != nil {
+		t.Fatalf("Set max-retries: %v", err)
+	}
+	if got := v.GetInt("run.max_retries"); got != 9 {
+		t.Fatalf("run.max_retries = %d, want 9", got)
+	}
+}
+
 func TestBindRunFlags(t *testing.T) {
 	cmd := newRunCmd()
 	v := viper.New()

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,11 @@ type RunConfig struct {
 	// Isolation is the default isolation mode when neither the CLI flag nor
 	// the agent manifest specifies one. Valid values: "" (none) or "worktree".
 	Isolation string `mapstructure:"isolation" yaml:"isolation"`
+	// MaxRetries is the number of additional attempts after a failed LLM
+	// call for transient errors (rate limits, 5xx, network blips). Total
+	// attempts = MaxRetries + 1. Zero or negative falls back to the
+	// package default in tools/retry.go.
+	MaxRetries int `mapstructure:"max_retries" yaml:"max_retries"`
 }
 
 // OtelConfig holds OpenTelemetry configuration.
@@ -219,6 +224,7 @@ func SetDefaults(v *viper.Viper) {
 	v.SetDefault("model.reasoning_prefixes", []string{"gpt-5"})
 	v.SetDefault("run.max_cost", 5.0)
 	v.SetDefault("run.isolation", "")
+	v.SetDefault("run.max_retries", 3)
 	v.SetDefault("agents.cache_dir", "")
 	v.SetDefault("agents.repositories", map[string]string{
 		"official": "https://github.com/cowdogmoo/squad-agents.git",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,34 @@ func TestDefaults(t *testing.T) {
 	if len(cfg.Model.ReasoningPrefixes) != 1 || cfg.Model.ReasoningPrefixes[0] != "gpt-5" {
 		t.Fatalf("unexpected reasoning prefixes: %+v", cfg.Model.ReasoningPrefixes)
 	}
+	if cfg.Run.MaxRetries != 3 {
+		t.Fatalf("expected run.max_retries default = 3, got %d", cfg.Run.MaxRetries)
+	}
+}
+
+func TestLoadFromPathMaxRetriesEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("run:\n  max_retries: 6\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath: %v", err)
+	}
+	if cfg.Run.MaxRetries != 6 {
+		t.Fatalf("expected run.max_retries = 6 from file, got %d", cfg.Run.MaxRetries)
+	}
+
+	t.Setenv("SQUAD_RUN_MAX_RETRIES", "9")
+	cfg, _, err = LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath: %v", err)
+	}
+	if cfg.Run.MaxRetries != 9 {
+		t.Fatalf("expected env override max_retries = 9, got %d", cfg.Run.MaxRetries)
+	}
 }
 
 func TestLoadFromPathWithEnvOverrides(t *testing.T) {

--- a/runner/model.go
+++ b/runner/model.go
@@ -243,6 +243,7 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 		Executor:           ex,
 		UseCacheControl:    useCacheControl,
 		ForceFirstToolCall: forceFirstTool,
+		MaxRetries:         opts.MaxRetries,
 	}, callOpts...)
 	m.Finish()
 	if err != nil {

--- a/runner/run.go
+++ b/runner/run.go
@@ -88,6 +88,9 @@ type RunOptions struct {
 	MaxIterations int
 	// MaxCost is the total cost budget in USD (0 = unlimited).
 	MaxCost float64
+	// MaxRetries overrides the per-call LLM retry count for transient
+	// errors. Zero or negative falls back to tools.DefaultMaxRetries.
+	MaxRetries int
 	// Mode is the run mode passed to prompt templates (e.g., "edit").
 	Mode string
 	// Vars holds template variables passed to prompt templates.

--- a/tools/retry.go
+++ b/tools/retry.go
@@ -16,9 +16,12 @@ import (
 )
 
 const (
-	maxRetries     = 3
-	retryBaseDelay = 2 * time.Second
-	retryMaxDelay  = 30 * time.Second
+	// DefaultMaxRetries is the number of additional attempts after a failed
+	// LLM call when no explicit override is supplied. Total attempts =
+	// DefaultMaxRetries + 1.
+	DefaultMaxRetries = 3
+	retryBaseDelay    = 2 * time.Second
+	retryMaxDelay     = 30 * time.Second
 )
 
 // retryableErrorCodes lists llms.ErrorCode values that warrant a retry.
@@ -107,8 +110,12 @@ func isRetryable(err error) bool {
 
 // retryGenerateContent wraps llm.GenerateContent with retry and exponential
 // backoff for transient errors. It returns the first successful response or
-// the last error after exhausting retries.
-func retryGenerateContent(ctx context.Context, llm llms.Model, messages []llms.MessageContent, callOpts []llms.CallOption) (*llms.ContentResponse, error) {
+// the last error after exhausting retries. A maxRetries <= 0 falls back to
+// DefaultMaxRetries.
+func retryGenerateContent(ctx context.Context, llm llms.Model, messages []llms.MessageContent, callOpts []llms.CallOption, maxRetries int) (*llms.ContentResponse, error) {
+	if maxRetries <= 0 {
+		maxRetries = DefaultMaxRetries
+	}
 	ctx, span := telemetry.Tracer().Start(ctx, "llm.generate",
 		trace.WithAttributes(
 			attribute.Int("llm.retry.max_attempts", maxRetries+1),

--- a/tools/retry_test.go
+++ b/tools/retry_test.go
@@ -167,11 +167,11 @@ func TestRetryGenerateContent(t *testing.T) {
 		{
 			name: "exhausts all retries",
 			responses: func() []*llms.ContentResponse {
-				r := make([]*llms.ContentResponse, maxRetries+1)
+				r := make([]*llms.ContentResponse, DefaultMaxRetries+1)
 				return r
 			}(),
 			errors: func() []error {
-				e := make([]error, maxRetries+1)
+				e := make([]error, DefaultMaxRetries+1)
 				for i := range e {
 					e[i] = fmt.Errorf("503 service unavailable")
 				}
@@ -181,7 +181,7 @@ func TestRetryGenerateContent(t *testing.T) {
 				return context.WithTimeout(context.Background(), 60*time.Second)
 			},
 			wantErr:   true,
-			wantCalls: maxRetries + 1,
+			wantCalls: DefaultMaxRetries + 1,
 		},
 		{
 			name:      "context canceled during backoff",
@@ -215,7 +215,7 @@ func TestRetryGenerateContent(t *testing.T) {
 				defer cancel()
 			}
 
-			got, err := retryGenerateContent(ctx, mock, nil, nil)
+			got, err := retryGenerateContent(ctx, mock, nil, nil, 0)
 
 			if tt.wantErr {
 				if err == nil {
@@ -234,6 +234,41 @@ func TestRetryGenerateContent(t *testing.T) {
 			}
 
 			if tt.wantCalls > 0 && mock.calls != tt.wantCalls {
+				t.Errorf("calls = %d, want %d", mock.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRetryGenerateContentCustomMaxRetries(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxRetries int
+		wantCalls  int
+	}{
+		{"zero falls back to default", 0, DefaultMaxRetries + 1},
+		{"negative falls back to default", -5, DefaultMaxRetries + 1},
+		{"explicit 1 retry = 2 calls", 1, 2},
+		{"explicit 2 retries = 3 calls", 2, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := tt.wantCalls
+			responses := make([]*llms.ContentResponse, n)
+			errs := make([]error, n)
+			for i := range errs {
+				errs[i] = fmt.Errorf("503 service unavailable")
+			}
+			mock := &mockLLM{responses: responses, errors: errs}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			_, err := retryGenerateContent(ctx, mock, nil, nil, tt.maxRetries)
+			if err == nil {
+				t.Fatal("expected error after exhausting retries")
+			}
+			if mock.calls != tt.wantCalls {
 				t.Errorf("calls = %d, want %d", mock.calls, tt.wantCalls)
 			}
 		})

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -333,6 +333,9 @@ type RunWithToolsConfig struct {
 	// answer immediately. Not set for the regular openai provider, which relies
 	// on auto behavior.
 	ForceFirstToolCall bool
+	// MaxRetries is the number of additional attempts after a failed LLM
+	// call for transient errors. Zero falls back to DefaultMaxRetries.
+	MaxRetries int
 }
 
 // RunWithTools drives the tool-calling loop for a LangChain-compatible LLM.
@@ -376,7 +379,7 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		return lastContent, loopErr
 	}
 
-	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, cfg.Metrics, callOpts)
+	return finishToolLoop(ctx, llm, messages, lastContent, maxIterations, cfg.Metrics, callOpts, cfg.MaxRetries)
 }
 
 // logIterationStart logs the current iteration number with cost/token info if metrics are available.
@@ -660,7 +663,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		SetIteration(ctx, i)
 		logIterationStart(ctx, i, maxIter, m)
 		iterStart := time.Now()
-		response, err := retryGenerateContent(ctx, llm, messages, resolveIterOpts(callOpts, cfg.ForceFirstToolCall, i))
+		response, err := retryGenerateContent(ctx, llm, messages, resolveIterOpts(callOpts, cfg.ForceFirstToolCall, i), cfg.MaxRetries)
 		iterDuration := time.Since(iterStart)
 		if err := validateResponse(ctx, response, err, iterDuration); err != nil {
 			return lastContent, messages, err, false
@@ -842,7 +845,7 @@ func toInt64(v any) int64 {
 	}
 }
 
-func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, maxIter int, m *metrics.Metrics, callOpts []llms.CallOption) (string, error) {
+func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageContent, lastContent string, maxIter int, m *metrics.Metrics, callOpts []llms.CallOption, maxRetries int) (string, error) {
 	budgetExceeded := m != nil && m.BudgetExceeded()
 
 	if budgetExceeded {
@@ -866,7 +869,7 @@ func finishToolLoop(ctx context.Context, llm llms.Model, messages []llms.Message
 	copy(finalOpts, callOpts)
 	finalOpts = append(finalOpts, llms.WithToolChoice("none"))
 
-	response, err := retryGenerateContent(ctx, llm, messages, finalOpts)
+	response, err := retryGenerateContent(ctx, llm, messages, finalOpts, maxRetries)
 	if err == nil && response != nil && len(response.Choices) > 0 {
 		if m != nil {
 			m.IncrementIterations()

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1159,7 +1159,7 @@ func TestRunWithToolsLoop(t *testing.T) {
 func TestFinishToolLoopFallback(t *testing.T) {
 	t.Parallel()
 	llm := &fakeLLM{responses: []*llms.ContentResponse{{Choices: []*llms.ContentChoice{{Content: ""}}}}}
-	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, nil, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("finishToolLoop() error = %v", err)
 	}
@@ -1204,7 +1204,7 @@ func TestFinishToolLoopFinalContent(t *testing.T) {
 	llm := &stubLLM{
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final"}}},
 	}
-	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("finishToolLoop() error = %v", err)
 	}
@@ -1215,7 +1215,7 @@ func TestFinishToolLoopFinalContent(t *testing.T) {
 
 func TestFinishToolLoopErrorNoContent(t *testing.T) {
 	llm := &stubLLM{err: errors.New("boom")}
-	_, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil)
+	_, err := finishToolLoop(context.Background(), llm, nil, "", 1, nil, nil, 0)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -1613,7 +1613,7 @@ func TestFinishToolLoopBudgetExceeded(t *testing.T) {
 	llm := &stubLLM{
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final"}}},
 	}
-	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, m, nil, 0)
 	if err != nil {
 		t.Fatalf("finishToolLoop() error = %v", err)
 	}
@@ -1796,7 +1796,7 @@ func TestFinishToolLoopBudgetExceededWithContent(t *testing.T) {
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final structured report"}}},
 	}
 
-	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "partial", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -1817,7 +1817,7 @@ func TestFinishToolLoopBudgetExceededNoContent(t *testing.T) {
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: "final report"}}},
 	}
 
-	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -1838,7 +1838,7 @@ func TestFinishToolLoopBudgetExceededGraceCallFails(t *testing.T) {
 		err: errors.New("API error"),
 	}
 
-	out, err := finishToolLoop(context.Background(), llm, nil, "partial fallback", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "partial fallback", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -2089,7 +2089,7 @@ func TestFinishToolLoopBudgetExceededGraceCallFailsNoContent(t *testing.T) {
 	// Grace call fails and there is no lastContent to fall back on.
 	llm := &stubLLM{err: errors.New("API error")}
 
-	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -2110,7 +2110,7 @@ func TestFinishToolLoopBudgetExceededEmptyGraceResponse(t *testing.T) {
 	}
 
 	// With lastContent: should return it.
-	out, err := finishToolLoop(context.Background(), llm, nil, "fallback", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "fallback", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}
@@ -2130,7 +2130,7 @@ func TestFinishToolLoopBudgetExceededEmptyGraceAndNoContent(t *testing.T) {
 		resp: &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: ""}}},
 	}
 
-	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil)
+	out, err := finishToolLoop(context.Background(), llm, nil, "", 1, m, nil, 0)
 	if !errors.Is(err, metrics.ErrBudgetExceeded) {
 		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
 	}


### PR DESCRIPTION
**Key Changes:**

- Added a configurable LLM retry count that controls transient error retries per call
- Exposed retry configuration through CLI flags, config files, and environment overrides
- Propagated retry settings through runner and tool-loop execution paths
- Expanded test coverage for defaults, overrides, fallback behavior, and custom retry counts

**Added:**

- Retry configuration option - Introduced `run.max_retries` with a default of 3 and support for YAML config, `SQUAD_RUN_MAX_RETRIES`, and the `--max-retries` CLI flag
- Runtime retry plumbing - Added `MaxRetries` to run and tool execution configuration so model calls can honor user-provided retry limits
- Retry behavior tests - Added coverage for config/env loading and custom retry counts, including zero and negative fallback behavior

**Changed:**

- LLM retry handling - Updated retry generation to accept an explicit retry count while falling back to `DefaultMaxRetries` when no valid override is provided
- Tool loop execution - Passed the configured retry count into both iterative model calls and final completion calls so retry behavior is consistent across the full run
- Retry constant visibility - Renamed the internal retry constant to exported `DefaultMaxRetries` so defaults are reusable and testable

**Removed:**

- Hardcoded retry-only behavior - Eliminated reliance on a fixed internal retry count for all LLM calls, allowing retries to be configured per run