### PR TITLE
docs: clarify logger and background command comments

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -41,7 +41,6 @@ var (
 )
 
 // LogLevel represents the supported log severity levels.
-
 type LogLevel int
 
 // OutputType defines the available logger output formats.

--- a/tools/bgcmd.go
+++ b/tools/bgcmd.go
@@ -67,7 +67,7 @@ func (r *BgCommandRegistry) Get(id string) (*BgCommand, bool) {
 	return r.commands.Get(id)
 }
 
-// IsDone returns true if the command has finished.
+// IsDone reports whether the command has finished.
 func (bg *BgCommand) IsDone() bool {
 	select {
 	case <-bg.Done:


### PR DESCRIPTION
**Key Changes:**

- Improved Go documentation wording for the background command completion check
- Cleaned up logger documentation formatting for consistency
- Limited changes to comments and whitespace with no runtime behavior impact

**Changed:**

- Documentation comments - Updated the BgCommand IsDone comment in tools/bgcmd.go to follow clearer Go doc wording and removed an unnecessary blank line in logging/logging.go for cleaner formatting