### PR TITLE
fix: quote unsafe ssm working directories

### DIFF
--- a/executor/ssm.go
+++ b/executor/ssm.go
@@ -102,8 +102,6 @@ func (e *SSMExecutor) Execute(ctx context.Context, command string) ([]byte, erro
 
 	// Prepend a cd into the working directory when one is configured so
 	// that commands run in the expected location on the remote host.
-	// IMPORTANT: workingDir may be user-controlled from CLI/config; avoid
-	// command injection by quoting it when it contains unsafe characters.
 	if e.workingDir != "" {
 		wd := e.workingDir
 		if !isShellSafePath(wd) {

--- a/executor/ssm.go
+++ b/executor/ssm.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -100,8 +102,14 @@ func (e *SSMExecutor) Execute(ctx context.Context, command string) ([]byte, erro
 
 	// Prepend a cd into the working directory when one is configured so
 	// that commands run in the expected location on the remote host.
+	// IMPORTANT: workingDir may be user-controlled from CLI/config; avoid
+	// command injection by quoting it when it contains unsafe characters.
 	if e.workingDir != "" {
-		command = fmt.Sprintf("mkdir -p %s && cd %s && %s", e.workingDir, e.workingDir, command)
+		wd := e.workingDir
+		if !isShellSafePath(wd) {
+			wd = shellSingleQuote(wd)
+		}
+		command = fmt.Sprintf("mkdir -p %s && cd %s && %s", wd, wd, command)
 	}
 
 	sendOut, err := e.client.SendCommand(ctx, &ssm.SendCommandInput{
@@ -225,4 +233,36 @@ func (e *SSMExecutor) EnvironmentDescription() string {
 		"If tools are installed inside Docker containers on the host, " +
 		"you must use 'docker exec <container> <command>' to reach them."
 	return desc
+}
+
+// isShellSafePath reports whether s contains only shell-safe path characters
+// that don't need quoting in a POSIX shell context.
+func isShellSafePath(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r == '/' || r == '.' || r == '-' || r == '_' || unicode.IsDigit(r) || unicode.IsLetter(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// shellSingleQuote returns s wrapped in single quotes with embedded single
+// quotes escaped for POSIX shells: ' becomes '\”
+func shellSingleQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			b.WriteString("'\\''")
+		} else {
+			b.WriteByte(s[i])
+		}
+	}
+	b.WriteByte('\'')
+	return b.String()
 }

--- a/executor/ssm_test.go
+++ b/executor/ssm_test.go
@@ -530,6 +530,89 @@ func TestSSMExecutor_Execute_ContextCancelled(t *testing.T) {
 	}
 }
 
+func TestIsShellSafePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"/opt/app", true},
+		{"relative/path", true},
+		{"with-dash_and.dot", true},
+		{"alpha123", true},
+		{"has space", false},
+		{"semi;colon", false},
+		{"dollar$sign", false},
+		{"back\\slash", false},
+		{"pipe|char", false},
+		{"quote'mark", false},
+	}
+	for _, c := range cases {
+		if got := isShellSafePath(c.in); got != c.want {
+			t.Errorf("isShellSafePath(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestShellSingleQuote(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"", "''"},
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"a'b", `'a'\''b'`},
+		{"a'b'c", `'a'\''b'\''c'`},
+		{"$dangerous;`stuff`", "'$dangerous;`stuff`'"},
+	}
+	for _, c := range cases {
+		if got := shellSingleQuote(c.in); got != c.want {
+			t.Errorf("shellSingleQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestSSMExecutor_Execute_QuotesUnsafeWorkingDir asserts that a workingDir
+// containing shell metacharacters is wrapped in single quotes before being
+// composed into the remote command, blocking CWE-77 command injection.
+func TestSSMExecutor_Execute_QuotesUnsafeWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeSSMClient{
+		sendCommandFn: func(_ context.Context, params *ssm.SendCommandInput) (*ssm.SendCommandOutput, error) {
+			return &ssm.SendCommandOutput{Command: &ssmtypes.Command{CommandId: aws.String("cid")}}, nil
+		},
+		getCommandInvocation: func(_ context.Context, _ *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:                ssmtypes.CommandInvocationStatusSuccess,
+				StandardOutputContent: aws.String("ok"),
+			}, nil
+		},
+	}
+
+	ex := &SSMExecutor{
+		instanceID: "i-abc123",
+		workingDir: "/opt/app; rm -rf /",
+		timeout:    defaultSSMTimeout,
+		client:     client,
+	}
+
+	if _, err := ex.Execute(context.Background(), "ls"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(client.sendCalls) != 1 {
+		t.Fatalf("expected 1 SendCommand call, got %d", len(client.sendCalls))
+	}
+	got := client.sendCalls[0].Parameters["commands"][0]
+	want := "mkdir -p '/opt/app; rm -rf /' && cd '/opt/app; rm -rf /' && ls"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
 func TestSSMExecutor_Execute_CancelledStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Key Changes:**

- Prevented shell command injection through user-controlled SSM working directory values
- Added POSIX-safe single-quote escaping for paths containing unsafe shell characters
- Preserved unquoted command behavior for simple, shell-safe working directory paths

**Added:**

- Shell path safety helpers - Added validation for safe path characters and single-quote escaping for unsafe values in `executor/ssm.go`

**Changed:**

- SSM command construction - Updated working directory handling to quote unsafe paths before building the `mkdir -p && cd && command` sequence, ensuring CLI/config-provided paths cannot alter the remote shell command structure