### PR TITLE
fix: resolve composed inline templates and config precedence

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -976,12 +976,13 @@ func buildInlineSystemMessage(manifest *Manifest, displayMode, workingDir, promp
 // InlineAgentConfig holds the configuration for an agent defined inline
 // within a composed agent's stage.
 type InlineAgentConfig struct {
-	Name       string            // stage name, used as the agent identity
-	EntryPoint string            // path to system prompt, relative to base dir
-	Wrapper    string            // path to wrapper prompt, relative to base dir
-	Task       string            // path to task prompt, relative to base dir
-	Models     []ModelPreference // model preferences
-	References []string          // paths to reference files, relative to base dir
+	Name          string            // stage name, used as the agent identity
+	EntryPoint    string            // path to system prompt, relative to base dir
+	Wrapper       string            // path to wrapper prompt, relative to base dir
+	Task          string            // path to task prompt, relative to base dir
+	Models        []ModelPreference // model preferences
+	References    []string          // paths to reference files, relative to base dir
+	TemplatesRoot string            // dir holding _templates/ for {{include}}; empty = baseDir
 }
 
 // resolveInlinePromptDir returns the directory containing the inline agent's
@@ -998,9 +999,15 @@ func resolveInlinePromptDir(baseDir, name, entryPoint string) string {
 // BuildBundleInline assembles a bundle from inline agent config.
 // baseDir is the composed agent's directory where prompt files live.
 // Files are resolved with progressive lookup: stages/<name>/ first, then baseDir.
+// {{include}} resolves against cfg.TemplatesRoot/_templates/ when set, else baseDir/_templates/.
 func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDir, mode string, vars map[string]string) (*Bundle, error) {
 	// Resolve the prompt directory: check stages/<name>/ first, then baseDir.
 	promptDir := resolveInlinePromptDir(baseDir, cfg.Name, cfg.EntryPoint)
+
+	includeRoot := cfg.TemplatesRoot
+	if includeRoot == "" {
+		includeRoot = baseDir
+	}
 
 	manifest := &Manifest{
 		Name:       cfg.Name,
@@ -1015,7 +1022,7 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 	displayMode := resolveDisplayMode(mode)
 
 	data := TemplateData{Mode: displayMode, Vars: vars, AgentDir: promptDir}
-	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(promptDir, baseDir, manifest, data)
+	systemContent, wrapperContent, taskContent, err := loadAndProcessPrompts(promptDir, includeRoot, manifest, data)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/bundle_internal_test.go
+++ b/agent/bundle_internal_test.go
@@ -491,6 +491,53 @@ func TestBuildBundleInline_MissingEntrypoint(t *testing.T) {
 	}
 }
 
+// TestBuildBundleInline_IncludeFromTemplatesRoot verifies that {{include "..."}}
+// in an inline-stage system template resolves against cfg.TemplatesRoot/_templates/
+// rather than baseDir/_templates/ — needed for composed agents whose stages live
+// one level inside the shared agents directory.
+func TestBuildBundleInline_IncludeFromTemplatesRoot(t *testing.T) {
+	t.Parallel()
+	templatesRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(templatesRoot, "_templates", "severity"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(templatesRoot, "_templates", "severity", "standard.md"),
+		[]byte("shared severity rubric"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	baseDir := filepath.Join(templatesRoot, "composed-agent")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(baseDir, "system.md"),
+		[]byte(`prelude {{include "severity/standard.md"}} postlude`), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(baseDir, "agent.md"), []byte("wrapper"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &InlineAgentConfig{
+		Name:          "stage",
+		EntryPoint:    "system.md",
+		Wrapper:       "agent.md",
+		TemplatesRoot: templatesRoot,
+	}
+	bundle, err := BuildBundleInline(baseDir, cfg, "go", "/tmp", "edit", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(bundle.System, "shared severity rubric") {
+		t.Errorf("system prompt did not pick up shared template; got %q", bundle.System)
+	}
+}
+
 // TestProcessTemplate_NowFunction exercises the {{now}} template helper.
 // Default layout is time.RFC3339; a custom layout argument is honored.
 func TestProcessTemplate_NowFunction(t *testing.T) {

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1463,7 +1463,7 @@ func TestBuildBundleInline_BaseDirReferenceFallback(t *testing.T) {
 		Wrapper:    "wrapper.md",
 		References: []string{"shared-ref.md"},
 	}
-	bundle, err := BuildBundleInline(baseDir, cfg, "prompt", baseDir, "", nil)
+	bundle, err := BuildBundleInline(baseDir, cfg, "prompt", t.TempDir(), "", nil)
 	if err != nil {
 		t.Fatalf("BuildBundleInline: %v", err)
 	}
@@ -1503,7 +1503,7 @@ func TestBuildBundleInline_ReferenceMissingEverywhere(t *testing.T) {
 		Wrapper:    "wrapper.md",
 		References: []string{"missing.md"},
 	}
-	_, err := BuildBundleInline(baseDir, cfg, "p", baseDir, "", nil)
+	_, err := BuildBundleInline(baseDir, cfg, "p", t.TempDir(), "", nil)
 	if err == nil {
 		t.Fatal("expected error when reference missing in both stage and baseDir")
 	}

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -84,11 +84,12 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 func buildAgentBundle(agentName, prompt, wd, mode string, mergedVars map[string]string, agentsDir, composedAgentDir string, cfg *config.Config, pipelineRunner *pl.Runner) (*agent.Bundle, error) {
 	if inlineCfg, ok := pipelineRunner.InlineAgents[agentName]; ok && inlineCfg != nil {
 		inlineAgent := &agent.InlineAgentConfig{
-			Name:       agentName,
-			EntryPoint: inlineCfg.EntryPoint,
-			Wrapper:    inlineCfg.Wrapper,
-			Task:       inlineCfg.Task,
-			References: inlineCfg.References,
+			Name:          agentName,
+			EntryPoint:    inlineCfg.EntryPoint,
+			Wrapper:       inlineCfg.Wrapper,
+			Task:          inlineCfg.Task,
+			References:    inlineCfg.References,
+			TemplatesRoot: agentsDir,
 		}
 		for _, m := range inlineCfg.Models {
 			inlineAgent.Models = append(inlineAgent.Models, agent.ModelPreference{
@@ -214,19 +215,14 @@ func buildComposedRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOpt
 	apiVersion := flagOrViper(cmd, "api-version", v, "provider.api_version")
 	apiType := flagOrViper(cmd, "api-type", v, "provider.api_type")
 
-	openAICompatMax, _ := cmd.Flags().GetBool("openai-compat-max-tokens")
-	temp, _ := cmd.Flags().GetFloat64("temperature")
-	maxTokens, _ := cmd.Flags().GetInt("max-tokens")
-	numCtx, _ := cmd.Flags().GetInt("num-ctx")
-
-	maxIter, _ := cmd.Flags().GetInt("max-iterations")
-	if maxIter < 10 {
-		maxIter = 10
-	} else if maxIter > 1000 {
-		maxIter = 1000
-	}
-
-	maxCost, _ := cmd.Flags().GetFloat64("max-cost")
+	// Configuration-style flags follow the same precedence: explicit flag,
+	// then Viper if set, then the flag's default.
+	openAICompatMax := flagOrViperBool(cmd, "openai-compat-max-tokens", v, "provider.openai_compat_max_tokens")
+	temp := flagOrViperFloat(cmd, "temperature", v, "model.temperature")
+	maxTokens := flagOrViperInt(cmd, "max-tokens", v, "model.max_tokens")
+	numCtx := flagOrViperInt(cmd, "num-ctx", v, "provider.num_ctx")
+	maxIter := clampInt(flagOrViperInt(cmd, "max-iterations", v, "run.max_iterations"), 10, 1000)
+	maxCost := flagOrViperFloat(cmd, "max-cost", v, "run.max_cost")
 	if maxCost < 0 {
 		maxCost = 0
 	}
@@ -262,6 +258,77 @@ func flagOrViper(cmd *cobra.Command, flagName string, v interface{ GetString(str
 		return v.GetString(viperKey)
 	}
 	return ""
+}
+
+// viperBool is the structural subset of *viper.Viper used by flagOrViperBool.
+type viperBool interface {
+	IsSet(string) bool
+	GetBool(string) bool
+}
+
+// viperFloat is the structural subset of *viper.Viper used by flagOrViperFloat.
+type viperFloat interface {
+	IsSet(string) bool
+	GetFloat64(string) float64
+}
+
+// viperInt is the structural subset of *viper.Viper used by flagOrViperInt.
+type viperInt interface {
+	IsSet(string) bool
+	GetInt(string) int
+}
+
+// flagOrViperBool picks the explicit flag value if set, else the Viper value
+// when present, else the flag's default.
+func flagOrViperBool(cmd *cobra.Command, flagName string, v viperBool, viperKey string) bool {
+	if cmd.Flags().Changed(flagName) {
+		b, _ := cmd.Flags().GetBool(flagName)
+		return b
+	}
+	if v != nil && v.IsSet(viperKey) {
+		return v.GetBool(viperKey)
+	}
+	b, _ := cmd.Flags().GetBool(flagName)
+	return b
+}
+
+// flagOrViperFloat picks the explicit flag value if set, else the Viper value
+// when present, else the flag's default.
+func flagOrViperFloat(cmd *cobra.Command, flagName string, v viperFloat, viperKey string) float64 {
+	if cmd.Flags().Changed(flagName) {
+		f, _ := cmd.Flags().GetFloat64(flagName)
+		return f
+	}
+	if v != nil && v.IsSet(viperKey) {
+		return v.GetFloat64(viperKey)
+	}
+	f, _ := cmd.Flags().GetFloat64(flagName)
+	return f
+}
+
+// flagOrViperInt picks the explicit flag value if set, else the Viper value
+// when present, else the flag's default.
+func flagOrViperInt(cmd *cobra.Command, flagName string, v viperInt, viperKey string) int {
+	if cmd.Flags().Changed(flagName) {
+		i, _ := cmd.Flags().GetInt(flagName)
+		return i
+	}
+	if v != nil && v.IsSet(viperKey) {
+		return v.GetInt(viperKey)
+	}
+	i, _ := cmd.Flags().GetInt(flagName)
+	return i
+}
+
+// clampInt clamps v into [lo, hi].
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
 }
 
 // mergeVars combines base and override variable maps, with override taking precedence.

--- a/cmd/squad/pipeline_test.go
+++ b/cmd/squad/pipeline_test.go
@@ -890,11 +890,108 @@ func TestOutputReport_FormatError(t *testing.T) {
 	}
 }
 
-// mockViper implements the interface { GetString(string) string } for testing.
+// mockViper implements the structural Viper subsets used by flagOrViper and
+// its typed siblings (flagOrViperBool/Float/Int). Any key present in a
+// values map is reported as IsSet=true.
 type mockViper struct {
-	vals map[string]string
+	vals   map[string]string
+	bools  map[string]bool
+	floats map[string]float64
+	ints   map[string]int
 }
 
-func (m *mockViper) GetString(key string) string {
-	return m.vals[key]
+func (m *mockViper) GetString(key string) string { return m.vals[key] }
+
+func (m *mockViper) IsSet(key string) bool {
+	if _, ok := m.bools[key]; ok {
+		return true
+	}
+	if _, ok := m.floats[key]; ok {
+		return true
+	}
+	if _, ok := m.ints[key]; ok {
+		return true
+	}
+	_, ok := m.vals[key]
+	return ok
+}
+
+func (m *mockViper) GetBool(key string) bool       { return m.bools[key] }
+func (m *mockViper) GetFloat64(key string) float64 { return m.floats[key] }
+func (m *mockViper) GetInt(key string) int         { return m.ints[key] }
+
+func TestFlagOrViperTyped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bool: flag changed wins over viper", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("flag", false, "")
+		_ = cmd.Flags().Set("flag", "true")
+		mv := &mockViper{bools: map[string]bool{"k": false}}
+		if got := flagOrViperBool(cmd, "flag", mv, "k"); !got {
+			t.Fatalf("expected true from explicit flag, got %v", got)
+		}
+	})
+
+	t.Run("bool: viper used when flag unset", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("flag", false, "")
+		mv := &mockViper{bools: map[string]bool{"k": true}}
+		if got := flagOrViperBool(cmd, "flag", mv, "k"); !got {
+			t.Fatalf("expected true from viper fallback, got %v", got)
+		}
+	})
+
+	t.Run("bool: flag default when neither set", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("flag", true, "")
+		if got := flagOrViperBool(cmd, "flag", nil, "k"); !got {
+			t.Fatalf("expected flag default true, got %v", got)
+		}
+	})
+
+	t.Run("float: flag changed wins over viper", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Float64("flag", 0, "")
+		_ = cmd.Flags().Set("flag", "1.5")
+		mv := &mockViper{floats: map[string]float64{"k": 9.9}}
+		if got := flagOrViperFloat(cmd, "flag", mv, "k"); got != 1.5 {
+			t.Fatalf("expected 1.5 from flag, got %v", got)
+		}
+	})
+
+	t.Run("float: viper used when flag unset", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Float64("flag", 0, "")
+		mv := &mockViper{floats: map[string]float64{"k": 2.5}}
+		if got := flagOrViperFloat(cmd, "flag", mv, "k"); got != 2.5 {
+			t.Fatalf("expected 2.5 from viper, got %v", got)
+		}
+	})
+
+	t.Run("int: flag changed wins over viper", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Int("flag", 0, "")
+		_ = cmd.Flags().Set("flag", "7")
+		mv := &mockViper{ints: map[string]int{"k": 99}}
+		if got := flagOrViperInt(cmd, "flag", mv, "k"); got != 7 {
+			t.Fatalf("expected 7 from flag, got %v", got)
+		}
+	})
+
+	t.Run("int: viper used when flag unset", func(t *testing.T) {
+		t.Parallel()
+		cmd := &cobra.Command{}
+		cmd.Flags().Int("flag", 0, "")
+		mv := &mockViper{ints: map[string]int{"k": 42}}
+		if got := flagOrViperInt(cmd, "flag", mv, "k"); got != 42 {
+			t.Fatalf("expected 42 from viper, got %v", got)
+		}
+	})
 }


### PR DESCRIPTION
**Key Changes:**

- Fixed inline stage template includes so composed agents can resolve shared `_templates` from the agents root instead of only the composed agent directory
- Updated composed pipeline bundle creation to pass the shared agents directory as the inline agent template root
- Restored config-file precedence for composed run options by reading typed Viper values when CLI flags are not explicitly set
- Added coverage for shared template include resolution and tightened bundle tests to avoid relying on the prompt directory as the working directory

**Added:**

- Inline agent template root support - Added `TemplatesRoot` to `InlineAgentConfig` so inline prompt processing can resolve `{{include}}` templates from a caller-provided shared root
- Typed flag resolution helpers - Added bool, float, and int flag/Viper helper functions plus integer clamping to consistently apply explicit flag, config, then default precedence
- Shared template include regression coverage - Added a test verifying inline composed stages can include templates from `TemplatesRoot/_templates`

**Changed:**

- Inline bundle construction - Updated `BuildBundleInline` to use `TemplatesRoot` for include processing when provided, while preserving the existing base directory behavior as the fallback
- Composed agent pipeline behavior - Updated inline bundle setup to pass `agentsDir` as the template root and changed composed run option construction to honor Viper-backed config values for model, provider, and run limits
- Bundle test isolation - Adjusted inline reference tests to use a separate temporary working directory so reference fallback behavior is validated independently of the runtime working directory