### PR TITLE
fix: resolve missing skill-relative references

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   goreleaser:

--- a/.github/workflows/meta-labeler.yaml
+++ b/.github/workflows/meta-labeler.yaml
@@ -14,15 +14,8 @@ jobs:
     name: Labeler
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
-
       - name: Labeler
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           configuration-path: .github/labeler.yaml
-          repo-token: "${{ steps.app-token.outputs.token }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 permissions:
   actions: read

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/squad
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4

--- a/tools/skillresolve_test.go
+++ b/tools/skillresolve_test.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cowdogmoo/squad/skill"
+)
+
+// entryForDir builds a minimal catalog entry pointing at dir. Only Dir and a
+// name are needed for path-resolution tests.
+func entryForDir(name, dir string) skill.Entry {
+	return skill.Entry{
+		Manifest: &skill.Manifest{Name: name, Description: "test", Body: "test"},
+		Dir:      dir,
+	}
+}
+
+// TestResolvePathInRunRelativeReferenceUnderSkill is the regression guard for
+// the progressive-disclosure read path. A skill body links its reference with
+// a relative path (`references/foo.md`); when the agent Reads that path the
+// resolver must reach the file inside the loaded skill directory even though
+// the working directory has no such file. Before the existence-aware fallback,
+// the working-dir anchor claimed the relative path unconditionally and the
+// skill stack was never consulted, so the Read failed with not-found.
+func TestResolvePathInRunRelativeReferenceUnderSkill(t *testing.T) {
+	workingDir := t.TempDir()
+	skillDir := t.TempDir()
+
+	refRel := filepath.Join("references", "tell-categories.md")
+	refAbs := filepath.Join(skillDir, refRel)
+	if err := os.MkdirAll(filepath.Dir(refAbs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(refAbs, []byte("corpus"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := skill.NewStack()
+	stack.Push(entryForDir("detect-llm-tells", skillDir))
+	ctx := WithSkillRuntime(context.Background(), &SkillRuntime{Stack: stack})
+
+	got, err := resolvePathInRun(ctx, workingDir, refRel)
+	if err != nil {
+		t.Fatalf("resolvePathInRun returned error: %v", err)
+	}
+	if got != refAbs {
+		t.Errorf("resolved %q, want the skill-dir reference %q", got, refAbs)
+	}
+}
+
+// TestResolvePathInRunWorkingDirWins confirms the fallback does not change
+// behavior when the relative path DOES exist under the working directory: the
+// working-dir copy must still win over a same-named file inside a skill.
+func TestResolvePathInRunWorkingDirWins(t *testing.T) {
+	workingDir := t.TempDir()
+	skillDir := t.TempDir()
+
+	rel := "shared.md"
+	wdAbs := filepath.Join(workingDir, rel)
+	if err := os.WriteFile(wdAbs, []byte("working"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, rel), []byte("skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := skill.NewStack()
+	stack.Push(entryForDir("s", skillDir))
+	ctx := WithSkillRuntime(context.Background(), &SkillRuntime{Stack: stack})
+
+	got, err := resolvePathInRun(ctx, workingDir, rel)
+	if err != nil {
+		t.Fatalf("resolvePathInRun returned error: %v", err)
+	}
+	if got != wdAbs {
+		t.Errorf("resolved %q, want the working-dir file %q", got, wdAbs)
+	}
+}
+
+// TestResolvePathInRunMissingEverywhere confirms that when a relative path
+// exists in neither the working dir nor any skill, the resolver still returns
+// the working-dir-anchored path so the caller's not-found error matches the
+// input the user supplied.
+func TestResolvePathInRunMissingEverywhere(t *testing.T) {
+	workingDir := t.TempDir()
+	skillDir := t.TempDir()
+
+	stack := skill.NewStack()
+	stack.Push(entryForDir("s", skillDir))
+	ctx := WithSkillRuntime(context.Background(), &SkillRuntime{Stack: stack})
+
+	rel := "nope.md"
+	got, err := resolvePathInRun(ctx, workingDir, rel)
+	if err != nil {
+		t.Fatalf("resolvePathInRun returned error: %v", err)
+	}
+	if want := filepath.Join(workingDir, rel); got != want {
+		t.Errorf("resolved %q, want working-dir path %q", got, want)
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2111,21 +2111,63 @@ func (b *FlexBool) UnmarshalJSON(data []byte) error {
 func resolvePathInRun(ctx context.Context, workingDir, input string) (string, error) {
 	abs, err := ResolvePath(workingDir, input)
 	if err == nil {
-		return abs, nil
-	}
-	stack := GetSkillStack(ctx)
-	if stack == nil {
-		return "", err
-	}
-	if abs, ok := stack.Resolve(input); ok {
-		// Resolve confirms lexical containment; this rejects an existing
-		// target that escapes the skill dir through a symlink.
-		if serr := stack.VerifyNoSymlinkEscape(abs); serr != nil {
+		// The working-dir anchor accepted the path. ResolvePath only checks
+		// containment, not existence, so a relative path like
+		// "references/foo.md" "succeeds" here even when no such file exists in
+		// the working directory — which would shadow an identically-named file
+		// inside an active skill directory and break progressive disclosure.
+		// Prefer the working-dir target when it actually exists; otherwise fall
+		// through to the skill stack before giving up.
+		if _, statErr := os.Stat(abs); statErr == nil {
+			return abs, nil
+		}
+		resolved, ok, serr := resolveInSkillStack(ctx, input)
+		if serr != nil {
 			return "", serr
 		}
+		if ok {
+			if _, statErr := os.Stat(resolved); statErr == nil {
+				return resolved, nil
+			}
+		}
+		// Nothing exists in either anchor; return the working-dir path so the
+		// caller's not-found error matches the input the user supplied.
 		return abs, nil
 	}
+	// The working-dir anchor rejected the path (e.g. an absolute path or
+	// traversal outside the working dir). It may still live inside a loaded
+	// skill directory.
+	resolved, ok, serr := resolveInSkillStack(ctx, input)
+	if serr != nil {
+		return "", serr
+	}
+	if ok {
+		return resolved, nil
+	}
 	return "", err
+}
+
+// resolveInSkillStack resolves input against the run's active skill
+// directories. It returns:
+//   - (path, true, nil)  — input is inside an active skill dir and safe;
+//   - ("", false, nil)   — no skill stack, or input is not inside any skill dir;
+//   - ("", false, err)   — input is inside a skill dir but an existing target
+//     escapes it through a symlink (a rejection the caller must surface).
+func resolveInSkillStack(ctx context.Context, input string) (string, bool, error) {
+	stack := GetSkillStack(ctx)
+	if stack == nil {
+		return "", false, nil
+	}
+	abs, ok := stack.Resolve(input)
+	if !ok {
+		return "", false, nil
+	}
+	// Resolve confirms lexical containment; this rejects an existing target
+	// that escapes the skill dir through a symlink.
+	if err := stack.VerifyNoSymlinkEscape(abs); err != nil {
+		return "", false, err
+	}
+	return abs, true, nil
 }
 
 // ResolvePath resolves input against workingDir and verifies the result is


### PR DESCRIPTION
**Key Changes:**

- Fixed skill-relative path resolution so progressive-disclosure references can be read from active skill directories when they do not exist in the working directory
- Preserved working-directory precedence when the requested relative file exists in both the working directory and a loaded skill
- Added regression coverage for skill reference resolution, working-directory priority, and missing-file fallback behavior
- Updated the Squad Claude agent configuration to use Sonnet with explicit file and shell tools

**Added:**

- Regression tests for resolvePathInRun behavior - Added coverage for reading relative references from skill directories, preferring existing working-directory files, and returning working-directory paths for missing files in tools/skillresolve_test.go
- Reusable skill-stack resolution helper - Added resolveInSkillStack to centralize safe resolution against active skill directories and preserve symlink escape validation in tools/tools.go

**Changed:**

- Path resolution fallback behavior - Updated resolvePathInRun in tools/tools.go to check whether the working-directory target actually exists before falling back to the active skill stack, preventing non-existent working-directory paths from shadowing skill references
- Agent metadata and capabilities - Updated .claude/agents/squad-expert.md to use the Sonnet model, declare Read, Glob, Grep, and Bash tools explicitly, and simplify description formatting

**Removed:**

- Obsolete agent color metadata - Removed the color field from .claude/agents/squad-expert.md