### PR TITLE
feat: add comments-only edit guardrails

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -93,6 +93,12 @@ type Manifest struct {
 	DisableTask   bool               `yaml:"disable_task,omitempty"`
 	MaxIterations int                `yaml:"max_iterations,omitempty"` // iteration cap for this agent (0 = use CLI default)
 	EditDeadline  int                `yaml:"edit_deadline,omitempty"`  // stop after N iterations with no Edit calls (0 = disabled)
+	// CommentsOnly, when true, restricts Edit and MultiEdit calls to
+	// changes that only add or remove comment lines or blank lines.
+	// Edits that modify, add, or remove non-comment code are rejected.
+	// Use for comment-cleanup agents (e.g. go-scrub-comments) so an LLM
+	// hallucinating new code cannot silently break the codebase.
+	CommentsOnly bool `yaml:"comments_only,omitempty"`
 	// Isolation declares the recommended isolation mode: "" (none) or
 	// "worktree" to run inside a fresh git worktree on a new branch.
 	// CLI --isolate and config run.isolation override this.
@@ -247,6 +253,9 @@ type Bundle struct {
 	// filesystem tools are not registered and the runner skips
 	// working-dir resolution / repo-summary injection.
 	RemoteOnly bool
+	// CommentsOnly mirrors Manifest.CommentsOnly. Restricts Edit/MultiEdit
+	// to comment-only changes when true.
+	CommentsOnly bool
 	// SkillEntries is the filtered set of skills surfaced in the system
 	// prompt's "Available skills" block. The runner uses these to build
 	// the Skill tool's runtime so the names the agent sees are exactly
@@ -924,6 +933,7 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 		MaxIterations: manifest.MaxIterations,
 		EditDeadline:  manifest.EditDeadline,
 		RemoteOnly:    manifest.IsRemoteOnly(),
+		CommentsOnly:  manifest.CommentsOnly,
 		SkillEntries:  skillEntries,
 	}, nil
 }

--- a/runner/model.go
+++ b/runner/model.go
@@ -336,6 +336,12 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	// tool_choice:"required" so the model must explore before answering.
 	// Regular openai users rely on the auto behavior; only restrict compat endpoints.
 	forceFirstTool := provider == "openai-compat"
+	// langchaingo's OpenAI chat-completions integration rejects a single
+	// role:"tool" message with multiple parts ("expected exactly one part
+	// for role tool, got N"). Emit one message per tool result for those
+	// providers; Anthropic, Responses API, gemini, ollama keep the
+	// single-message form.
+	splitToolResults := provider == "openai" || provider == "openai-compat"
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
 	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, tools.RunWithToolsConfig{
 		MaxIterations:      opts.MaxIterations,
@@ -345,6 +351,7 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 		Executor:           ex,
 		UseCacheControl:    useCacheControl,
 		ForceFirstToolCall: forceFirstTool,
+		SplitToolResults:   splitToolResults,
 		Skill:              buildSkillRuntime(ctx, bundle, opts),
 		Confirm:            buildConfirmRuntime(opts),
 		MaxRetries:         opts.MaxRetries,

--- a/runner/run.go
+++ b/runner/run.go
@@ -176,8 +176,7 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 		logging.InfoContext(cmd.Context(), "remote-only agent: disabling require-actionable")
 	}
 
-	ctx := tools.InitEdits(cmd.Context())
-	ctx = tools.InitEditDeadline(ctx)
+	ctx := initRunContext(cmd.Context(), bundle)
 
 	logger, err := openSession(opts, bundle, prompt)
 	if err != nil {
@@ -216,6 +215,20 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	}
 
 	return nil
+}
+
+// initRunContext attaches per-run tool state (edits tracker, edit-deadline
+// counter, and opt-in modes from the manifest) to ctx before the agent
+// invocation. Returning a single helper keeps ExecuteRun's setup linear
+// regardless of how many opt-in modes get added over time.
+func initRunContext(ctx context.Context, bundle *agent.Bundle) context.Context {
+	ctx = tools.InitEdits(ctx)
+	ctx = tools.InitEditDeadline(ctx)
+	if bundle.CommentsOnly {
+		ctx = tools.InitCommentsOnlyMode(ctx)
+		logging.InfoContext(ctx, "comments-only mode: Edit/MultiEdit will reject non-comment changes")
+	}
+	return ctx
 }
 
 // handleBudgetExceeded reports a budget-exceeded run and applies any partial

--- a/tools/commentguard.go
+++ b/tools/commentguard.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type commentsOnlyKeyType struct{}
+
+// InitCommentsOnlyMode marks ctx as comments-only. While set, Edit and
+// MultiEdit calls reject any change that modifies non-comment lines.
+func InitCommentsOnlyMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, commentsOnlyKeyType{}, true)
+}
+
+// IsCommentsOnlyMode reports whether ctx is in comments-only mode.
+func IsCommentsOnlyMode(ctx context.Context) bool {
+	v, ok := ctx.Value(commentsOnlyKeyType{}).(bool)
+	return ok && v
+}
+
+// ValidateCommentsOnly returns nil when the diff between oldText and newText
+// touches only comment lines or blank lines, and an error otherwise. The
+// check is line-based and language-agnostic for common comment markers
+// (`//`, `#`, `--`, `/*`, `*/`, leading `*` inside a block comment).
+//
+// "Comment line" means the trimmed line is empty or starts with one of
+// those markers. The check enforces that the multiset of non-comment,
+// non-blank lines is identical in old and new — any added or removed
+// code line is a rejection.
+func ValidateCommentsOnly(oldText, newText string) error {
+	added, removed := codeLineDiff(oldText, newText)
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+	var sample string
+	switch {
+	case len(added) > 0:
+		sample = added[0]
+	default:
+		sample = removed[0]
+	}
+	return fmt.Errorf(
+		"comments-only edit rejected: %d non-comment line(s) added, %d removed (e.g. %q). "+
+			"This agent may only delete or trim comments. Edits that add/remove/modify code are forbidden",
+		len(added), len(removed), TruncateString(sample, 80))
+}
+
+// codeLineDiff returns the multiset difference of non-comment, non-blank
+// lines: lines present in newText but not (or in excess of) oldText are
+// "added"; the reverse are "removed".
+func codeLineDiff(oldText, newText string) (added, removed []string) {
+	oldCounts := countCodeLines(oldText)
+	newCounts := countCodeLines(newText)
+	for line, n := range newCounts {
+		excess := n - oldCounts[line]
+		for i := 0; i < excess; i++ {
+			added = append(added, line)
+		}
+	}
+	for line, n := range oldCounts {
+		excess := n - newCounts[line]
+		for i := 0; i < excess; i++ {
+			removed = append(removed, line)
+		}
+	}
+	return added, removed
+}
+
+// countCodeLines returns a multiset of non-comment, non-blank lines from
+// text, keyed by the trimmed line content with any trailing `// ...`
+// comment removed.
+func countCodeLines(text string) map[string]int {
+	out := make(map[string]int)
+	for _, raw := range strings.Split(text, "\n") {
+		line := stripTrailingLineComment(raw)
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if isCommentMarker(trimmed) {
+			continue
+		}
+		out[trimmed]++
+	}
+	return out
+}
+
+// isCommentMarker reports whether a trimmed line begins with a known
+// single- or multi-line comment marker.
+func isCommentMarker(trimmed string) bool {
+	switch {
+	case strings.HasPrefix(trimmed, "//"):
+		return true
+	case strings.HasPrefix(trimmed, "#"):
+		return true
+	case strings.HasPrefix(trimmed, "--"):
+		return true
+	case strings.HasPrefix(trimmed, "/*"), strings.HasPrefix(trimmed, "*/"):
+		return true
+	case strings.HasPrefix(trimmed, "*"):
+		return true
+	}
+	return false
+}
+
+// stripTrailingLineComment removes a trailing `// ...` on a code line. It
+// does not parse strings, so a `//` inside a string literal would also be
+// stripped — acceptable for this validator because the goal is to compare
+// code structure, not to render code.
+func stripTrailingLineComment(line string) string {
+	if i := strings.Index(line, "//"); i >= 0 {
+		return strings.TrimRight(line[:i], " \t")
+	}
+	return line
+}

--- a/tools/commentguard_test.go
+++ b/tools/commentguard_test.go
@@ -1,0 +1,352 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateCommentsOnly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		old     string
+		new     string
+		wantErr bool
+		wantSub string
+	}{
+		{
+			name: "delete entire single-line comment",
+			old: `// Set foo to bar.
+foo = bar`,
+			new:     `foo = bar`,
+			wantErr: false,
+		},
+		{
+			name: "delete one line of a doc-comment block",
+			old: `// Foo does the thing.
+// Step 1: prepare.
+func Foo() {}`,
+			new: `// Foo does the thing.
+func Foo() {}`,
+			wantErr: false,
+		},
+		{
+			name: "trim blank-line gap between doc comment and decl",
+			old: `// Foo does the thing.
+
+func Foo() {}`,
+			new: `// Foo does the thing.
+func Foo() {}`,
+			wantErr: false,
+		},
+		{
+			name: "add new function is rejected",
+			old: `package x
+
+func Foo() {}`,
+			new: `package x
+
+func Foo() {}
+
+func Bar() { return }`,
+			wantErr: true,
+			wantSub: "added",
+		},
+		{
+			name: "duplicate package decl is rejected",
+			old: `package tools
+
+const x = 1`,
+			new: `package tools
+
+package tools
+
+const x = 1`,
+			wantErr: true,
+			wantSub: "added",
+		},
+		{
+			name:    "modify code (rename identifier) is rejected",
+			old:     `foo := 1`,
+			new:     `bar := 1`,
+			wantErr: true,
+		},
+		{
+			name:    "no-op edit",
+			old:     `func Foo() {}`,
+			new:     `func Foo() {}`,
+			wantErr: false,
+		},
+		{
+			name:    "delete trailing line comment is allowed",
+			old:     `x := 1 // counter`,
+			new:     `x := 1`,
+			wantErr: false,
+		},
+		{
+			name: "python hash comment delete is allowed",
+			old: `# noisy
+x = 1`,
+			new:     `x = 1`,
+			wantErr: false,
+		},
+		{
+			name: "SQL dash comment delete is allowed",
+			old: `-- get all
+SELECT * FROM t`,
+			new:     `SELECT * FROM t`,
+			wantErr: false,
+		},
+		{
+			name: "block comment line delete is allowed",
+			old: `/* note */
+SELECT * FROM t`,
+			new:     `SELECT * FROM t`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateCommentsOnly(tt.old, tt.new)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantSub != "" && err != nil && !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("error %q missing substring %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestIsCommentsOnlyMode_defaultFalse(t *testing.T) {
+	t.Parallel()
+	if IsCommentsOnlyMode(context.Background()) {
+		t.Fatal("default ctx should not be in comments-only mode")
+	}
+}
+
+func TestInitCommentsOnlyMode(t *testing.T) {
+	t.Parallel()
+	ctx := InitCommentsOnlyMode(context.Background())
+	if !IsCommentsOnlyMode(ctx) {
+		t.Fatal("InitCommentsOnlyMode should set the flag")
+	}
+}
+
+// editPayload is the minimal JSON shape the Edit tool accepts. Declared
+// once so the integration tests below don't repeat the inline struct.
+type editPayload struct {
+	Path string `json:"path"`
+	Old  string `json:"old"`
+	New  string `json:"new"`
+}
+
+func TestEditTool_commentsOnlyMode_rejectsCodeChange(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const src = "package x\n\nfunc Foo() {}\n"
+	writeTestFile(t, dir, "main.go", src)
+
+	tool := editTool(dir)
+	ctx := InitCommentsOnlyMode(context.Background())
+	raw, _ := json.Marshal(editPayload{
+		Path: "main.go",
+		Old:  "func Foo() {}",
+		New:  "func Foo() {}\n\nfunc Bar() { return }",
+	})
+
+	_, err := tool(ctx, raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "comments-only") {
+		t.Fatalf("expected comments-only rejection, got: %v", err)
+	}
+	if got := readTestFile(t, dir+"/main.go"); got != src {
+		t.Fatalf("file should be unchanged on rejection; got: %q", got)
+	}
+}
+
+func TestEditTool_commentsOnlyMode_allowsCommentDelete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "main.go", "// Set foo to bar.\nfoo := bar\n")
+
+	tool := editTool(dir)
+	ctx := InitCommentsOnlyMode(context.Background())
+	raw, _ := json.Marshal(editPayload{
+		Path: "main.go",
+		Old:  "// Set foo to bar.\nfoo := bar\n",
+		New:  "foo := bar\n",
+	})
+
+	if _, err := tool(ctx, raw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := readTestFile(t, dir+"/main.go"); got != "foo := bar\n" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestEditTool_commentsOnlyMode_offByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "main.go", "func Foo() {}\n")
+
+	tool := editTool(dir)
+	raw, _ := json.Marshal(editPayload{
+		Path: "main.go",
+		Old:  "func Foo() {}",
+		New:  "func Bar() {}",
+	})
+
+	if _, err := tool(context.Background(), raw); err != nil {
+		t.Fatalf("default mode should allow code change: %v", err)
+	}
+	if got := readTestFile(t, dir+"/main.go"); got != "func Bar() {}\n" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestMultiEditTool_commentsOnlyMode_rejectsCodeChange(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const src = "package x\n\nfunc Foo() {}\n"
+	writeTestFile(t, dir, "main.go", src)
+
+	tool := multiEditTool(dir)
+	ctx := InitCommentsOnlyMode(context.Background())
+	raw, _ := json.Marshal(MultiEditArgs{
+		Path: "main.go",
+		Edits: []MultiEditOperation{
+			{Old: "func Foo() {}", New: "func Foo() {}\n\nfunc Bar() {}"},
+		},
+	})
+
+	_, err := tool(ctx, raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := readTestFile(t, dir+"/main.go"); got != src {
+		t.Fatalf("file should be unchanged on rejection; got: %q", got)
+	}
+}
+
+// TestEditTool_commentsOnlyMode_rejectsHallucinatedFunctionInsertion replays
+// the exact Edit payload the gpt-4.1-mini run made against ui/pane/pane.go —
+// it grafts an isTautologicalComment function and a call site into the
+// middle of ClassifyKind, framed as comment cleanup. Without the guardrail
+// this Edit succeeded and broke the build with `undefined: strings`. The
+// guardrail must reject it and leave the file byte-identical.
+func TestEditTool_commentsOnlyMode_rejectsHallucinatedFunctionInsertion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	original := `package pane
+
+import "strings"
+
+type Kind int
+
+const KindPrompt Kind = 0
+
+func ClassifyKind(raw string) (Kind, string) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return KindPrompt, ""
+	}
+	switch trimmed[0] {
+	case '/':
+		return KindPrompt, trimmed[1:]
+	}
+	return KindPrompt, trimmed
+}
+`
+	writeTestFile(t, dir, "pane.go", original)
+
+	oldStr := `	if trimmed == "" {
+		return KindPrompt, ""
+	}
+	switch trimmed[0] {`
+	newStr := `	if trimmed == "" {
+		return KindPrompt, ""
+	}
+	// Delete tautological comments like "// Prompt the user."
+	if isTautologicalComment(trimmed) {
+		return KindPrompt, ""
+	}
+	switch trimmed[0] {`
+
+	tool := editTool(dir)
+	ctx := InitCommentsOnlyMode(context.Background())
+	raw, _ := json.Marshal(editPayload{Path: "pane.go", Old: oldStr, New: newStr})
+
+	_, err := tool(ctx, raw)
+	if err == nil {
+		t.Fatal("guardrail failed: hallucinated Edit was accepted")
+	}
+	if !strings.Contains(err.Error(), "comments-only edit rejected") {
+		t.Fatalf("rejected for wrong reason: %v", err)
+	}
+	if got := readTestFile(t, dir+"/pane.go"); got != original {
+		t.Fatalf("file was mutated despite rejection:\nwant: %q\ngot:  %q", original, got)
+	}
+}
+
+// TestEditTool_commentsOnlyMode_rejectsDuplicatePackageBlock replays the
+// duplicate-package-decl injection the same run made against tools/retry.go.
+// Without the guardrail the file got two `package tools` declarations and
+// failed to compile.
+func TestEditTool_commentsOnlyMode_rejectsDuplicatePackageBlock(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	original := `package tools
+
+import "time"
+
+const (
+	DefaultMaxRetries = 3
+	retryBaseDelay    = 2 * time.Second
+)
+`
+	writeTestFile(t, dir, "retry.go", original)
+
+	oldStr := `const (
+	DefaultMaxRetries = 3
+	retryBaseDelay    = 2 * time.Second
+)`
+	newStr := `const (
+	DefaultMaxRetries = 3
+	retryBaseDelay    = 2 * time.Second
+)
+
+package tools
+
+import "time"
+
+const (
+	DefaultMaxRetries = 3
+	retryBaseDelay    = 2 * time.Second
+)`
+
+	tool := editTool(dir)
+	ctx := InitCommentsOnlyMode(context.Background())
+	raw, _ := json.Marshal(editPayload{Path: "retry.go", Old: oldStr, New: newStr})
+
+	_, err := tool(ctx, raw)
+	if err == nil {
+		t.Fatal("guardrail failed: duplicate package decl Edit was accepted")
+	}
+	if !strings.Contains(err.Error(), "comments-only edit rejected") {
+		t.Fatalf("rejected for wrong reason: %v", err)
+	}
+	if got := readTestFile(t, dir+"/retry.go"); got != original {
+		t.Fatal("file mutated despite rejection")
+	}
+}

--- a/tools/multiedit.go
+++ b/tools/multiedit.go
@@ -107,6 +107,16 @@ func multiEditTool(workingDir string) func(ctx context.Context, rawArgs []byte) 
 				})
 				continue
 			}
+			if IsCommentsOnlyMode(ctx) {
+				if err := ValidateCommentsOnly(edit.Old, edit.New); err != nil {
+					failed = append(failed, FailedEdit{
+						Index: i,
+						Old:   edit.Old,
+						Error: err.Error(),
+					})
+					continue
+				}
+			}
 			if bool(edit.ReplaceAll) {
 				content = strings.ReplaceAll(content, edit.Old, edit.New)
 			} else {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -345,6 +345,13 @@ type RunWithToolsConfig struct {
 	// MaxRetries is the number of additional attempts after a failed LLM
 	// call for transient errors. Zero falls back to DefaultMaxRetries.
 	MaxRetries int
+	// SplitToolResults, when true, emits one llms.MessageContent per tool
+	// result instead of batching all parts into a single message. Required
+	// for OpenAI chat completions, whose API rejects a single role:"tool"
+	// message with multiple parts ("expected exactly one part for role
+	// tool"). Anthropic requires the single-message form, so leave this
+	// false for the anthropic provider.
+	SplitToolResults bool
 }
 
 // RunWithTools drives the tool-calling loop for a LangChain-compatible LLM.
@@ -718,7 +725,7 @@ func toolLoop(ctx context.Context, llm llms.Model, messages []llms.MessageConten
 		// Snapshot cache size before execution to detect new file reads.
 		cacheSizeBefore := readCacheSize(ctx)
 
-		messages = executeToolCalls(ctx, messages, mergedToolCalls, handlers)
+		messages = executeToolCalls(ctx, messages, mergedToolCalls, handlers, cfg.SplitToolResults)
 
 		postResult := trackPostExecution(ctx, messages, mergedToolCalls, editEnforcer, phaseEnforcer, &loopDetector, &grace, cacheSizeBefore)
 		if postResult.stuck {
@@ -998,10 +1005,13 @@ var serialTools = map[string]bool{
 	"Task":           true,
 }
 
-func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]Handler) []llms.MessageContent {
-	// Batch all tool results into a single message.  Anthropic requires every
-	// tool_result to be in the same user message that follows the assistant
-	// message containing the corresponding tool_use blocks.
+func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolCalls []llms.ToolCall, handlers map[string]Handler, splitResults bool) []llms.MessageContent {
+	// Default form: batch all tool results into a single message. Anthropic
+	// requires every tool_result to be in the same user message that follows
+	// the assistant message containing the corresponding tool_use blocks.
+	// When splitResults is set (OpenAI chat completions), emit one message
+	// per tool result instead — chat-completions rejects multi-part
+	// role:"tool" messages.
 	parts := make([]llms.ContentPart, len(toolCalls))
 
 	// Determine if we can parallelize: only when there are multiple calls
@@ -1031,6 +1041,16 @@ func executeToolCalls(ctx context.Context, messages []llms.MessageContent, toolC
 		for i, toolCall := range toolCalls {
 			parts[i] = executeToolCall(ctx, toolCall, handlers)
 		}
+	}
+
+	if splitResults {
+		for _, part := range parts {
+			messages = append(messages, llms.MessageContent{
+				Role:  llms.ChatMessageTypeTool,
+				Parts: []llms.ContentPart{part},
+			})
+		}
+		return messages
 	}
 
 	return append(messages, llms.MessageContent{
@@ -1584,6 +1604,11 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		content := string(data)
 		if !strings.Contains(content, payload.Old) {
 			return "", fmt.Errorf("text not found in %s", payload.Path)
+		}
+		if IsCommentsOnlyMode(ctx) {
+			if err := ValidateCommentsOnly(payload.Old, payload.New); err != nil {
+				return "", err
+			}
 		}
 		var updated string
 		replaced := 1

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -2224,7 +2224,7 @@ func TestExecuteToolCallsParallel(t *testing.T) {
 		{ID: "2", FunctionCall: &llms.FunctionCall{Name: "Glob", Arguments: `{"pattern":"*.go"}`}},
 	}
 
-	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers)
+	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers, false)
 	if len(messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messages))
 	}
@@ -2261,13 +2261,61 @@ func TestExecuteToolCallsSerialWhenMutating(t *testing.T) {
 		{ID: "2", FunctionCall: &llms.FunctionCall{Name: "Bash", Arguments: `{"command":"echo hi"}`}},
 	}
 
-	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers)
+	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers, false)
 	if len(messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messages))
 	}
 	// Sequential execution: order should be preserved.
 	if len(callOrder) != 2 || callOrder[0] != "Read" || callOrder[1] != "Bash" {
 		t.Fatalf("callOrder = %v, want [Read Bash]", callOrder)
+	}
+}
+
+// TestExecuteToolCallsSplitResults checks both branches of the
+// splitResults parameter. When false (Anthropic, Responses API, gemini,
+// ollama), all N tool results are batched into one role:"tool" message
+// with N parts. When true (OpenAI chat completions and openai-compat),
+// the same N results become N separate messages with 1 part each — the
+// shape langchaingo's OpenAI integration needs to avoid the
+// "expected exactly one part for role tool, got N" error.
+func TestExecuteToolCallsSplitResults(t *testing.T) {
+	t.Parallel()
+	handlers := map[string]Handler{
+		"Read": {
+			Def: llms.Tool{Function: &llms.FunctionDefinition{Name: "Read"}},
+			Call: func(_ context.Context, _ []byte) (string, error) {
+				return "ok", nil
+			},
+		},
+	}
+	toolCalls := make([]llms.ToolCall, 6)
+	for i := range toolCalls {
+		toolCalls[i] = llms.ToolCall{
+			ID: fmt.Sprintf("%d", i+1),
+			FunctionCall: &llms.FunctionCall{
+				Name:      "Read",
+				Arguments: fmt.Sprintf(`{"path":"%c.go"}`, 'a'+i),
+			},
+		}
+	}
+
+	batched := executeToolCalls(context.Background(), nil, toolCalls, handlers, false)
+	if len(batched) != 1 || len(batched[0].Parts) != 6 {
+		t.Fatalf("batched shape: want 1 message * 6 parts, got %d messages",
+			len(batched))
+	}
+
+	split := executeToolCalls(context.Background(), nil, toolCalls, handlers, true)
+	if len(split) != 6 {
+		t.Fatalf("split shape: want 6 messages, got %d", len(split))
+	}
+	for i, msg := range split {
+		if len(msg.Parts) != 1 {
+			t.Fatalf("split message %d has %d parts, want 1", i, len(msg.Parts))
+		}
+		if msg.Role != llms.ChatMessageTypeTool {
+			t.Fatalf("split message %d has role %q, want tool", i, msg.Role)
+		}
 	}
 }
 
@@ -2285,7 +2333,7 @@ func TestExecuteToolCallsSingleCallNoParallel(t *testing.T) {
 		{ID: "1", FunctionCall: &llms.FunctionCall{Name: "Read", Arguments: `{}`}},
 	}
 
-	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers)
+	messages := executeToolCalls(context.Background(), nil, toolCalls, handlers, false)
 	if len(messages) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(messages))
 	}


### PR DESCRIPTION
**Key Changes:**

- Added opt-in comments-only mode for agents that should only modify comments or blank lines
- Enforced comments-only validation in Edit and MultiEdit before files are mutated
- Split OpenAI tool results into one message per result to satisfy chat-completions constraints
- Added coverage for comment validation, guarded edit behavior, and provider-specific tool result shaping

**Added:**

- Comments-only manifest support - Introduced a comments_only agent option that flows into bundle runtime state so specialized cleanup agents can opt into stricter edit validation
- Comment guard validation - Added language-agnostic line-based validation that permits comment and blank-line changes while rejecting added, removed, or modified non-comment code
- Guardrail test coverage - Added tests for allowed comment cleanup, rejected code changes, hallucinated function insertion, duplicate package injection, and comments-only context state
- Split tool result configuration - Added a SplitToolResults runtime option to support providers that require one tool result per message

**Changed:**

- Run initialization - Centralized per-run context setup so edit tracking, edit-deadline tracking, and comments-only mode are initialized together before agent execution
- Edit tool enforcement - Updated Edit and MultiEdit to reject non-comment changes in comments-only mode before applying replacements, preserving files unchanged on rejection
- Tool result emission - Updated tool call execution to keep batched tool results by default while splitting results for OpenAI and OpenAI-compatible chat-completions providers
- Existing tool execution tests - Updated call sites for the new split-results parameter and added assertions for both batched and split message shapes