### PR TITLE
docs: refresh project docs and add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,4 +655,4 @@ This project is licensed under the MIT License — see the [LICENSE](LICENSE) fi
 
 ## Security
 
-Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel, the Semgrep + govulncheck pipeline, and guidance for running squad safely in production workflows.
+Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel and the Semgrep + govulncheck pipeline. For operational guidance on running squad safely in production (cost caps, isolation, secrets, agent-yaml review), see [Running Squad Safely](docs/configuration.md#running-squad-safely) in the configuration docs.

--- a/README.md
+++ b/README.md
@@ -9,158 +9,256 @@
 [![Release](https://img.shields.io/github/v/release/CowDogMoo/squad?label=Release&logo=github)](https://github.com/CowDogMoo/squad/releases)
 [![codecov](https://codecov.io/github/CowDogMoo/squad/graph/badge.svg?token=O74GTQA4J7)](https://codecov.io/github/CowDogMoo/squad)
 <br />
-[![Semgrep](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml)
+[![Tests](https://github.com/CowDogMoo/squad/actions/workflows/tests.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/tests.yaml)
 [![Pre-Commit](https://github.com/CowDogMoo/squad/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/pre-commit.yaml)
+[![Semgrep](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml)
 [![Renovate](https://github.com/CowDogMoo/squad/actions/workflows/renovate.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/renovate.yaml)
-
-<h4><code>squad</code> is an open-source framework for building, sharing, and running AI agents from the command line.</h4>
 
 </div>
 
 ---
 
-## Overview
+`squad` is a framework for building, sharing, and running unattended AI agents from the command line. Define an agent as plain markdown prompts and a YAML manifest, point it at any LLM provider, and let it work through a codebase using a fixed tool surface (Read, Write, Edit, Glob, Grep, Bash, plus any MCP server).
 
-Inspired by [Daniel Miessler's Fabric](https://github.com/danielmiessler/fabric).
-Define an agent in markdown and YAML, point it at any LLM, and turn it
-loose on a codebase.
+Agents run in a deterministic tool loop with per-run cost caps, structured event logs, and session resume. Multi-agent **pipelines** compose stages with dependency ordering and regression gates. **Routines** schedule unattended runs through OS-native daemons. Provider support includes OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, vLLM, LM Studio, Together AI). Execution can target the local machine, a Docker container, a Kubernetes pod, or an EC2 instance over AWS SSM.
 
-- Works with OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, DeepInfra, Together AI, vLLM, LM Studio, and more)
-- Agents are just files: markdown prompts + YAML manifest, checked into git
-- Built-in tools: Read, Write, Edit, Glob, Grep, Bash, plus any MCP server
-- Multi-agent pipelines with dependency ordering, parallel stages, and regression gates
-- Runs locally, in Docker, on Kubernetes, or over AWS SSM
-- Scheduled unattended runs via OS-native daemons (launchd, systemd, Task Scheduler)
+## Table of Contents
 
-**Built for:**
+- [Architecture](#architecture)
+- [Quick Start](#quick-start)
+- [CLI Reference](#cli-reference)
+- [Agents](#agents)
+- [Multi-Agent Pipelines](#multi-agent-pipelines)
+- [Routines](#routines)
+- [Sessions & Resume](#sessions--resume)
+- [Execution Backends](#execution-backends)
+- [MCP Servers](#mcp-servers)
+- [Skills](#skills)
+- [Browser Profiles](#browser-profiles)
+- [Configuration](#configuration)
+- [Repository Layout](#repository-layout)
+- [Development](#development)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+- [Security](#security)
 
-- Security teams running code review, audits, and recon
-- Platform engineers enforcing standards across repos
-- Developers building review and refactoring workflows
+## Architecture
 
-## Prerequisites
+`squad` is a single Go binary built around a deterministic tool-calling loop. The CLI assembles an **agent bundle** (system prompt + tool definitions + budget config) from on-disk markdown and YAML, then drives the model through tool calls until it returns a final response or a budget/iteration cap fires.
 
-| Requirement    | Version | Notes                                   |
-| -------------- | ------- | --------------------------------------- |
-| **Go**         | 1.24+   | Required for `go install`               |
-| **LLM access** | -       | OpenAI, Anthropic, Google AI, or Ollama |
-
-## Installation
-
-```bash
-go install github.com/cowdogmoo/squad/cmd/squad@latest
+```text
+                        ┌──────────────────────────────────────────────┐
+                        │                squad (CLI)                   │
+                        │   run · agents · routine · pipeline · ...    │
+                        └──────────────┬───────────────────────────────┘
+                                       │
+                        ┌──────────────▼───────────────┐
+                        │     Agent Bundle (agent/)    │
+                        │  system.md + agent.md +      │
+                        │  agent.yaml + skills + refs  │
+                        └──────────────┬───────────────┘
+                                       │
+                        ┌──────────────▼───────────────┐
+                        │   Tool Loop (tools/)         │
+                        │ Read · Edit · Bash · Glob ·  │
+                        │ Grep · Task · MCP · Skill    │
+                        └──┬───────────┬────────────┬──┘
+                           │           │            │
+            ┌──────────────▼─┐  ┌──────▼──────┐ ┌───▼─────────────┐
+            │  LLM Providers  │  │  Executor   │ │  MCP Servers    │
+            │ openai · gpt    │  │ local ·     │ │ stdio · sse ·   │
+            │ anthropic       │  │ docker ·    │ │ http (any tool) │
+            │ gemini · ollama │  │ kubectl ·   │ │                 │
+            │ openai-compat   │  │ ssm         │ │                 │
+            └─────────────────┘  └─────────────┘ └─────────────────┘
 ```
 
-### Build from Source
-
-```bash
-git clone https://github.com/cowdogmoo/squad.git
-cd squad
-go build -o squad ./cmd/squad
-```
-
-### Verification
-
-```bash
-squad version
-```
+| Package      | Purpose                                                                    |
+| ------------ | -------------------------------------------------------------------------- |
+| `cmd/squad`  | Cobra CLI: subcommands for `run`, `agents`, `routine`, `pipeline`, etc.    |
+| `agent`      | Manifest parsing, bundle assembly, model preferences, skill catalog        |
+| `runner`     | Per-run context (edits, deadlines, modes), model invocation, response apply |
+| `tools`      | Tool definitions and the iteration loop (Read/Write/Edit/Glob/Grep/Bash/…) |
+| `pipeline`   | Multi-stage agent composition with parallel stages and regression gates    |
+| `skill`      | On-demand Anthropic-format Skills: progressive-disclosure tool extensions  |
+| `mcp`        | Model Context Protocol client + handler registration                       |
+| `executor`   | Run shell commands locally, in Docker, on K8s, or over AWS SSM             |
+| `routine`    | OS-native scheduled runs (launchd, systemd, Windows Task Scheduler)        |
+| `responses`  | OpenAI Responses API path (server-side state, large-result offload)        |
+| `metrics`    | Token + cost accounting, per-run budget enforcement                        |
+| `grading`    | Rubric-based scoring of agent runs                                         |
+| `ui`         | Bubble Tea TUI for interactive launch and monitoring                       |
+| `source`     | Skill discovery from local paths and git-hosted agent repos                |
+| `session`    | Append-only event log per run; powers `--resume`                           |
 
 ## Quick Start
 
+### Prerequisites
+
+| Requirement    | Version | Notes                                                                |
+| -------------- | ------- | -------------------------------------------------------------------- |
+| **Go**         | 1.24+   | Required for `go install`                                            |
+| **LLM access** | -       | OpenAI, Anthropic, Google AI, Ollama, or any OpenAI-compatible endpoint |
+| **Git**        | -       | Required for agent-repository fetching and worktree isolation         |
+
+### Install
+
 ```bash
-# Initialize configuration
+# Install latest release
+go install github.com/cowdogmoo/squad/cmd/squad@latest
+
+# Or build from source
+git clone https://github.com/cowdogmoo/squad.git && cd squad
+go build -o squad ./cmd/squad
+
+# Verify
+squad version
+```
+
+### Configure
+
+```bash
+# Initialize config at ~/.config/squad/config.yaml
 squad config init
 
-# Add the official agents repository
-squad agents add official https://github.com/cowdogmoo/squad-agents.git
+# Set a default provider and model
+squad config set provider.default anthropic
+squad config set model.default claude-sonnet-4-6
 
-# List available agents
-squad agents list
-
-# Run an agent against your codebase
-squad run --agent go-review --provider openai --model gpt-4.1-mini
-
-# Run with local Ollama — no API key required
-squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
-
-# Run a composed (multi-agent) pipeline
-squad run --agent security-audit "Review this codebase"
-
-# Resume a prior run after a crash, ctrl-c, or budget stop
-squad run --agent go-review --resume 20260429T150220Z-a1b2c3d4 \
-    "continue where you left off; finish the remaining files"
+# Show the merged effective config
+squad config show
 ```
 
-## Usage
+API keys can come from environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_AI_API_KEY`) or from `$(command)` substitution in `config.yaml` for secret managers.
 
-### Key Run Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--agent` | Agent name to run | required |
-| `--provider` | LLM provider | config default |
-| `--model` | Model identifier | config default |
-| `--working-dir` | Target directory | current dir |
-| `--max-cost` | USD budget cap | `5.00` |
-| `--max-iterations` | Max tool-call loops | `100` |
-| `--apply` | Apply suggested diffs via git apply | `false` |
-| `--dry-run` | Estimate cost without running | `false` |
-| `--stream` | Stream tokens to stderr in real time | `false` |
-| `--resume` | Resume a session by ID | — |
-| `--out` | Write response to file | — |
-| `--var KEY=VALUE` | Template variable (repeatable) | — |
-| `--mcp-server` | MCP server spec (repeatable) | — |
-| `--isolate` | Isolation mode (e.g. `worktree`) | — |
-
-### Sessions
-
-Every run writes an append-only event log to `./.squad/sessions/<id>/`:
-
-| File               | Contents                                               |
-| ------------------ | ------------------------------------------------------ |
-| `meta.json`        | Run options, last response id, cost, status            |
-| `events.jsonl`     | One line per prompt, response, tool call, tool result  |
-| `results/<id>.txt` | Full bytes of any tool result that exceeded 8 KiB      |
-
-`--resume <id>` reopens that session and chains the next request to the
-prior OpenAI Responses API id, so the model picks up server-side state
-without re-sending the transcript. When a tool result is too large to
-inline, the model sees a `[result:<id> — N bytes elided …]` placeholder
-and can fetch the full bytes via the `get_tool_result` tool.
-
-### Creating Your Own Agent
+### First Run
 
 ```bash
-# Scaffold from a built-in template
-squad init agent my-review --lang go
+# Pull the official agents repo
+squad agents add official https://github.com/cowdogmoo/squad-agents.git
+squad agents list
 
-# Edit the prompts
-$EDITOR agents/my-review/system.md
+# Run an agent against the current directory
+squad run --agent go-review --provider openai --model gpt-4.1-mini
 
-# Test it
-squad run --agent my-review --print
+# Run with local Ollama (no API key required)
+squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
+
+# Estimate cost without calling the model
+squad run --agent go-review --dry-run
+
+# Resume a prior run after a crash, ctrl-c, or budget stop
+squad run --agent go-review --resume 20260429T150220Z-a1b2c3d4
 ```
 
-Agent directory structure:
+## CLI Reference
 
-```
+`squad` is a unified CLI with the following subcommands:
+
+| Subcommand   | Purpose                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `run`        | Run a single agent or composed pipeline                                  |
+| `agents`     | Add, remove, and list agent sources (local paths and git repos)          |
+| `init`       | Scaffold a new agent, config, or routine from templates                  |
+| `config`     | Initialize, inspect, and edit the squad config                           |
+| `routine`    | Manage scheduled, unattended agent runs                                  |
+| `skill`      | Inspect, validate, and manage Agent Skills                               |
+| `mcp`        | Inspect and debug MCP servers                                            |
+| `grade`      | Grade an agent run output against a rubric                               |
+| `browser`    | Manage named browser profiles for agents that drive Chrome               |
+| `ui`         | Interactive TUI for launching and monitoring runs                        |
+| `completion` | Generate shell completion scripts                                        |
+| `version`    | Print the active binary version                                          |
+
+Run `squad <subcommand> --help` for full flag documentation.
+
+### Global Flags
+
+| Flag                | Description                                              | Default                          |
+| ------------------- | -------------------------------------------------------- | -------------------------------- |
+| `-c, --config`      | Config file path                                         | `~/.config/squad/config.yaml`    |
+| `--log-level`       | `debug`, `info`, `warn`, `error`                         | `info`                           |
+| `--log-format`      | `text`, `json`, `color`                                  | `text`                           |
+| `--otel-endpoint`   | OpenTelemetry OTLP endpoint (e.g. `localhost:4318`)      | disabled                         |
+| `-q, --quiet`       | Suppress non-error output                                | `false`                          |
+| `-v, --verbose`     | Show debug output                                        | `false`                          |
+
+### `squad run` — Key Flags
+
+| Flag                  | Description                                                       | Default       |
+| --------------------- | ----------------------------------------------------------------- | ------------- |
+| `--agent`             | Agent name (required)                                             | —             |
+| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, …)       | config        |
+| `--model`             | Model identifier                                                  | config        |
+| `--working-dir`       | Target directory the agent operates on                            | current dir   |
+| `--max-cost`          | USD budget cap (0 = unlimited)                                    | `5.00`        |
+| `--max-iterations`    | Max tool-calling iterations (10-1000)                             | `100`         |
+| `--mode`              | Override agent's default mode (e.g. `readonly`)                   | manifest      |
+| `--apply`             | Apply unified diff from response to working directory             | `false`       |
+| `--dry-run`           | Build bundle and exit without calling the model                   | `false`       |
+| `--resume`            | Resume a prior session by ID                                      | —             |
+| `--isolate`           | Isolation mode: `worktree`, `branch`, `commit`, `staged`, `none`  | manifest      |
+| `--stream`            | Stream tokens to stderr in real time                              | `false`       |
+| `--out`               | Write final response to file                                      | —             |
+| `--var KEY=VALUE`     | Template variable (repeatable)                                    | —             |
+| `--mcp-server`        | MCP server spec (repeatable)                                      | —             |
+| `--allow-skill`       | Restrict skills to this allowlist (repeatable)                    | manifest      |
+| `--auto-confirm`      | How `Confirm` tool resolves in non-TTY runs (`yes`/`no`/`abort`)  | `abort`       |
+
+## Agents
+
+An agent is a directory of plain files checked into git. The CLI loads it, assembles the bundle, and drives the tool loop.
+
+```text
 my-review/
-├── agent.yaml      # Manifest (model preferences, tools, budget, pipeline)
+├── agent.yaml      # Manifest: model preferences, tools, budget, pipeline
 ├── system.md       # Agent identity, rules, and workflow
 ├── agent.md        # Execution wrapper
 ├── task.md         # Default task instructions
 └── references/     # Optional knowledge-base documents
 ```
 
+### Scaffold
+
+```bash
+# Create a new agent from a built-in template
+squad init agent my-review --lang go
+
+# Edit the system prompt
+$EDITOR agents/my-review/system.md
+
+# Test it
+squad run --agent my-review --print
+```
+
+### Sources
+
+Agents can come from local directories or git-hosted repositories:
+
+```bash
+squad agents add official https://github.com/cowdogmoo/squad-agents.git
+squad agents add team git@github.com:internal/agents.git
+squad agents add scratch ./local-agents/
+
+squad agents list
+squad agents update              # pull all sources
+squad agents remove team
+```
+
+The [official agents repo](https://github.com/CowDogMoo/squad-agents) ships production-tuned agents for Go review, Python review, comment scrubbing, security audit, Ansible playbook validation, and more.
+
+Full agent-authoring guide: [docs/creating-agents.md](docs/creating-agents.md). For the underlying taxonomy (agents, skills, the `Task` tool, and pipelines, and when to reach for each), see [docs/agents-and-skills.md](docs/agents-and-skills.md). First time writing prompts? Start with [docs/prompt-engineering-basics.md](docs/prompt-engineering-basics.md).
+
 ## Multi-Agent Pipelines
 
-Define pipelines declaratively in `agent.yaml` using `stages` and `gates`:
+Define pipelines declaratively in `agent.yaml` with `stages` and `gates`:
 
 ```yaml
 name: security-audit
 stages:
   - name: scan
-    agents: [go-review, dependency-check]  # run in parallel
+    agents: [go-review, dependency-check]   # run in parallel
   - name: report
     agent: summarize
     depends_on: [scan]
@@ -174,7 +272,7 @@ gates:
 squad run --agent security-audit "Audit all changes since last release"
 ```
 
-Stages can also partition work automatically across files:
+Stages can partition work automatically across files:
 
 ```yaml
 stages:
@@ -186,137 +284,70 @@ stages:
       max_per_partition: 10
 ```
 
-## Scheduled Runs (Routines)
+Full pipeline reference: [docs/pipelines.md](docs/pipelines.md).
 
-Routines enable unattended agent runs via OS-native schedulers (macOS launchd,
-Linux systemd, Windows Task Scheduler).
+## Routines
+
+Routines run agents unattended on a schedule via OS-native daemons (launchd on macOS, systemd on Linux, Task Scheduler on Windows).
 
 ```bash
-# Create a nightly audit routine (installs daemon automatically)
+# Create and install a nightly audit routine
 squad routine create nightly-audit
 
-# List all routines and their next fire time
-squad routine list
-
-# Fire a routine immediately to test it
-squad routine run-now nightly-audit
-
-# Tail the daemon log
-squad routine logs --follow
-
-# Check daemon health
-squad routine doctor
-```
-
-Per-repo routine manifest (`.squad/routines/nightly-audit.yaml`):
-
-```yaml
+# Per-repo manifest at .squad/routines/nightly-audit.yaml
+cat > .squad/routines/nightly-audit.yaml <<'EOF'
 id: nightly-audit
 agent: go-security-audit
-schedule: "0 2 * * *"           # standard cron or @daily / @every 30m
+schedule: "0 2 * * *"           # cron, or @daily / @every 30m
 prompt: "Audit changes merged in the last 24 hours"
 provider: anthropic
 model: claude-sonnet-4-6
 max_cost: 5.00
 max_iterations: 30
 enabled: true
+EOF
+
+# Monitor
+squad routine list
+squad routine logs --follow
+squad routine doctor
 ```
 
-Checked into git, per-repo routines give the whole team the same automated
-reviews. Global routines live in `~/.config/squad/routines/` for
-personal cross-repo automations.
+| Command                       | Description                              |
+| ----------------------------- | ---------------------------------------- |
+| `routine create <id>`         | Create and install a routine             |
+| `routine list`                | List all routines with status            |
+| `routine show <id>`           | Full details and next fire time          |
+| `routine run-now <id>`        | Fire immediately                         |
+| `routine enable/disable <id>` | Toggle a routine                         |
+| `routine history <id>`        | List past sessions                       |
+| `routine logs [--follow]`     | Tail daemon output                       |
+| `routine doctor`              | Health check                             |
+| `routine repair`              | Reinstall the OS service                 |
 
-| Routine Command | Description |
-|----------------|-------------|
-| `routine create <id>` | Create and install a routine |
-| `routine list` | List all routines with status |
-| `routine show <id>` | Full details and next fire time |
-| `routine run-now <id>` | Fire immediately |
-| `routine enable/disable <id>` | Toggle a routine |
-| `routine history <id>` | List past sessions |
-| `routine logs [--follow]` | Tail daemon output |
-| `routine doctor` | Health check |
-| `routine repair` | Reinstall the OS service |
+Per-repo routines (checked into git) give the whole team identical automation. Global routines live in `~/.config/squad/routines/`. Full reference: [docs/routines.md](docs/routines.md).
 
-## Configuration
+## Sessions & Resume
 
-Config is loaded from (highest to lowest precedence):
-CLI flags → `SQUAD_*` environment variables → config file → built-in defaults.
+Every run writes an append-only event log to `./.squad/sessions/<id>/`:
 
-```bash
-squad config init    # Create config at the default location
-squad config show    # View the merged effective config
-squad config path    # Show the active config file path
-squad config set provider.default anthropic
-squad config get model.default
-```
+| File               | Contents                                              |
+| ------------------ | ----------------------------------------------------- |
+| `meta.json`        | Run options, last response id, cost, status          |
+| `events.jsonl`     | One line per prompt, response, tool call, tool result |
+| `results/<id>.txt` | Full bytes of any tool result that exceeded 8 KiB    |
 
-**Default path:** `~/.config/squad/config.yaml`
+`--resume <id>` reopens that session and chains the next request to the prior OpenAI Responses API id, so the model picks up server-side state without re-sending the transcript. When a tool result is too large to inline, the model sees a `[result:<id> — N bytes elided …]` placeholder and can fetch the full bytes via the `get_tool_result` tool.
 
-### Config File Reference
-
-```yaml
-log:
-  level: info              # debug | info | warn | error
-  format: text             # text | json | color
-
-provider:
-  default: openai          # openai | anthropic | google | ollama | openai-compat
-  token: $OPENAI_API_KEY   # supports $VAR and $(command) for dynamic resolution
-  base_url: ""             # override provider endpoint (OpenAI-compatible APIs)
-  organization: ""         # OpenAI organization ID
-  api_version: ""          # for Azure OpenAI
-
-model:
-  default: gpt-4.1-mini
-  temperature: 0.2
-  max_tokens: 1024
-
-agents:
-  repositories:
-    official: https://github.com/cowdogmoo/squad-agents.git
-  local_paths: []          # additional local agent search directories
-
-run:
-  max_iterations: 100
-  max_cost: 5.0            # USD
-  stream: false
-  apply: false
-  require_actionable: true
-
-otel:
-  endpoint: ""             # OTLP endpoint; empty disables tracing
-```
-
-### Environment Variables
-
-All config keys are available as `SQUAD_*` environment variables
-(replace `.` with `_`, uppercase):
-
-```bash
-SQUAD_PROVIDER_DEFAULT=anthropic
-SQUAD_PROVIDER_TOKEN=$ANTHROPIC_API_KEY
-SQUAD_MODEL_DEFAULT=claude-sonnet-4-6
-SQUAD_RUN_MAX_COST=10.0
-SQUAD_LOG_LEVEL=debug
-```
-
-### OpenAI-Compatible Endpoints
-
-```yaml
-provider:
-  default: openai-compat
-  base_url: https://api.together.xyz/v1
-  token: $TOGETHER_API_KEY
-```
-
-Works with NVIDIA NIM, Databricks, Together AI, vLLM, LM Studio, and any
-OpenAI-compatible API.
+Streaming output, OpenTelemetry tracing, cost budgeting, and the grading rubric are documented in [docs/observability.md](docs/observability.md).
 
 ## Execution Backends
 
-Run agents in isolated or remote environments by adding an `environment` block
-to `agent.yaml`:
+Run agents in isolated or remote environments by adding an `environment` block to `agent.yaml`.
+
+### Local (default)
+
+No `environment` block needed — the agent runs in the current shell.
 
 ### Docker
 
@@ -352,91 +383,276 @@ environment:
     region: us-east-1
 ```
 
-## Features
+Full reference: [docs/execution-backends.md](docs/execution-backends.md).
 
-### Core Capabilities
+## MCP Servers
 
-| Feature | Description |
-|---------|-------------|
-| **Agent Execution** | Run agents with Read, Write, Edit, Glob, Grep, Bash tools |
-| **Multi-provider** | OpenAI, Anthropic, Google AI, Ollama, any OpenAI-compatible endpoint |
-| **Streaming Output** | Real-time token streaming to stderr |
-| **Fix + Analyze Modes** | Agents can apply fixes or report only |
-| **Agent Scaffolding** | `squad init agent` from templates or existing agents |
-| **Agent Repositories** | Git-based agent sharing and discovery |
+Agents can call any [Model Context Protocol](https://modelcontextprotocol.io/) server as a tool source — stdio, SSE, or Streamable HTTP.
 
-### Orchestration
+```yaml
+# agent.yaml
+mcp_servers:
+  - name: postgres
+    type: stdio
+    command: ["mcp-server-postgres", "$DATABASE_URL"]
+  - name: linear
+    type: http
+    url: https://mcp.linear.app/sse
+```
 
-| Feature | Description |
-|---------|-------------|
-| **Declarative Pipelines** | Multi-stage YAML pipelines with dependency ordering |
-| **Parallel Execution** | Multiple agents in a stage run concurrently |
-| **Regression Gates** | Shell commands validate state between stages |
-| **Background Tasks** | Spawn child agents with `Task(background=true)` |
-| **Cost Budgeting** | Per-run and per-stage USD caps with dry-run estimation |
+Or pass at run time:
 
-### Infrastructure
+```bash
+squad run --agent my-agent \
+  --mcp-server "postgres:mcp-server-postgres,$DATABASE_URL" \
+  --mcp-server "linear:http:https://mcp.linear.app/sse"
 
-| Feature | Description |
-|---------|-------------|
-| **Execution Backends** | Local, Docker, Kubernetes, AWS SSM |
-| **MCP Integration** | Connect to any Model Context Protocol server |
-| **OpenTelemetry** | OTLP tracing for agent runs and tool calls |
-| **Agent Grading** | Grade outputs against quality rubrics |
-| **XDG Configuration** | Standard config paths with env var overrides |
-| **Routines** | OS-native daemon for scheduled unattended agent runs |
+# Inspect tools a server exposes
+squad mcp inspect postgres
+```
+
+Full reference: [docs/mcp-servers.md](docs/mcp-servers.md).
+
+## Skills
+
+Skills are single-directory capabilities a running agent loads on demand. They follow [Anthropic's open Agent Skills standard](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) — the same format Claude Code, Codex CLI, and ChatGPT consume — so a skill checked into your repo runs everywhere without conversion.
+
+```text
+skills/
+└── comment-scrub-playbook/
+    ├── SKILL.md             # required: identity, allowed_tools, instructions
+    └── references/          # optional: knowledge-base documents the skill cites
+```
+
+Squad surfaces discovered skills in the agent's system prompt as an "Available skills" catalog. The agent loads one with `Skill("name")`, the skill's body and references are injected into context, and `Read`/`Bash` access expands to include the skill's directory for the rest of the run.
+
+```bash
+# Inspect a skill's metadata
+squad skill show comment-scrub-playbook
+
+# Validate every skill in a directory
+squad skill validate ./skills
+
+# List skills the active config can discover
+squad skill list
+```
+
+Per-agent control lives under `agent.yaml`'s `skills:` block (allow/deny lists, scope filters); CLI flags `--allow-skill`/`--deny-skill`/`--skills-disabled` override per run.
+
+Full reference: [docs/skills.md](docs/skills.md).
+
+## Browser Profiles
+
+Agents that drive Chrome via [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) reuse named, persistent profiles so cookies, logins, and session state survive across runs.
+
+```bash
+squad browser open amazon https://amazon.com   # create + open profile for interactive setup
+squad browser list                              # show profiles + paths
+squad browser path amazon                       # print the profile's userDataDir
+```
+
+In `agent.yaml`, refer to the profile path with the `BrowserProfile` template helper:
+
+```yaml
+mcp_servers:
+  - name: chrome
+    command: npx
+    args: [chrome-devtools-mcp@latest, --userDataDir={{.BrowserProfile "amazon"}}]
+```
+
+Full reference: [docs/browser-profiles.md](docs/browser-profiles.md).
+
+## Configuration
+
+Config is loaded from (highest to lowest precedence):
+**CLI flags → `SQUAD_*` env vars → config file → built-in defaults.**
+
+Default path: `~/.config/squad/config.yaml`.
+
+### Config File
+
+```yaml
+log:
+  level: info               # debug | info | warn | error
+  format: text              # text | json | color
+
+provider:
+  default: openai           # openai | anthropic | google | ollama | openai-compat
+  token: $OPENAI_API_KEY    # supports $VAR and $(command) for dynamic resolution
+  base_url: ""              # override provider endpoint (OpenAI-compatible APIs)
+  organization: ""          # OpenAI organization ID
+  api_version: ""           # for Azure OpenAI
+
+model:
+  default: gpt-4.1-mini
+  temperature: 0.2
+  max_tokens: 1024
+
+agents:
+  repositories:
+    official: https://github.com/cowdogmoo/squad-agents.git
+  local_paths: []           # additional local agent search directories
+
+run:
+  max_iterations: 100
+  max_cost: 5.0             # USD
+  stream: false
+  apply: false
+  require_actionable: true
+
+otel:
+  endpoint: ""              # OTLP endpoint; empty disables tracing
+```
+
+### Environment Variables
+
+All config keys are available as `SQUAD_*` env vars (replace `.` with `_`, uppercase).
+
+**LLM Providers** (at least one required):
+
+| Variable             | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `OPENAI_API_KEY`     | OpenAI API key                                    |
+| `ANTHROPIC_API_KEY`  | Anthropic API key                                 |
+| `GOOGLE_AI_API_KEY`  | Google AI Studio key                              |
+| `OLLAMA_BASE_URL`    | Local Ollama server URL (default `http://localhost:11434`) |
+
+**Squad Defaults** (override config-file values):
+
+| Variable                  | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `SQUAD_PROVIDER_DEFAULT`  | Default LLM provider                         |
+| `SQUAD_PROVIDER_TOKEN`    | API key for the default provider             |
+| `SQUAD_MODEL_DEFAULT`     | Default model identifier                     |
+| `SQUAD_RUN_MAX_COST`      | Default USD budget cap                       |
+| `SQUAD_RUN_MAX_ITERATIONS`| Default max tool-call iterations             |
+| `SQUAD_LOG_LEVEL`         | Log level                                    |
+| `SQUAD_LOG_FORMAT`        | Log format                                   |
+| `SQUAD_OTEL_ENDPOINT`     | OTLP endpoint for telemetry                  |
+
+### OpenAI-Compatible Endpoints
+
+```yaml
+provider:
+  default: openai-compat
+  base_url: https://api.together.xyz/v1
+  token: $TOGETHER_API_KEY
+```
+
+Works with NVIDIA NIM, Databricks, Together AI, vLLM, LM Studio, and any OpenAI-compatible API.
+
+Full reference: [docs/configuration.md](docs/configuration.md).
+
+## Repository Layout
+
+```text
+cmd/squad/                # Cobra entry point
+cmd/squad-routined/       # Routine daemon binary
+
+agent/                    # Manifest parsing, bundle assembly
+runner/                   # Run execution, model invocation
+tools/                    # Tool definitions + the iteration loop
+pipeline/                 # Multi-stage agent composition
+skill/                    # Agent Skills (Anthropic format)
+mcp/                      # Model Context Protocol client
+executor/                 # Local/Docker/K8s/SSM execution backends
+routine/                  # Scheduled unattended runs
+responses/                # OpenAI Responses API path
+metrics/                  # Token + cost accounting
+grading/                  # Run grading and rubrics
+ui/                       # Interactive TUI
+
+config/                   # Config loading and validation
+source/                   # Agent + skill discovery
+session/                  # Per-run event log
+templates/                # Built-in agent scaffolds
+docs/                     # User documentation (linked below)
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.24+
+- [pre-commit](https://pre-commit.com/) (recommended)
+- [golangci-lint](https://golangci-lint.run/) (CI uses v2.11.4)
+
+### Build & Test
+
+```bash
+git clone https://github.com/cowdogmoo/squad.git && cd squad
+
+go mod download
+go build ./cmd/squad      # build the binary
+go test ./...              # run the full test suite
+go vet ./...
+golangci-lint run --timeout=5m
+```
+
+### Pre-Commit Hooks
+
+The repository ships with a comprehensive pre-commit pipeline (gofmt, goimports, gocyclo, golangci-lint, gocritic, go-build, go-mod-tidy, govulncheck, yamllint, codespell, markdownlint, actionlint, GoReleaser config check). Install once and the hooks run on every commit:
+
+```bash
+pre-commit install
+```
+
+CI rejects any commit that fails the hooks.
 
 ## Documentation
 
 ### Getting Started
 
-- **[Agent and Skill Concepts](docs/agents-and-skills.md)** - Taxonomy guide: agents, skills, Task tool, and pipelines and when to reach for each
-- **[Configuration](docs/configuration.md)** - Providers, environment variables, and config file reference
-- **[Creating Agents](docs/creating-agents.md)** - Build your own agents from scratch or from templates
-- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** - LLM fundamentals, context windows, and how to write effective agent prompts
+- **[Agent and Skill Concepts](docs/agents-and-skills.md)** — taxonomy: agents, skills, Task tool, pipelines, and when to reach for each
+- **[Configuration](docs/configuration.md)** — providers, environment variables, full config-file reference
+- **[Creating Agents](docs/creating-agents.md)** — build your own agents from scratch or from templates
+- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** — LLM fundamentals, context windows, and writing effective agent prompts
 
 ### Guides
 
-- **[Pipelines](docs/pipelines.md)** - Multi-agent orchestration with stages, gates, and cost budgets
-- **[Execution Backends](docs/execution-backends.md)** - Run agents in Docker, Kubernetes, or AWS SSM
-- **[MCP Servers](docs/mcp-servers.md)** - Connect agents to external tools via Model Context Protocol
-- **[Observability](docs/observability.md)** - Streaming output, OpenTelemetry tracing, cost budgeting, and grading
-- **[Routines](docs/routines.md)** - Scheduled unattended runs via OS-native daemons
-- **[Skills](docs/skills.md)** - On-demand capabilities a running agent loads — Anthropic Agent Skills format
+- **[Pipelines](docs/pipelines.md)** — multi-agent orchestration with stages, gates, and cost budgets
+- **[Execution Backends](docs/execution-backends.md)** — run agents in Docker, Kubernetes, or AWS SSM
+- **[MCP Servers](docs/mcp-servers.md)** — connect agents to external tools via Model Context Protocol
+- **[Observability](docs/observability.md)** — streaming output, OpenTelemetry tracing, cost budgeting, and grading
+- **[Routines](docs/routines.md)** — scheduled unattended runs via OS-native daemons
+- **[Skills](docs/skills.md)** — on-demand capabilities a running agent loads (Anthropic Agent Skills format)
+- **[Browser Profiles](docs/browser-profiles.md)** — named Chrome profiles for agents that drive a browser
+
+### Engineering
+
+- **[Agent Quality Guide](docs/agent-quality.md)** — tuning methodology and grading rubric
+- **[Agents Engineering Pipeline](docs/agents-engineering-pipeline-basics.md)** — agent-engineering CI/CD with squad
 
 ### Agents
 
-- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** - Production-ready agents for Go, Python, Ansible, and Molecule
-- **[Agent Quality Guide](docs/agent-quality.md)** - Tuning methodology and grading rubric
+- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** — production-ready agents for Go, Python, Ansible, and Molecule
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Make your changes and add tests
-4. Run the test suite: `go test ./...`
-5. Commit your changes: `git commit -m 'Add my feature'`
-6. Push to the branch: `git push origin feature/my-feature`
-7. Open a Pull Request
+Contributions are welcome. The contributor flow:
 
-### Development Setup
+1. Fork and create a feature branch off `main`.
+2. Install pre-commit hooks: `pre-commit install`.
+3. Make changes and add tests (`go test ./...`).
+4. Ensure `golangci-lint run` and `go vet ./...` pass.
+5. Open a PR. CI will reject commits that fail any hook.
 
-```bash
-git clone https://github.com/cowdogmoo/squad.git
-cd squad
-go mod download
-go build ./...
-go test ./...
-```
+For agent contributions, the [official agents repo](https://github.com/CowDogMoo/squad-agents) is the home — open PRs there.
 
-## Built With
+Inspired by [Daniel Miessler's Fabric](https://github.com/danielmiessler/fabric).
 
-- [LangChainGo](https://github.com/tmc/langchaingo)
-- [Cobra](https://github.com/spf13/cobra)
-- [Viper](https://github.com/spf13/viper)
-- [Bubble Tea](https://github.com/charmbracelet/bubbletea)
-- [go-git](https://github.com/go-git/go-git)
+### Built With
+
+- [LangChainGo](https://github.com/tmc/langchaingo) — LLM provider abstraction
+- [Cobra](https://github.com/spf13/cobra) — CLI framework
+- [Viper](https://github.com/spf13/viper) — config loading
+- [Bubble Tea](https://github.com/charmbracelet/bubbletea) — TUI
+- [go-git](https://github.com/go-git/go-git) — agent-repo fetching
 
 ## License
 
-[MIT License](./LICENSE)
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+
+## Security
+
+Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel, the Semgrep + govulncheck pipeline, and guidance for running squad safely in production workflows.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,18 +56,3 @@ configured to auto-merge low-risk patch upgrades after CI passes.
 - Release binaries are built via `goreleaser` on tagged commits only
 - No `replace` directives are allowed in `go.mod` (enforced by
   [`.hooks/go-no-replacement.sh`](.hooks/go-no-replacement.sh))
-
-## Defensive Use
-
-`squad` is dual-use software: it drives LLM agents through filesystem,
-shell, and network tools. When integrating squad into a production
-workflow, please:
-
-- Set a per-run `--max-cost` cap and an `--auto-confirm` policy
-  appropriate for unattended execution
-- Use the `--isolate worktree` or `environment: docker` execution backends
-  to sandbox file modifications
-- Audit agent prompts and `agent.yaml` manifests in code review the same
-  way you'd audit any code that runs `Bash`
-- Never hard-code API keys in `agent.yaml`; use `$VAR` or `$(command)`
-  substitution to pull from a secret manager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Reporting and Fixing Security Issues
+
+Please do not open GitHub issues or pull requests for security
+vulnerabilities — that makes the problem visible to everyone, including
+malicious actors.
+
+Report security issues privately by emailing the maintainers at
+**jayson.e.grace@gmail.com** with the subject prefix `[squad-security]`.
+
+When reporting, please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a minimal proof-of-concept
+- The squad version (`squad version`) and your platform (`uname -a`)
+- Any mitigating factors you're aware of
+
+We'll acknowledge the report within three business days and aim to ship a
+fix or coordinated disclosure within 30 days of confirmation.
+
+## Static Analysis with Semgrep
+
+This project uses Semgrep for automated security analysis. The scanner
+runs on:
+
+- All pull requests targeting `main`
+- Direct pushes to `main`
+- Weekly scheduled scans (Sundays at 00:00 UTC)
+
+### Enabled Rulesets
+
+| Ruleset                | Purpose                                   |
+| ---------------------- | ----------------------------------------- |
+| `p/security-audit`     | General security best practices           |
+| `p/secrets`            | Detection of hard-coded secrets           |
+| `p/ci`                 | CI configuration risks                    |
+| `p/supply-chain`       | Supply-chain security checks              |
+| `p/golang`             | Go-specific checks                        |
+| `p/trailofbits-go`     | Trail of Bits Go security ruleset         |
+
+Findings are surfaced in the GitHub Security tab and block merges on PRs.
+
+## Dependency Scanning
+
+`govulncheck` runs in the pre-commit pipeline and on CI. Vulnerable
+dependencies without an upstream fix are tracked in
+[`.hooks/govulncheck-scan.sh`](.hooks/govulncheck-scan.sh) so the build
+stays green while still surfacing the advisory text.
+
+`renovate` opens PRs for upstream version bumps; the Renovate workflow is
+configured to auto-merge low-risk patch upgrades after CI passes.
+
+## Supply Chain
+
+- All third-party GitHub Actions are pinned to commit SHAs (not tag refs)
+- Dependencies are tracked in `go.sum` with hash verification
+- Release binaries are built via `goreleaser` on tagged commits only
+- No `replace` directives are allowed in `go.mod` (enforced by
+  [`.hooks/go-no-replacement.sh`](.hooks/go-no-replacement.sh))
+
+## Defensive Use
+
+`squad` is dual-use software: it drives LLM agents through filesystem,
+shell, and network tools. When integrating squad into a production
+workflow, please:
+
+- Set a per-run `--max-cost` cap and an `--auto-confirm` policy
+  appropriate for unattended execution
+- Use the `--isolate worktree` or `environment: docker` execution backends
+  to sandbox file modifications
+- Audit agent prompts and `agent.yaml` manifests in code review the same
+  way you'd audit any code that runs `Bash`
+- Never hard-code API keys in `agent.yaml`; use `$VAR` or `$(command)`
+  substitution to pull from a secret manager

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ squad run --agent go-review --provider openai --model gpt-4.1-mini
 ### Anthropic
 
 ```bash
-squad run --agent go-review --provider anthropic --model claude-sonnet-4-20250514
+squad run --agent go-review --provider anthropic --model claude-sonnet-4-6
 ```
 
 ### Google AI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -387,3 +387,15 @@ squad run --agent go-review \
   --base-url https://ollama.example.com/v1 \
   --model qwen2.5-coder:7b-instruct
 ```
+
+## Running Squad Safely
+
+`squad` is dual-use software: it drives LLM agents through filesystem, shell, and network tools. A misbehaving agent (whether hallucinating, prompt-injected, or misconfigured) can mutate files, run shell commands, or burn budget unless you constrain it at config time.
+
+When you integrate squad into a production workflow:
+
+- **Cap cost on every run.** Set `--max-cost` (or `run.max_cost` in the config file) to a sane USD ceiling. A budget cap is the only universally reliable stop.
+- **Pick an explicit `--auto-confirm` policy** for unattended execution. The default `abort` is correct for interactive runs; for routines, choose `yes` only when you've audited the agent's tool surface.
+- **Sandbox writes** with `--isolate worktree` (separate dir + branch) or the `environment: docker` execution backend ([docs/execution-backends.md](./execution-backends.md)) so a bad edit lands in a throwaway tree, not your working copy.
+- **Review `agent.yaml` and the prompt files like code.** The `Bash` tool runs arbitrary shell; treat every manifest change in PR review the same way you'd treat a change to a CI workflow.
+- **Never hard-code API keys** in `agent.yaml` or shell history. Use `$VAR` or `$(command)` token resolution to pull from a secret manager — see [Token resolution](#token-resolution) above.

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -43,11 +43,27 @@ references:
   - references/criteria.md
 task: task.md
 
+# Optional: ranked model preferences. First entry is primary; later entries
+# are fallbacks when their provider credentials are detected.
+models:
+  - model: claude-sonnet-4-6
+    provider: anthropic
+  - model: gpt-4.1-mini
+    provider: openai
+
+# Optional: per-agent run policy
+max_iterations: 100        # iteration cap (0 = use CLI default)
+edit_deadline: 25          # stop after N iterations with no Edit calls
+disable_task: false        # when true, the Task tool is not registered
+comments_only: false       # when true, Edit/MultiEdit reject non-comment changes
+isolation: ""              # "worktree" | "branch" | "commit" | "staged" | ""
+working_dir: ""             # set "none" for remote-only agents (no local FS tools)
+
 # Optional: execution environment (local, docker, ssm, kubectl)
 environment:
   type: docker
   options:
-    image: golang:1.23
+    image: golang:1.26
     volumes: ".:/workspace"
     working_dir: /workspace
 
@@ -78,10 +94,23 @@ mcp_servers:
   - name: mytools
     command: npx
     args: ["@myorg/mcp-server"]
+
+# Optional: Agent Skills catalog control. See docs/skills.md.
+skills:
+  enabled: true                # nil = auto-enable when any skill is discovered
+  scopes: [repo, catalog]      # which scopes to surface
+  allow: []                    # exclusive allowlist of skill names
+  deny: []                     # remove skills by name (only when allow is empty)
 ```
 
-Only `name`, `entrypoint`, `wrapper`, and `task` are required. Everything
-else is optional.
+Only `name`, `entrypoint`, `wrapper`, and `task` are required. Everything else is optional.
+
+**Notable manifest options:**
+
+- `comments_only` is for cleanup agents (e.g. `go-scrub-comments`). When set, the Edit and MultiEdit tools reject any change that touches non-comment lines, so an LLM hallucinating new code can't silently mutate the codebase.
+- `disable_task` removes the `Task` tool from the agent, useful for leaf agents that shouldn't dispatch child runs.
+- `edit_deadline` enters a grace period after N iterations without an Edit; reads are blocked so the model is forced to commit pending fixes.
+- `isolation` defers to the CLI `--isolate` flag and, ultimately, the config default. `worktree` is the safest for agents that apply diffs.
 
 ### system.md (Main Prompt)
 

--- a/docs/execution-backends.md
+++ b/docs/execution-backends.md
@@ -19,7 +19,7 @@ declared in the agent's `agent.yaml` manifest.
 environment:
   type: docker
   options:
-    image: golang:1.23
+    image: golang:1.26
     volumes: ".:/workspace"
     working_dir: /workspace
     shell: /bin/bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,7 +38,7 @@ Each line is a JSON object with a timestamp, an event type, and a payload:
 ```jsonl
 {"ts":"2026-05-07T14:30:22Z","type":"run_start","payload":{"agent":"go-review","model":"gpt-4o","provider":"openai"}}
 {"ts":"2026-05-07T14:30:23Z","type":"prompt","payload":{"content":"Review the authentication changes in this PR..."}}
-{"ts":"2026-05-07T14:30:25Z","type":"tool_call","payload":{"name":"read_file","input":{"path":"auth/middleware.go"}}}
+{"ts":"2026-05-07T14:30:25Z","type":"tool_call","payload":{"name":"Read","input":{"path":"auth/middleware.go"}}}
 {"ts":"2026-05-07T14:30:25Z","type":"tool_result","payload":{"tool_call_id":"tc_01","content":"package auth\n..."}}
 {"ts":"2026-05-07T14:30:48Z","type":"iteration","payload":{"iteration":1}}
 {"ts":"2026-05-07T14:31:10Z","type":"run_end","payload":{"status":"completed"}}
@@ -152,9 +152,9 @@ Spans are created for each layer of execution. A typical run produces a tree lik
 ```
 agent.run (go-review)
 ├── model.invoke
-├── tool.call (read_file)
+├── tool.call (Read)
 ├── model.invoke
-├── tool.call (bash)
+├── tool.call (Bash)
 │   └── executor.local
 ├── model.invoke
 └── tool.call (mcp/filesystem/read)

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -87,7 +87,7 @@ id: nightly-audit             # required, user-supplied slug
 agent: go-security-audit      # required
 schedule: "0 2 * * *"         # required, see schedule syntax above
 prompt: "Audit pending changes since last run"
-working_dir: /Users/l/code/api  # required for global; defaults to repo root for per-repo
+working_dir: ~/code/my-project  # required for global; defaults to repo root for per-repo
 provider: anthropic           # optional, falls back to squad config default
 model: claude-sonnet-4-6      # optional
 max_cost: 5.00                # optional per-fire USD cap


### PR DESCRIPTION
**Key Changes:**

- Reworked the main README into a comprehensive project guide covering architecture, setup, CLI usage, agents, pipelines, routines, backends, MCP, skills, browser profiles, configuration, and development
- Added a dedicated security policy with private vulnerability reporting, Semgrep coverage, dependency scanning, supply-chain controls, and safe-use guidance
- Updated agent-authoring documentation with current manifest options for model fallbacks, run policy, isolation, task control, comments-only mode, and skills
- Aligned examples across docs with current model names, tool naming, Go versions, and routine paths

**Added:**

- Security reporting and hardening guidance - Added SECURITY.md with private disclosure instructions, scan cadence, enabled Semgrep rulesets, dependency handling, supply-chain expectations, and defensive-use recommendations
- Expanded user-facing documentation coverage - Added README sections for architecture, table of contents, CLI reference, agent sources, sessions and resume, execution backends, MCP servers, skills, browser profiles, repository layout, development workflow, and security

**Changed:**

- Main project documentation - Replaced the shorter README overview with a fuller, better-organized guide that reflects unattended agents, deterministic tool loops, cost caps, structured logs, session resume, official agents, routines, supported providers, and current development practices
- Agent manifest guidance - Updated docs/creating-agents.md to document ranked model preferences, per-agent run policies, skill controls, comments-only safeguards, task disabling, edit deadlines, and safer isolation defaults
- Example configuration values - Refreshed docs/configuration.md, docs/execution-backends.md, and docs/routines.md with current Anthropic model naming, newer Go Docker image examples, and clearer working directory examples
- Observability examples - Updated docs/observability.md to use current tool names such as Read and Bash in event logs and tracing spans

**Removed:**

- Outdated README structure - Removed older duplicated quick-start, usage, feature, and development sections in favor of the consolidated current documentation flow