### PR TITLE
feat: add pinned agent and skill repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,4 +655,4 @@ This project is licensed under the MIT License — see the [LICENSE](LICENSE) fi
 
 ## Security
 
-Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel, the Semgrep + govulncheck pipeline, and guidance for running squad safely in production workflows.
+Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel and the Semgrep + govulncheck pipeline. For operational guidance on running squad safely in production (cost caps, isolation, secrets, agent-yaml review), see [Running Squad Safely](docs/configuration.md#running-squad-safely) in the configuration docs.

--- a/README.md
+++ b/README.md
@@ -241,8 +241,15 @@ squad agents add official https://github.com/cowdogmoo/squad-agents.git
 squad agents add team git@github.com:internal/agents.git
 squad agents add scratch ./local-agents/
 
+# Pin a source to a specific commit, tag, or branch so unattended runs
+# always resolve the same content.
+squad agents add official https://github.com/cowdogmoo/squad-agents.git --ref v0.4.2
+squad agents pin official v0.5.0
+squad agents pin official --unset             # back to tracking the default branch
+
 squad agents list
-squad agents update              # pull all sources
+squad agents update                            # pulls unpinned sources; skips pins
+squad agents update --force                    # re-resolves pinned refs too
 squad agents remove team
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Agents run in a deterministic tool loop with per-run cost caps, structured event
                            │           │            │
             ┌──────────────▼─┐  ┌──────▼──────┐ ┌───▼─────────────┐
             │  LLM Providers  │  │  Executor   │ │  MCP Servers    │
-            │ openai · gpt    │  │ local ·     │ │ stdio · sse ·   │
-            │ anthropic       │  │ docker ·    │ │ http (any tool) │
+            │ openai          │  │ local ·     │ │ stdio · sse ·   │
+            │ anthropic       │  │ docker ·    │ │ streamable_http │
             │ gemini · ollama │  │ kubectl ·   │ │                 │
             │ openai-compat   │  │ ssm         │ │                 │
             └─────────────────┘  └─────────────┘ └─────────────────┘
@@ -98,7 +98,7 @@ Agents run in a deterministic tool loop with per-run cost caps, structured event
 
 | Requirement    | Version | Notes                                                                |
 | -------------- | ------- | -------------------------------------------------------------------- |
-| **Go**         | 1.24+   | Required for `go install`                                            |
+| **Go**         | 1.26+   | Required for `go install`                                            |
 | **LLM access** | -       | OpenAI, Anthropic, Google AI, Ollama, or any OpenAI-compatible endpoint |
 | **Git**        | -       | Required for agent-repository fetching and worktree isolation         |
 
@@ -270,9 +270,9 @@ stages:
     agent: summarize
     depends_on: [scan]
 gates:
-  - name: tests-pass
+  - after: report
     command: go test ./...
-    on_error: halt
+    on_failure: stop   # revert | stop
 ```
 
 ```bash
@@ -286,7 +286,7 @@ stages:
   - name: review-files
     agent: go-review
     partition:
-      by: glob
+      by: files
       glob: "**/*.go"
       max_per_partition: 10
 ```
@@ -362,7 +362,7 @@ No `environment` block needed — the agent runs in the current shell.
 environment:
   type: docker
   options:
-    image: golang:1.24
+    image: golang:1.26
     volumes: ".:/workspace"
     working_dir: /workspace
 ```
@@ -374,7 +374,7 @@ environment:
   type: kubectl
   options:
     namespace: default
-    image: golang:1.24
+    image: golang:1.26
     resources:
       requests:
         memory: "512Mi"
@@ -400,10 +400,11 @@ Agents can call any [Model Context Protocol](https://modelcontextprotocol.io/) s
 # agent.yaml
 mcp_servers:
   - name: postgres
-    type: stdio
-    command: ["mcp-server-postgres", "$DATABASE_URL"]
+    transport: stdio
+    command: mcp-server-postgres
+    args: ["$DATABASE_URL"]
   - name: linear
-    type: http
+    transport: streamable_http
     url: https://mcp.linear.app/sse
 ```
 
@@ -411,7 +412,7 @@ Or pass at run time:
 
 ```bash
 squad run --agent my-agent \
-  --mcp-server "postgres:mcp-server-postgres,$DATABASE_URL" \
+  --mcp-server "postgres:mcp-server-postgres:$DATABASE_URL" \
   --mcp-server "linear:http:https://mcp.linear.app/sse"
 
 # Inspect tools a server exposes
@@ -580,7 +581,7 @@ docs/                     # User documentation (linked below)
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.26+
 - [pre-commit](https://pre-commit.com/) (recommended)
 - [golangci-lint](https://golangci-lint.run/) (CI uses v2.11.4)
 
@@ -598,7 +599,7 @@ golangci-lint run --timeout=5m
 
 ### Pre-Commit Hooks
 
-The repository ships with a comprehensive pre-commit pipeline (gofmt, goimports, gocyclo, golangci-lint, gocritic, go-build, go-mod-tidy, govulncheck, yamllint, codespell, markdownlint, actionlint, GoReleaser config check). Install once and the hooks run on every commit:
+Pre-commit hooks cover gofmt, goimports, gocyclo, golangci-lint, gocritic, go-build, go-mod-tidy, govulncheck, yamllint, codespell, markdownlint, actionlint, and the GoReleaser config check. Install once and they run on every commit:
 
 ```bash
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -9,158 +9,256 @@
 [![Release](https://img.shields.io/github/v/release/CowDogMoo/squad?label=Release&logo=github)](https://github.com/CowDogMoo/squad/releases)
 [![codecov](https://codecov.io/github/CowDogMoo/squad/graph/badge.svg?token=O74GTQA4J7)](https://codecov.io/github/CowDogMoo/squad)
 <br />
-[![Semgrep](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml)
+[![Tests](https://github.com/CowDogMoo/squad/actions/workflows/tests.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/tests.yaml)
 [![Pre-Commit](https://github.com/CowDogMoo/squad/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/pre-commit.yaml)
+[![Semgrep](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/semgrep.yaml)
 [![Renovate](https://github.com/CowDogMoo/squad/actions/workflows/renovate.yaml/badge.svg)](https://github.com/CowDogMoo/squad/actions/workflows/renovate.yaml)
-
-<h4><code>squad</code> is an open-source framework for building, sharing, and running AI agents from the command line.</h4>
 
 </div>
 
 ---
 
-## Overview
+`squad` is a framework for building, sharing, and running unattended AI agents from the command line. Define an agent as plain markdown prompts and a YAML manifest, point it at any LLM provider, and let it work through a codebase using a fixed tool surface (Read, Write, Edit, Glob, Grep, Bash, plus any MCP server).
 
-Inspired by [Daniel Miessler's Fabric](https://github.com/danielmiessler/fabric).
-Define an agent in markdown and YAML, point it at any LLM, and turn it
-loose on a codebase.
+Agents run in a deterministic tool loop with per-run cost caps, structured event logs, and session resume. Multi-agent **pipelines** compose stages with dependency ordering and regression gates. **Routines** schedule unattended runs through OS-native daemons. Provider support includes OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, vLLM, LM Studio, Together AI). Execution can target the local machine, a Docker container, a Kubernetes pod, or an EC2 instance over AWS SSM.
 
-- Works with OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, DeepInfra, Together AI, vLLM, LM Studio, and more)
-- Agents are just files: markdown prompts + YAML manifest, checked into git
-- Built-in tools: Read, Write, Edit, Glob, Grep, Bash, plus any MCP server
-- Multi-agent pipelines with dependency ordering, parallel stages, and regression gates
-- Runs locally, in Docker, on Kubernetes, or over AWS SSM
-- Scheduled unattended runs via OS-native daemons (launchd, systemd, Task Scheduler)
+## Table of Contents
 
-**Built for:**
+- [Architecture](#architecture)
+- [Quick Start](#quick-start)
+- [CLI Reference](#cli-reference)
+- [Agents](#agents)
+- [Multi-Agent Pipelines](#multi-agent-pipelines)
+- [Routines](#routines)
+- [Sessions & Resume](#sessions--resume)
+- [Execution Backends](#execution-backends)
+- [MCP Servers](#mcp-servers)
+- [Skills](#skills)
+- [Browser Profiles](#browser-profiles)
+- [Configuration](#configuration)
+- [Repository Layout](#repository-layout)
+- [Development](#development)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+- [Security](#security)
 
-- Security teams running code review, audits, and recon
-- Platform engineers enforcing standards across repos
-- Developers building review and refactoring workflows
+## Architecture
 
-## Prerequisites
+`squad` is a single Go binary built around a deterministic tool-calling loop. The CLI assembles an **agent bundle** (system prompt + tool definitions + budget config) from on-disk markdown and YAML, then drives the model through tool calls until it returns a final response or a budget/iteration cap fires.
 
-| Requirement    | Version | Notes                                   |
-| -------------- | ------- | --------------------------------------- |
-| **Go**         | 1.24+   | Required for `go install`               |
-| **LLM access** | -       | OpenAI, Anthropic, Google AI, or Ollama |
-
-## Installation
-
-```bash
-go install github.com/cowdogmoo/squad/cmd/squad@latest
+```text
+                        ┌──────────────────────────────────────────────┐
+                        │                squad (CLI)                   │
+                        │   run · agents · routine · pipeline · ...    │
+                        └──────────────┬───────────────────────────────┘
+                                       │
+                        ┌──────────────▼───────────────┐
+                        │     Agent Bundle (agent/)    │
+                        │  system.md + agent.md +      │
+                        │  agent.yaml + skills + refs  │
+                        └──────────────┬───────────────┘
+                                       │
+                        ┌──────────────▼───────────────┐
+                        │   Tool Loop (tools/)         │
+                        │ Read · Edit · Bash · Glob ·  │
+                        │ Grep · Task · MCP · Skill    │
+                        └──┬───────────┬────────────┬──┘
+                           │           │            │
+            ┌──────────────▼─┐  ┌──────▼──────┐ ┌───▼─────────────┐
+            │  LLM Providers  │  │  Executor   │ │  MCP Servers    │
+            │ openai · gpt    │  │ local ·     │ │ stdio · sse ·   │
+            │ anthropic       │  │ docker ·    │ │ http (any tool) │
+            │ gemini · ollama │  │ kubectl ·   │ │                 │
+            │ openai-compat   │  │ ssm         │ │                 │
+            └─────────────────┘  └─────────────┘ └─────────────────┘
 ```
 
-### Build from Source
-
-```bash
-git clone https://github.com/cowdogmoo/squad.git
-cd squad
-go build -o squad ./cmd/squad
-```
-
-### Verification
-
-```bash
-squad version
-```
+| Package      | Purpose                                                                    |
+| ------------ | -------------------------------------------------------------------------- |
+| `cmd/squad`  | Cobra CLI: subcommands for `run`, `agents`, `routine`, `pipeline`, etc.    |
+| `agent`      | Manifest parsing, bundle assembly, model preferences, skill catalog        |
+| `runner`     | Per-run context (edits, deadlines, modes), model invocation, response apply |
+| `tools`      | Tool definitions and the iteration loop (Read/Write/Edit/Glob/Grep/Bash/…) |
+| `pipeline`   | Multi-stage agent composition with parallel stages and regression gates    |
+| `skill`      | On-demand Anthropic-format Skills: progressive-disclosure tool extensions  |
+| `mcp`        | Model Context Protocol client + handler registration                       |
+| `executor`   | Run shell commands locally, in Docker, on K8s, or over AWS SSM             |
+| `routine`    | OS-native scheduled runs (launchd, systemd, Windows Task Scheduler)        |
+| `responses`  | OpenAI Responses API path (server-side state, large-result offload)        |
+| `metrics`    | Token + cost accounting, per-run budget enforcement                        |
+| `grading`    | Rubric-based scoring of agent runs                                         |
+| `ui`         | Bubble Tea TUI for interactive launch and monitoring                       |
+| `source`     | Skill discovery from local paths and git-hosted agent repos                |
+| `session`    | Append-only event log per run; powers `--resume`                           |
 
 ## Quick Start
 
+### Prerequisites
+
+| Requirement    | Version | Notes                                                                |
+| -------------- | ------- | -------------------------------------------------------------------- |
+| **Go**         | 1.24+   | Required for `go install`                                            |
+| **LLM access** | -       | OpenAI, Anthropic, Google AI, Ollama, or any OpenAI-compatible endpoint |
+| **Git**        | -       | Required for agent-repository fetching and worktree isolation         |
+
+### Install
+
 ```bash
-# Initialize configuration
+# Install latest release
+go install github.com/cowdogmoo/squad/cmd/squad@latest
+
+# Or build from source
+git clone https://github.com/cowdogmoo/squad.git && cd squad
+go build -o squad ./cmd/squad
+
+# Verify
+squad version
+```
+
+### Configure
+
+```bash
+# Initialize config at ~/.config/squad/config.yaml
 squad config init
 
-# Add the official agents repository
-squad agents add official https://github.com/cowdogmoo/squad-agents.git
+# Set a default provider and model
+squad config set provider.default anthropic
+squad config set model.default claude-sonnet-4-6
 
-# List available agents
-squad agents list
-
-# Run an agent against your codebase
-squad run --agent go-review --provider openai --model gpt-4.1-mini
-
-# Run with local Ollama — no API key required
-squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
-
-# Run a composed (multi-agent) pipeline
-squad run --agent security-audit "Review this codebase"
-
-# Resume a prior run after a crash, ctrl-c, or budget stop
-squad run --agent go-review --resume 20260429T150220Z-a1b2c3d4 \
-    "continue where you left off; finish the remaining files"
+# Show the merged effective config
+squad config show
 ```
 
-## Usage
+API keys can come from environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_AI_API_KEY`) or from `$(command)` substitution in `config.yaml` for secret managers.
 
-### Key Run Flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--agent` | Agent name to run | required |
-| `--provider` | LLM provider | config default |
-| `--model` | Model identifier | config default |
-| `--working-dir` | Target directory | current dir |
-| `--max-cost` | USD budget cap | `5.00` |
-| `--max-iterations` | Max tool-call loops | `100` |
-| `--apply` | Apply suggested diffs via git apply | `false` |
-| `--dry-run` | Estimate cost without running | `false` |
-| `--stream` | Stream tokens to stderr in real time | `false` |
-| `--resume` | Resume a session by ID | — |
-| `--out` | Write response to file | — |
-| `--var KEY=VALUE` | Template variable (repeatable) | — |
-| `--mcp-server` | MCP server spec (repeatable) | — |
-| `--isolate` | Isolation mode (e.g. `worktree`) | — |
-
-### Sessions
-
-Every run writes an append-only event log to `./.squad/sessions/<id>/`:
-
-| File               | Contents                                               |
-| ------------------ | ------------------------------------------------------ |
-| `meta.json`        | Run options, last response id, cost, status            |
-| `events.jsonl`     | One line per prompt, response, tool call, tool result  |
-| `results/<id>.txt` | Full bytes of any tool result that exceeded 8 KiB      |
-
-`--resume <id>` reopens that session and chains the next request to the
-prior OpenAI Responses API id, so the model picks up server-side state
-without re-sending the transcript. When a tool result is too large to
-inline, the model sees a `[result:<id> — N bytes elided …]` placeholder
-and can fetch the full bytes via the `get_tool_result` tool.
-
-### Creating Your Own Agent
+### First Run
 
 ```bash
-# Scaffold from a built-in template
-squad init agent my-review --lang go
+# Pull the official agents repo
+squad agents add official https://github.com/cowdogmoo/squad-agents.git
+squad agents list
 
-# Edit the prompts
-$EDITOR agents/my-review/system.md
+# Run an agent against the current directory
+squad run --agent go-review --provider openai --model gpt-4.1-mini
 
-# Test it
-squad run --agent my-review --print
+# Run with local Ollama (no API key required)
+squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
+
+# Estimate cost without calling the model
+squad run --agent go-review --dry-run
+
+# Resume a prior run after a crash, ctrl-c, or budget stop
+squad run --agent go-review --resume 20260429T150220Z-a1b2c3d4
 ```
 
-Agent directory structure:
+## CLI Reference
 
-```
+`squad` is a unified CLI with the following subcommands:
+
+| Subcommand   | Purpose                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `run`        | Run a single agent or composed pipeline                                  |
+| `agents`     | Add, remove, and list agent sources (local paths and git repos)          |
+| `init`       | Scaffold a new agent, config, or routine from templates                  |
+| `config`     | Initialize, inspect, and edit the squad config                           |
+| `routine`    | Manage scheduled, unattended agent runs                                  |
+| `skill`      | Inspect, validate, and manage Agent Skills                               |
+| `mcp`        | Inspect and debug MCP servers                                            |
+| `grade`      | Grade an agent run output against a rubric                               |
+| `browser`    | Manage named browser profiles for agents that drive Chrome               |
+| `ui`         | Interactive TUI for launching and monitoring runs                        |
+| `completion` | Generate shell completion scripts                                        |
+| `version`    | Print the active binary version                                          |
+
+Run `squad <subcommand> --help` for full flag documentation.
+
+### Global Flags
+
+| Flag                | Description                                              | Default                          |
+| ------------------- | -------------------------------------------------------- | -------------------------------- |
+| `-c, --config`      | Config file path                                         | `~/.config/squad/config.yaml`    |
+| `--log-level`       | `debug`, `info`, `warn`, `error`                         | `info`                           |
+| `--log-format`      | `text`, `json`, `color`                                  | `text`                           |
+| `--otel-endpoint`   | OpenTelemetry OTLP endpoint (e.g. `localhost:4318`)      | disabled                         |
+| `-q, --quiet`       | Suppress non-error output                                | `false`                          |
+| `-v, --verbose`     | Show debug output                                        | `false`                          |
+
+### `squad run` — Key Flags
+
+| Flag                  | Description                                                       | Default       |
+| --------------------- | ----------------------------------------------------------------- | ------------- |
+| `--agent`             | Agent name (required)                                             | —             |
+| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, …)       | config        |
+| `--model`             | Model identifier                                                  | config        |
+| `--working-dir`       | Target directory the agent operates on                            | current dir   |
+| `--max-cost`          | USD budget cap (0 = unlimited)                                    | `5.00`        |
+| `--max-iterations`    | Max tool-calling iterations (10-1000)                             | `100`         |
+| `--mode`              | Override agent's default mode (e.g. `readonly`)                   | manifest      |
+| `--apply`             | Apply unified diff from response to working directory             | `false`       |
+| `--dry-run`           | Build bundle and exit without calling the model                   | `false`       |
+| `--resume`            | Resume a prior session by ID                                      | —             |
+| `--isolate`           | Isolation mode: `worktree`, `branch`, `commit`, `staged`, `none`  | manifest      |
+| `--stream`            | Stream tokens to stderr in real time                              | `false`       |
+| `--out`               | Write final response to file                                      | —             |
+| `--var KEY=VALUE`     | Template variable (repeatable)                                    | —             |
+| `--mcp-server`        | MCP server spec (repeatable)                                      | —             |
+| `--allow-skill`       | Restrict skills to this allowlist (repeatable)                    | manifest      |
+| `--auto-confirm`      | How `Confirm` tool resolves in non-TTY runs (`yes`/`no`/`abort`)  | `abort`       |
+
+## Agents
+
+An agent is a directory of plain files checked into git. The CLI loads it, assembles the bundle, and drives the tool loop.
+
+```text
 my-review/
-├── agent.yaml      # Manifest (model preferences, tools, budget, pipeline)
+├── agent.yaml      # Manifest: model preferences, tools, budget, pipeline
 ├── system.md       # Agent identity, rules, and workflow
 ├── agent.md        # Execution wrapper
 ├── task.md         # Default task instructions
 └── references/     # Optional knowledge-base documents
 ```
 
+### Scaffold
+
+```bash
+# Create a new agent from a built-in template
+squad init agent my-review --lang go
+
+# Edit the system prompt
+$EDITOR agents/my-review/system.md
+
+# Test it
+squad run --agent my-review --print
+```
+
+### Sources
+
+Agents can come from local directories or git-hosted repositories:
+
+```bash
+squad agents add official https://github.com/cowdogmoo/squad-agents.git
+squad agents add team git@github.com:internal/agents.git
+squad agents add scratch ./local-agents/
+
+squad agents list
+squad agents update              # pull all sources
+squad agents remove team
+```
+
+The [official agents repo](https://github.com/CowDogMoo/squad-agents) ships production-tuned agents for Go review, Python review, comment scrubbing, security audit, Ansible playbook validation, and more.
+
+Full agent-authoring guide: [docs/creating-agents.md](docs/creating-agents.md). For the underlying taxonomy (agents, skills, the `Task` tool, and pipelines, and when to reach for each), see [docs/agents-and-skills.md](docs/agents-and-skills.md). First time writing prompts? Start with [docs/prompt-engineering-basics.md](docs/prompt-engineering-basics.md).
+
 ## Multi-Agent Pipelines
 
-Define pipelines declaratively in `agent.yaml` using `stages` and `gates`:
+Define pipelines declaratively in `agent.yaml` with `stages` and `gates`:
 
 ```yaml
 name: security-audit
 stages:
   - name: scan
-    agents: [go-review, dependency-check]  # run in parallel
+    agents: [go-review, dependency-check]   # run in parallel
   - name: report
     agent: summarize
     depends_on: [scan]
@@ -174,7 +272,7 @@ gates:
 squad run --agent security-audit "Audit all changes since last release"
 ```
 
-Stages can also partition work automatically across files:
+Stages can partition work automatically across files:
 
 ```yaml
 stages:
@@ -186,137 +284,70 @@ stages:
       max_per_partition: 10
 ```
 
-## Scheduled Runs (Routines)
+Full pipeline reference: [docs/pipelines.md](docs/pipelines.md).
 
-Routines enable unattended agent runs via OS-native schedulers (macOS launchd,
-Linux systemd, Windows Task Scheduler).
+## Routines
+
+Routines run agents unattended on a schedule via OS-native daemons (launchd on macOS, systemd on Linux, Task Scheduler on Windows).
 
 ```bash
-# Create a nightly audit routine (installs daemon automatically)
+# Create and install a nightly audit routine
 squad routine create nightly-audit
 
-# List all routines and their next fire time
-squad routine list
-
-# Fire a routine immediately to test it
-squad routine run-now nightly-audit
-
-# Tail the daemon log
-squad routine logs --follow
-
-# Check daemon health
-squad routine doctor
-```
-
-Per-repo routine manifest (`.squad/routines/nightly-audit.yaml`):
-
-```yaml
+# Per-repo manifest at .squad/routines/nightly-audit.yaml
+cat > .squad/routines/nightly-audit.yaml <<'EOF'
 id: nightly-audit
 agent: go-security-audit
-schedule: "0 2 * * *"           # standard cron or @daily / @every 30m
+schedule: "0 2 * * *"           # cron, or @daily / @every 30m
 prompt: "Audit changes merged in the last 24 hours"
 provider: anthropic
 model: claude-sonnet-4-6
 max_cost: 5.00
 max_iterations: 30
 enabled: true
+EOF
+
+# Monitor
+squad routine list
+squad routine logs --follow
+squad routine doctor
 ```
 
-Checked into git, per-repo routines give the whole team the same automated
-reviews. Global routines live in `~/.config/squad/routines/` for
-personal cross-repo automations.
+| Command                       | Description                              |
+| ----------------------------- | ---------------------------------------- |
+| `routine create <id>`         | Create and install a routine             |
+| `routine list`                | List all routines with status            |
+| `routine show <id>`           | Full details and next fire time          |
+| `routine run-now <id>`        | Fire immediately                         |
+| `routine enable/disable <id>` | Toggle a routine                         |
+| `routine history <id>`        | List past sessions                       |
+| `routine logs [--follow]`     | Tail daemon output                       |
+| `routine doctor`              | Health check                             |
+| `routine repair`              | Reinstall the OS service                 |
 
-| Routine Command | Description |
-|----------------|-------------|
-| `routine create <id>` | Create and install a routine |
-| `routine list` | List all routines with status |
-| `routine show <id>` | Full details and next fire time |
-| `routine run-now <id>` | Fire immediately |
-| `routine enable/disable <id>` | Toggle a routine |
-| `routine history <id>` | List past sessions |
-| `routine logs [--follow]` | Tail daemon output |
-| `routine doctor` | Health check |
-| `routine repair` | Reinstall the OS service |
+Per-repo routines (checked into git) give the whole team identical automation. Global routines live in `~/.config/squad/routines/`. Full reference: [docs/routines.md](docs/routines.md).
 
-## Configuration
+## Sessions & Resume
 
-Config is loaded from (highest to lowest precedence):
-CLI flags → `SQUAD_*` environment variables → config file → built-in defaults.
+Every run writes an append-only event log to `./.squad/sessions/<id>/`:
 
-```bash
-squad config init    # Create config at the default location
-squad config show    # View the merged effective config
-squad config path    # Show the active config file path
-squad config set provider.default anthropic
-squad config get model.default
-```
+| File               | Contents                                              |
+| ------------------ | ----------------------------------------------------- |
+| `meta.json`        | Run options, last response id, cost, status          |
+| `events.jsonl`     | One line per prompt, response, tool call, tool result |
+| `results/<id>.txt` | Full bytes of any tool result that exceeded 8 KiB    |
 
-**Default path:** `~/.config/squad/config.yaml`
+`--resume <id>` reopens that session and chains the next request to the prior OpenAI Responses API id, so the model picks up server-side state without re-sending the transcript. When a tool result is too large to inline, the model sees a `[result:<id> — N bytes elided …]` placeholder and can fetch the full bytes via the `get_tool_result` tool.
 
-### Config File Reference
-
-```yaml
-log:
-  level: info              # debug | info | warn | error
-  format: text             # text | json | color
-
-provider:
-  default: openai          # openai | anthropic | google | ollama | openai-compat
-  token: $OPENAI_API_KEY   # supports $VAR and $(command) for dynamic resolution
-  base_url: ""             # override provider endpoint (OpenAI-compatible APIs)
-  organization: ""         # OpenAI organization ID
-  api_version: ""          # for Azure OpenAI
-
-model:
-  default: gpt-4.1-mini
-  temperature: 0.2
-  max_tokens: 1024
-
-agents:
-  repositories:
-    official: https://github.com/cowdogmoo/squad-agents.git
-  local_paths: []          # additional local agent search directories
-
-run:
-  max_iterations: 100
-  max_cost: 5.0            # USD
-  stream: false
-  apply: false
-  require_actionable: true
-
-otel:
-  endpoint: ""             # OTLP endpoint; empty disables tracing
-```
-
-### Environment Variables
-
-All config keys are available as `SQUAD_*` environment variables
-(replace `.` with `_`, uppercase):
-
-```bash
-SQUAD_PROVIDER_DEFAULT=anthropic
-SQUAD_PROVIDER_TOKEN=$ANTHROPIC_API_KEY
-SQUAD_MODEL_DEFAULT=claude-sonnet-4-6
-SQUAD_RUN_MAX_COST=10.0
-SQUAD_LOG_LEVEL=debug
-```
-
-### OpenAI-Compatible Endpoints
-
-```yaml
-provider:
-  default: openai-compat
-  base_url: https://api.together.xyz/v1
-  token: $TOGETHER_API_KEY
-```
-
-Works with NVIDIA NIM, Databricks, Together AI, vLLM, LM Studio, and any
-OpenAI-compatible API.
+Streaming output, OpenTelemetry tracing, cost budgeting, and the grading rubric are documented in [docs/observability.md](docs/observability.md).
 
 ## Execution Backends
 
-Run agents in isolated or remote environments by adding an `environment` block
-to `agent.yaml`:
+Run agents in isolated or remote environments by adding an `environment` block to `agent.yaml`.
+
+### Local (default)
+
+No `environment` block needed — the agent runs in the current shell.
 
 ### Docker
 
@@ -352,91 +383,276 @@ environment:
     region: us-east-1
 ```
 
-## Features
+Full reference: [docs/execution-backends.md](docs/execution-backends.md).
 
-### Core Capabilities
+## MCP Servers
 
-| Feature | Description |
-|---------|-------------|
-| **Agent Execution** | Run agents with Read, Write, Edit, Glob, Grep, Bash tools |
-| **Multi-provider** | OpenAI, Anthropic, Google AI, Ollama, any OpenAI-compatible endpoint |
-| **Streaming Output** | Real-time token streaming to stderr |
-| **Fix + Analyze Modes** | Agents can apply fixes or report only |
-| **Agent Scaffolding** | `squad init agent` from templates or existing agents |
-| **Agent Repositories** | Git-based agent sharing and discovery |
+Agents can call any [Model Context Protocol](https://modelcontextprotocol.io/) server as a tool source — stdio, SSE, or Streamable HTTP.
 
-### Orchestration
+```yaml
+# agent.yaml
+mcp_servers:
+  - name: postgres
+    type: stdio
+    command: ["mcp-server-postgres", "$DATABASE_URL"]
+  - name: linear
+    type: http
+    url: https://mcp.linear.app/sse
+```
 
-| Feature | Description |
-|---------|-------------|
-| **Declarative Pipelines** | Multi-stage YAML pipelines with dependency ordering |
-| **Parallel Execution** | Multiple agents in a stage run concurrently |
-| **Regression Gates** | Shell commands validate state between stages |
-| **Background Tasks** | Spawn child agents with `Task(background=true)` |
-| **Cost Budgeting** | Per-run and per-stage USD caps with dry-run estimation |
+Or pass at run time:
 
-### Infrastructure
+```bash
+squad run --agent my-agent \
+  --mcp-server "postgres:mcp-server-postgres,$DATABASE_URL" \
+  --mcp-server "linear:http:https://mcp.linear.app/sse"
 
-| Feature | Description |
-|---------|-------------|
-| **Execution Backends** | Local, Docker, Kubernetes, AWS SSM |
-| **MCP Integration** | Connect to any Model Context Protocol server |
-| **OpenTelemetry** | OTLP tracing for agent runs and tool calls |
-| **Agent Grading** | Grade outputs against quality rubrics |
-| **XDG Configuration** | Standard config paths with env var overrides |
-| **Routines** | OS-native daemon for scheduled unattended agent runs |
+# Inspect tools a server exposes
+squad mcp inspect postgres
+```
+
+Full reference: [docs/mcp-servers.md](docs/mcp-servers.md).
+
+## Skills
+
+Skills are single-directory capabilities a running agent loads on demand. They follow [Anthropic's open Agent Skills standard](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) — the same format Claude Code, Codex CLI, and ChatGPT consume — so a skill checked into your repo runs everywhere without conversion.
+
+```text
+skills/
+└── comment-scrub-playbook/
+    ├── SKILL.md             # required: identity, allowed_tools, instructions
+    └── references/          # optional: knowledge-base documents the skill cites
+```
+
+Squad surfaces discovered skills in the agent's system prompt as an "Available skills" catalog. The agent loads one with `Skill("name")`, the skill's body and references are injected into context, and `Read`/`Bash` access expands to include the skill's directory for the rest of the run.
+
+```bash
+# Inspect a skill's metadata
+squad skill show comment-scrub-playbook
+
+# Validate every skill in a directory
+squad skill validate ./skills
+
+# List skills the active config can discover
+squad skill list
+```
+
+Per-agent control lives under `agent.yaml`'s `skills:` block (allow/deny lists, scope filters); CLI flags `--allow-skill`/`--deny-skill`/`--skills-disabled` override per run.
+
+Full reference: [docs/skills.md](docs/skills.md).
+
+## Browser Profiles
+
+Agents that drive Chrome via [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) reuse named, persistent profiles so cookies, logins, and session state survive across runs.
+
+```bash
+squad browser open amazon https://amazon.com   # create + open profile for interactive setup
+squad browser list                              # show profiles + paths
+squad browser path amazon                       # print the profile's userDataDir
+```
+
+In `agent.yaml`, refer to the profile path with the `BrowserProfile` template helper:
+
+```yaml
+mcp_servers:
+  - name: chrome
+    command: npx
+    args: [chrome-devtools-mcp@latest, --userDataDir={{.BrowserProfile "amazon"}}]
+```
+
+Full reference: [docs/browser-profiles.md](docs/browser-profiles.md).
+
+## Configuration
+
+Config is loaded from (highest to lowest precedence):
+**CLI flags → `SQUAD_*` env vars → config file → built-in defaults.**
+
+Default path: `~/.config/squad/config.yaml`.
+
+### Config File
+
+```yaml
+log:
+  level: info               # debug | info | warn | error
+  format: text              # text | json | color
+
+provider:
+  default: openai           # openai | anthropic | google | ollama | openai-compat
+  token: $OPENAI_API_KEY    # supports $VAR and $(command) for dynamic resolution
+  base_url: ""              # override provider endpoint (OpenAI-compatible APIs)
+  organization: ""          # OpenAI organization ID
+  api_version: ""           # for Azure OpenAI
+
+model:
+  default: gpt-4.1-mini
+  temperature: 0.2
+  max_tokens: 1024
+
+agents:
+  repositories:
+    official: https://github.com/cowdogmoo/squad-agents.git
+  local_paths: []           # additional local agent search directories
+
+run:
+  max_iterations: 100
+  max_cost: 5.0             # USD
+  stream: false
+  apply: false
+  require_actionable: true
+
+otel:
+  endpoint: ""              # OTLP endpoint; empty disables tracing
+```
+
+### Environment Variables
+
+All config keys are available as `SQUAD_*` env vars (replace `.` with `_`, uppercase).
+
+**LLM Providers** (at least one required):
+
+| Variable             | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `OPENAI_API_KEY`     | OpenAI API key                                    |
+| `ANTHROPIC_API_KEY`  | Anthropic API key                                 |
+| `GOOGLE_AI_API_KEY`  | Google AI Studio key                              |
+| `OLLAMA_BASE_URL`    | Local Ollama server URL (default `http://localhost:11434`) |
+
+**Squad Defaults** (override config-file values):
+
+| Variable                  | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `SQUAD_PROVIDER_DEFAULT`  | Default LLM provider                         |
+| `SQUAD_PROVIDER_TOKEN`    | API key for the default provider             |
+| `SQUAD_MODEL_DEFAULT`     | Default model identifier                     |
+| `SQUAD_RUN_MAX_COST`      | Default USD budget cap                       |
+| `SQUAD_RUN_MAX_ITERATIONS`| Default max tool-call iterations             |
+| `SQUAD_LOG_LEVEL`         | Log level                                    |
+| `SQUAD_LOG_FORMAT`        | Log format                                   |
+| `SQUAD_OTEL_ENDPOINT`     | OTLP endpoint for telemetry                  |
+
+### OpenAI-Compatible Endpoints
+
+```yaml
+provider:
+  default: openai-compat
+  base_url: https://api.together.xyz/v1
+  token: $TOGETHER_API_KEY
+```
+
+Works with NVIDIA NIM, Databricks, Together AI, vLLM, LM Studio, and any OpenAI-compatible API.
+
+Full reference: [docs/configuration.md](docs/configuration.md).
+
+## Repository Layout
+
+```text
+cmd/squad/                # Cobra entry point
+cmd/squad-routined/       # Routine daemon binary
+
+agent/                    # Manifest parsing, bundle assembly
+runner/                   # Run execution, model invocation
+tools/                    # Tool definitions + the iteration loop
+pipeline/                 # Multi-stage agent composition
+skill/                    # Agent Skills (Anthropic format)
+mcp/                      # Model Context Protocol client
+executor/                 # Local/Docker/K8s/SSM execution backends
+routine/                  # Scheduled unattended runs
+responses/                # OpenAI Responses API path
+metrics/                  # Token + cost accounting
+grading/                  # Run grading and rubrics
+ui/                       # Interactive TUI
+
+config/                   # Config loading and validation
+source/                   # Agent + skill discovery
+session/                  # Per-run event log
+templates/                # Built-in agent scaffolds
+docs/                     # User documentation (linked below)
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.24+
+- [pre-commit](https://pre-commit.com/) (recommended)
+- [golangci-lint](https://golangci-lint.run/) (CI uses v2.11.4)
+
+### Build & Test
+
+```bash
+git clone https://github.com/cowdogmoo/squad.git && cd squad
+
+go mod download
+go build ./cmd/squad      # build the binary
+go test ./...              # run the full test suite
+go vet ./...
+golangci-lint run --timeout=5m
+```
+
+### Pre-Commit Hooks
+
+The repository ships with a comprehensive pre-commit pipeline (gofmt, goimports, gocyclo, golangci-lint, gocritic, go-build, go-mod-tidy, govulncheck, yamllint, codespell, markdownlint, actionlint, GoReleaser config check). Install once and the hooks run on every commit:
+
+```bash
+pre-commit install
+```
+
+CI rejects any commit that fails the hooks.
 
 ## Documentation
 
 ### Getting Started
 
-- **[Agent and Skill Concepts](docs/agents-and-skills.md)** - Taxonomy guide: agents, skills, Task tool, and pipelines and when to reach for each
-- **[Configuration](docs/configuration.md)** - Providers, environment variables, and config file reference
-- **[Creating Agents](docs/creating-agents.md)** - Build your own agents from scratch or from templates
-- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** - LLM fundamentals, context windows, and how to write effective agent prompts
+- **[Agent and Skill Concepts](docs/agents-and-skills.md)** — taxonomy: agents, skills, Task tool, pipelines, and when to reach for each
+- **[Configuration](docs/configuration.md)** — providers, environment variables, full config-file reference
+- **[Creating Agents](docs/creating-agents.md)** — build your own agents from scratch or from templates
+- **[Prompt Engineering Basics](docs/prompt-engineering-basics.md)** — LLM fundamentals, context windows, and writing effective agent prompts
 
 ### Guides
 
-- **[Pipelines](docs/pipelines.md)** - Multi-agent orchestration with stages, gates, and cost budgets
-- **[Execution Backends](docs/execution-backends.md)** - Run agents in Docker, Kubernetes, or AWS SSM
-- **[MCP Servers](docs/mcp-servers.md)** - Connect agents to external tools via Model Context Protocol
-- **[Observability](docs/observability.md)** - Streaming output, OpenTelemetry tracing, cost budgeting, and grading
-- **[Routines](docs/routines.md)** - Scheduled unattended runs via OS-native daemons
-- **[Skills](docs/skills.md)** - On-demand capabilities a running agent loads — Anthropic Agent Skills format
+- **[Pipelines](docs/pipelines.md)** — multi-agent orchestration with stages, gates, and cost budgets
+- **[Execution Backends](docs/execution-backends.md)** — run agents in Docker, Kubernetes, or AWS SSM
+- **[MCP Servers](docs/mcp-servers.md)** — connect agents to external tools via Model Context Protocol
+- **[Observability](docs/observability.md)** — streaming output, OpenTelemetry tracing, cost budgeting, and grading
+- **[Routines](docs/routines.md)** — scheduled unattended runs via OS-native daemons
+- **[Skills](docs/skills.md)** — on-demand capabilities a running agent loads (Anthropic Agent Skills format)
+- **[Browser Profiles](docs/browser-profiles.md)** — named Chrome profiles for agents that drive a browser
+
+### Engineering
+
+- **[Agent Quality Guide](docs/agent-quality.md)** — tuning methodology and grading rubric
+- **[Agents Engineering Pipeline](docs/agents-engineering-pipeline-basics.md)** — agent-engineering CI/CD with squad
 
 ### Agents
 
-- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** - Production-ready agents for Go, Python, Ansible, and Molecule
-- **[Agent Quality Guide](docs/agent-quality.md)** - Tuning methodology and grading rubric
+- **[Official Agents](https://github.com/CowDogMoo/squad-agents)** — production-ready agents for Go, Python, Ansible, and Molecule
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/my-feature`
-3. Make your changes and add tests
-4. Run the test suite: `go test ./...`
-5. Commit your changes: `git commit -m 'Add my feature'`
-6. Push to the branch: `git push origin feature/my-feature`
-7. Open a Pull Request
+Contributions are welcome. The contributor flow:
 
-### Development Setup
+1. Fork and create a feature branch off `main`.
+2. Install pre-commit hooks: `pre-commit install`.
+3. Make changes and add tests (`go test ./...`).
+4. Ensure `golangci-lint run` and `go vet ./...` pass.
+5. Open a PR. CI will reject commits that fail any hook.
 
-```bash
-git clone https://github.com/cowdogmoo/squad.git
-cd squad
-go mod download
-go build ./...
-go test ./...
-```
+For agent contributions, the [official agents repo](https://github.com/CowDogMoo/squad-agents) is the home — open PRs there.
 
-## Built With
+Inspired by [Daniel Miessler's Fabric](https://github.com/danielmiessler/fabric).
 
-- [LangChainGo](https://github.com/tmc/langchaingo)
-- [Cobra](https://github.com/spf13/cobra)
-- [Viper](https://github.com/spf13/viper)
-- [Bubble Tea](https://github.com/charmbracelet/bubbletea)
-- [go-git](https://github.com/go-git/go-git)
+### Built With
+
+- [LangChainGo](https://github.com/tmc/langchaingo) — LLM provider abstraction
+- [Cobra](https://github.com/spf13/cobra) — CLI framework
+- [Viper](https://github.com/spf13/viper) — config loading
+- [Bubble Tea](https://github.com/charmbracelet/bubbletea) — TUI
+- [go-git](https://github.com/go-git/go-git) — agent-repo fetching
 
 ## License
 
-[MIT License](./LICENSE)
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+
+## Security
+
+Please do not file public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting channel, the Semgrep + govulncheck pipeline, and guidance for running squad safely in production workflows.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,18 +56,3 @@ configured to auto-merge low-risk patch upgrades after CI passes.
 - Release binaries are built via `goreleaser` on tagged commits only
 - No `replace` directives are allowed in `go.mod` (enforced by
   [`.hooks/go-no-replacement.sh`](.hooks/go-no-replacement.sh))
-
-## Defensive Use
-
-`squad` is dual-use software: it drives LLM agents through filesystem,
-shell, and network tools. When integrating squad into a production
-workflow, please:
-
-- Set a per-run `--max-cost` cap and an `--auto-confirm` policy
-  appropriate for unattended execution
-- Use the `--isolate worktree` or `environment: docker` execution backends
-  to sandbox file modifications
-- Audit agent prompts and `agent.yaml` manifests in code review the same
-  way you'd audit any code that runs `Bash`
-- Never hard-code API keys in `agent.yaml`; use `$VAR` or `$(command)`
-  substitution to pull from a secret manager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Reporting and Fixing Security Issues
+
+Please do not open GitHub issues or pull requests for security
+vulnerabilities — that makes the problem visible to everyone, including
+malicious actors.
+
+Report security issues privately by emailing the maintainers at
+**jayson.e.grace@gmail.com** with the subject prefix `[squad-security]`.
+
+When reporting, please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a minimal proof-of-concept
+- The squad version (`squad version`) and your platform (`uname -a`)
+- Any mitigating factors you're aware of
+
+We'll acknowledge the report within three business days and aim to ship a
+fix or coordinated disclosure within 30 days of confirmation.
+
+## Static Analysis with Semgrep
+
+This project uses Semgrep for automated security analysis. The scanner
+runs on:
+
+- All pull requests targeting `main`
+- Direct pushes to `main`
+- Weekly scheduled scans (Sundays at 00:00 UTC)
+
+### Enabled Rulesets
+
+| Ruleset                | Purpose                                   |
+| ---------------------- | ----------------------------------------- |
+| `p/security-audit`     | General security best practices           |
+| `p/secrets`            | Detection of hard-coded secrets           |
+| `p/ci`                 | CI configuration risks                    |
+| `p/supply-chain`       | Supply-chain security checks              |
+| `p/golang`             | Go-specific checks                        |
+| `p/trailofbits-go`     | Trail of Bits Go security ruleset         |
+
+Findings are surfaced in the GitHub Security tab and block merges on PRs.
+
+## Dependency Scanning
+
+`govulncheck` runs in the pre-commit pipeline and on CI. Vulnerable
+dependencies without an upstream fix are tracked in
+[`.hooks/govulncheck-scan.sh`](.hooks/govulncheck-scan.sh) so the build
+stays green while still surfacing the advisory text.
+
+`renovate` opens PRs for upstream version bumps; the Renovate workflow is
+configured to auto-merge low-risk patch upgrades after CI passes.
+
+## Supply Chain
+
+- All third-party GitHub Actions are pinned to commit SHAs (not tag refs)
+- Dependencies are tracked in `go.sum` with hash verification
+- Release binaries are built via `goreleaser` on tagged commits only
+- No `replace` directives are allowed in `go.mod` (enforced by
+  [`.hooks/go-no-replacement.sh`](.hooks/go-no-replacement.sh))
+
+## Defensive Use
+
+`squad` is dual-use software: it drives LLM agents through filesystem,
+shell, and network tools. When integrating squad into a production
+workflow, please:
+
+- Set a per-run `--max-cost` cap and an `--auto-confirm` policy
+  appropriate for unattended execution
+- Use the `--isolate worktree` or `environment: docker` execution backends
+  to sandbox file modifications
+- Audit agent prompts and `agent.yaml` manifests in code review the same
+  way you'd audit any code that runs `Bash`
+- Never hard-code API keys in `agent.yaml`; use `$VAR` or `$(command)`
+  substitution to pull from a secret manager

--- a/cmd/squad/agents.go
+++ b/cmd/squad/agents.go
@@ -130,7 +130,6 @@ func init() {
 	agentsCmd.AddCommand(agentsPinCmd)
 }
 
-// runAgentsList lists available agents from configured sources.
 func runAgentsList(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {
@@ -166,7 +165,6 @@ func runAgentsList(cmd *cobra.Command, args []string) error {
 	return w.Flush()
 }
 
-// runAgentsAdd adds an agent source from a git repository or local path.
 func runAgentsAdd(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {
@@ -193,7 +191,6 @@ func runAgentsAdd(cmd *cobra.Command, args []string) error {
 
 	if source.IsGitURL(urlOrPath) {
 		if name == "" {
-			// Generate name from URL
 			name = guessRepoName(urlOrPath)
 		}
 		if err := manager.AddRepository(name, urlOrPath, agentsAddRef); err != nil {
@@ -217,7 +214,6 @@ func runAgentsAdd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runAgentsPin updates the pinned ref on an existing repository.
 func runAgentsPin(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {
@@ -253,7 +249,6 @@ func runAgentsPin(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runAgentsRemove removes a configured agent source.
 func runAgentsRemove(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {
@@ -273,7 +268,6 @@ func runAgentsRemove(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runAgentsUpdate updates all configured git repositories.
 func runAgentsUpdate(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {
@@ -293,7 +287,6 @@ func runAgentsUpdate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runAgentsSources lists configured agent sources.
 func runAgentsSources(cmd *cobra.Command, args []string) error {
 	cfg := configFromContext(cmd)
 	if cfg == nil {

--- a/cmd/squad/agents.go
+++ b/cmd/squad/agents.go
@@ -54,6 +54,12 @@ var agentsListCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 }
 
+var (
+	agentsAddRef       string
+	agentsUpdateForce  bool
+	agentsPinUnsetFlag bool
+)
+
 var agentsAddCmd = &cobra.Command{
 	Use:   "add [name] <url-or-path>",
 	Short: "Add an agent source",
@@ -63,9 +69,26 @@ For git repositories:
   squad agents add https://github.com/user/agents.git
   squad agents add myrepo https://github.com/user/agents.git
 
+Pin a repository to a specific commit, tag, or branch with --ref so
+unattended runs always resolve the same source content:
+
+  squad agents add official https://github.com/cowdogmoo/squad-agents.git --ref v0.4.2
+  squad agents add official https://github.com/cowdogmoo/squad-agents.git --ref 7a3fe6cf
+
 For local directories:
   squad agents add /path/to/agents`,
 	RunE: runAgentsAdd,
+	Args: cobra.RangeArgs(1, 2),
+}
+
+var agentsPinCmd = &cobra.Command{
+	Use:   "pin <name> <ref>",
+	Short: "Pin an agent source to a specific ref",
+	Long: `Pin an existing agent repository to a specific commit SHA, tag, or branch.
+
+Subsequent 'squad agents update' calls skip pinned sources unless --force
+is supplied. To unpin, use 'squad agents pin <name> --unset'.`,
+	RunE: runAgentsPin,
 	Args: cobra.RangeArgs(1, 2),
 }
 
@@ -95,11 +118,16 @@ var agentsSourcesCmd = &cobra.Command{
 }
 
 func init() {
+	agentsAddCmd.Flags().StringVar(&agentsAddRef, "ref", "", "Pin to commit SHA, tag, or branch (defaults to tracking the default branch)")
+	agentsUpdateCmd.Flags().BoolVar(&agentsUpdateForce, "force", false, "Re-resolve and update pinned repositories too")
+	agentsPinCmd.Flags().BoolVar(&agentsPinUnsetFlag, "unset", false, "Remove an existing pin (alias for empty ref)")
+
 	agentsCmd.AddCommand(agentsListCmd)
 	agentsCmd.AddCommand(agentsAddCmd)
 	agentsCmd.AddCommand(agentsRemoveCmd)
 	agentsCmd.AddCommand(agentsUpdateCmd)
 	agentsCmd.AddCommand(agentsSourcesCmd)
+	agentsCmd.AddCommand(agentsPinCmd)
 }
 
 // runAgentsList lists available agents from configured sources.
@@ -168,17 +196,60 @@ func runAgentsAdd(cmd *cobra.Command, args []string) error {
 			// Generate name from URL
 			name = guessRepoName(urlOrPath)
 		}
-		if err := manager.AddRepository(name, urlOrPath); err != nil {
+		if err := manager.AddRepository(name, urlOrPath, agentsAddRef); err != nil {
 			return err
 		}
-		logging.InfoContext(ctx, "Added repository %s: %s", name, urlOrPath)
+		if agentsAddRef != "" {
+			logging.InfoContext(ctx, "Added repository %s: %s (pinned to %s)", name, urlOrPath, agentsAddRef)
+		} else {
+			logging.InfoContext(ctx, "Added repository %s: %s", name, urlOrPath)
+		}
 	} else {
+		if agentsAddRef != "" {
+			return fmt.Errorf("--ref only applies to git repositories, not local paths")
+		}
 		if err := manager.AddLocalPath(urlOrPath); err != nil {
 			return err
 		}
 		logging.InfoContext(ctx, "Added local path: %s", urlOrPath)
 	}
 
+	return nil
+}
+
+// runAgentsPin updates the pinned ref on an existing repository.
+func runAgentsPin(cmd *cobra.Command, args []string) error {
+	cfg := configFromContext(cmd)
+	if cfg == nil {
+		return fmt.Errorf("config not available in context")
+	}
+
+	manager, err := source.NewManager(cfg)
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	ref := ""
+	switch {
+	case agentsPinUnsetFlag:
+		if len(args) > 1 {
+			return fmt.Errorf("cannot combine --unset with a ref argument")
+		}
+	case len(args) == 2:
+		ref = args[1]
+	default:
+		return fmt.Errorf("usage: squad agents pin <name> <ref> | squad agents pin <name> --unset")
+	}
+
+	if err := manager.PinRepository(name, ref); err != nil {
+		return err
+	}
+	if ref == "" {
+		logging.InfoContext(cmd.Context(), "Unpinned %s (now tracking the default branch)", name)
+	} else {
+		logging.InfoContext(cmd.Context(), "Pinned %s to %s", name, ref)
+	}
 	return nil
 }
 
@@ -214,7 +285,7 @@ func runAgentsUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := manager.UpdateRepositories(); err != nil {
+	if err := manager.UpdateRepositories(agentsUpdateForce); err != nil {
 		return err
 	}
 
@@ -233,9 +304,13 @@ func runAgentsSources(cmd *cobra.Command, args []string) error {
 
 	if len(cfg.Agents.Repositories) > 0 {
 		_, _ = fmt.Fprintln(w, "REPOSITORIES:")
-		_, _ = fmt.Fprintln(w, "NAME\tURL")
-		for name, url := range cfg.Agents.Repositories {
-			_, _ = fmt.Fprintf(w, "%s\t%s\n", name, url)
+		_, _ = fmt.Fprintln(w, "NAME\tURL\tREF")
+		for name, spec := range cfg.Agents.Repositories {
+			ref := spec.Ref
+			if ref == "" {
+				ref = "-"
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", name, spec.URL, ref)
 		}
 		_, _ = fmt.Fprintln(w)
 	}

--- a/cmd/squad/agents_pin_test.go
+++ b/cmd/squad/agents_pin_test.go
@@ -110,6 +110,14 @@ func TestAgentsPin_unsetWithRefArgRejected(t *testing.T) {
 	}
 }
 
+func TestAgentsPin_missingRepoErrors(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	_, err := runAgentsSubcmd(t, cfg, agentsPinCmd, "ghost", "v1.0.0")
+	if err == nil {
+		t.Fatal("expected error when pinning an unknown repository")
+	}
+}
+
 func TestAgentsPin_missingRefArgRejected(t *testing.T) {
 	cfg := newAgentsTestCfg(t)
 	cfg.Agents.Repositories["official"] = config.RepoSpec{URL: "https://x.test/r.git"}
@@ -139,6 +147,91 @@ func TestAgentsUpdate_forceAttemptsPinned(t *testing.T) {
 	_, err := runAgentsSubcmd(t, cfg, agentsUpdateCmd, "--force")
 	if err == nil {
 		t.Fatal("expected --force to attempt the upstream and surface the failure")
+	}
+}
+
+func TestAgentsAdd_singleArgUrlDerivesName(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd,
+		"https://github.com/cowdogmoo/squad-agents.git",
+	); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// guessRepoName strips .git and takes the trailing path component.
+	if _, ok := cfg.Agents.Repositories["squad-agents"]; !ok {
+		t.Fatalf("expected derived name 'squad-agents', got %v",
+			cfg.Agents.Repositories)
+	}
+}
+
+func TestAgentsAdd_twoArgNonURLRejected(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	_, err := runAgentsSubcmd(t, cfg, agentsAddCmd, "alias", "/not/a/url")
+	if err == nil {
+		t.Fatal("expected error: alias-form second arg must be a git URL")
+	}
+}
+
+func TestAgentsAdd_localPathSucceeds(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	dir := t.TempDir()
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd, dir); err != nil {
+		t.Fatalf("add local path: %v", err)
+	}
+	if len(cfg.Agents.LocalPaths) != 1 || cfg.Agents.LocalPaths[0] != dir {
+		t.Fatalf("LocalPaths = %v, want [%s]", cfg.Agents.LocalPaths, dir)
+	}
+}
+
+func TestAgentsAdd_unpinnedGitSucceeds(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd,
+		"team", "https://example.com/agents.git",
+	); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got := cfg.Agents.Repositories["team"]
+	if got.URL != "https://example.com/agents.git" || got.IsPinned() {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestAgentsAdd_duplicateErrors(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["team"] = config.RepoSpec{
+		URL: "https://example.com/agents.git",
+	}
+	_, err := runAgentsSubcmd(t, cfg, agentsAddCmd,
+		"team", "https://example.com/agents.git",
+	)
+	if err == nil {
+		t.Fatal("expected duplicate-add error")
+	}
+}
+
+func TestAgentsSources_emptyMessage(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	out, err := runAgentsSubcmd(t, cfg, agentsSourcesCmd)
+	if err != nil {
+		t.Fatalf("sources: %v", err)
+	}
+	if !strings.Contains(out, "No sources configured") {
+		t.Fatalf("expected empty-sources message, got:\n%s", out)
+	}
+}
+
+func TestAgentsSources_localPathsOnly(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.LocalPaths = []string{"/tmp/local-agents"}
+	out, err := runAgentsSubcmd(t, cfg, agentsSourcesCmd)
+	if err != nil {
+		t.Fatalf("sources: %v", err)
+	}
+	if !strings.Contains(out, "LOCAL PATHS") || !strings.Contains(out, "/tmp/local-agents") {
+		t.Fatalf("expected LOCAL PATHS row, got:\n%s", out)
+	}
+	if strings.Contains(out, "REPOSITORIES") {
+		t.Fatalf("REPOSITORIES section should be omitted, got:\n%s", out)
 	}
 }
 

--- a/cmd/squad/agents_pin_test.go
+++ b/cmd/squad/agents_pin_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// newAgentsTestCfg installs an isolated XDG layout so the source.Manager's
+// config-save side effect can't bleed into the developer's real ~/.config.
+func newAgentsTestCfg(t *testing.T) *config.Config {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, ".cache"))
+	t.Setenv("HOME", tmp)
+	return &config.Config{
+		Agents: config.AgentsConfig{
+			Repositories: map[string]config.RepoSpec{},
+			LocalPaths:   nil,
+		},
+	}
+}
+
+// runAgentsSubcmd invokes a `squad agents <sub>` command against an injected
+// config. Returns combined stdout/stderr plus the RunE error so callers can
+// assert on either.
+func runAgentsSubcmd(t *testing.T, cfg *config.Config, sub *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	// Cobra's command instances retain flag state across calls, so reset
+	// every flag to its zero/default value before each invocation. This
+	// mirrors what a fresh process invocation would see.
+	sub.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = sub.Flags().Set(f.Name, f.DefValue)
+	})
+
+	sub.SetContext(withConfig(context.Background(), cfg))
+	var buf bytes.Buffer
+	sub.SetOut(&buf)
+	sub.SetErr(&buf)
+	if err := sub.ParseFlags(args); err != nil {
+		return buf.String(), err
+	}
+	if err := sub.RunE(sub, sub.Flags().Args()); err != nil {
+		return buf.String(), err
+	}
+	return buf.String(), nil
+}
+
+func TestAgentsAdd_withRefStoresPinnedSpec(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd,
+		"official", "https://github.com/cowdogmoo/squad-agents.git", "--ref", "v0.4.2",
+	); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got := cfg.Agents.Repositories["official"]
+	if got.URL != "https://github.com/cowdogmoo/squad-agents.git" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if got.Ref != "v0.4.2" {
+		t.Errorf("Ref = %q, want v0.4.2", got.Ref)
+	}
+}
+
+func TestAgentsAdd_refOnLocalPathRejected(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	dir := t.TempDir()
+	_, err := runAgentsSubcmd(t, cfg, agentsAddCmd, dir, "--ref", "main")
+	if err == nil {
+		t.Fatal("expected --ref on local path to error")
+	}
+	if !strings.Contains(err.Error(), "--ref only applies to git repositories") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAgentsPin_setsAndUnsets(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["official"] = config.RepoSpec{
+		URL: "https://github.com/cowdogmoo/squad-agents.git",
+	}
+	if _, err := runAgentsSubcmd(t, cfg, agentsPinCmd, "official", "v0.5.0"); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	if got := cfg.Agents.Repositories["official"].Ref; got != "v0.5.0" {
+		t.Fatalf("Ref = %q, want v0.5.0", got)
+	}
+
+	if _, err := runAgentsSubcmd(t, cfg, agentsPinCmd, "official", "--unset"); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+	if cfg.Agents.Repositories["official"].IsPinned() {
+		t.Fatal("expected unpinned after --unset")
+	}
+}
+
+func TestAgentsPin_unsetWithRefArgRejected(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["official"] = config.RepoSpec{URL: "https://x.test/r.git"}
+	_, err := runAgentsSubcmd(t, cfg, agentsPinCmd, "official", "v1", "--unset")
+	if err == nil {
+		t.Fatal("expected error when combining --unset with a ref")
+	}
+}
+
+func TestAgentsPin_missingRefArgRejected(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["official"] = config.RepoSpec{URL: "https://x.test/r.git"}
+	_, err := runAgentsSubcmd(t, cfg, agentsPinCmd, "official")
+	if err == nil {
+		t.Fatal("expected usage error when ref is missing and --unset is not set")
+	}
+}
+
+func TestAgentsUpdate_skipsPinnedWithoutForce(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.invalid/never.git",
+		Ref: "v1",
+	}
+	if _, err := runAgentsSubcmd(t, cfg, agentsUpdateCmd); err != nil {
+		t.Fatalf("expected pinned repo to be skipped, got: %v", err)
+	}
+}
+
+func TestAgentsUpdate_forceAttemptsPinned(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.invalid/never.git",
+		Ref: "v1",
+	}
+	_, err := runAgentsSubcmd(t, cfg, agentsUpdateCmd, "--force")
+	if err == nil {
+		t.Fatal("expected --force to attempt the upstream and surface the failure")
+	}
+}
+
+func TestAgentsSources_rendersRefColumn(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.com/pinned.git",
+		Ref: "v1.0.0",
+	}
+	cfg.Agents.Repositories["floating"] = config.RepoSpec{
+		URL: "https://example.com/floating.git",
+	}
+	out, err := runAgentsSubcmd(t, cfg, agentsSourcesCmd)
+	if err != nil {
+		t.Fatalf("sources: %v", err)
+	}
+	if !strings.Contains(out, "REF") {
+		t.Errorf("sources output should include REF column, got:\n%s", out)
+	}
+	if !strings.Contains(out, "v1.0.0") {
+		t.Errorf("sources output should include the pinned ref, got:\n%s", out)
+	}
+	if !strings.Contains(out, "floating") {
+		t.Errorf("sources output should include the floating row, got:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "floating") {
+			if !strings.HasSuffix(strings.TrimRight(line, " \t"), "-") {
+				t.Errorf("unpinned source should render '-' for ref column, got line: %q", line)
+			}
+		}
+	}
+}

--- a/cmd/squad/config.go
+++ b/cmd/squad/config.go
@@ -233,7 +233,7 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 
 	// Unmarshal back into typed config to preserve structure and tags
 	var newCfg config.Config
-	if err := v.Unmarshal(&newCfg); err != nil {
+	if err := v.Unmarshal(&newCfg, config.DecodeHooks()); err != nil {
 		return fmt.Errorf("failed to unmarshal updated config: %w", err)
 	}
 

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -164,7 +164,7 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Re-unmarshal so flag/env overrides are reflected in the config struct.
-	if err := v.Unmarshal(cfg); err != nil {
+	if err := v.Unmarshal(cfg, config.DecodeHooks()); err != nil {
 		return fmt.Errorf("failed to apply config overrides: %w", err)
 	}
 

--- a/cmd/squad/skill.go
+++ b/cmd/squad/skill.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/skill"
 	"github.com/cowdogmoo/squad/source"
@@ -65,6 +66,7 @@ lower-precedence scope.`,
 		newSkillUpdateCmd(),
 		newSkillSourcesCmd(),
 		newSkillNewCmd(),
+		newSkillPinCmd(),
 	)
 	return cmd
 }
@@ -204,7 +206,8 @@ func newSkillValidateCmd() *cobra.Command {
 }
 
 func newSkillAddCmd() *cobra.Command {
-	return &cobra.Command{
+	var ref string
+	cmd := &cobra.Command{
 		Use:   "add <alias> <git-url> | <local-path>",
 		Short: "Register a skill catalog source (git repo or local directory)",
 		Long: `Register a new skills catalog. Two forms are accepted:
@@ -215,7 +218,12 @@ func newSkillAddCmd() *cobra.Command {
 Git repositories require an alias (the short handle used by
 'squad skill remove'). Local paths are identified by the path itself, so no
 alias is needed. Git repositories are cloned into the skills cache on
-registration so the catalog is immediately discoverable.`,
+registration so the catalog is immediately discoverable.
+
+Pin a catalog to a specific commit, tag, or branch with --ref so updates
+are explicit:
+
+  squad skill add myteam https://github.com/me/squad-skills.git --ref v1.2.0`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -233,6 +241,9 @@ registration so the catalog is immediately discoverable.`,
 				if source.IsGitURL(target) {
 					return fmt.Errorf("git repositories require an alias: squad skill add <alias> %s", target)
 				}
+				if ref != "" {
+					return fmt.Errorf("--ref only applies to git repositories, not local paths")
+				}
 				if err := mgr.AddLocalPath(target); err != nil {
 					return err
 				}
@@ -243,10 +254,14 @@ registration so the catalog is immediately discoverable.`,
 				if !source.IsGitURL(target) {
 					return fmt.Errorf("two-argument form is for git repositories; %q is not a git URL (drop the alias to register a local path)", target)
 				}
-				if err := mgr.AddRepository(alias, target); err != nil {
+				if err := mgr.AddRepository(alias, target, ref); err != nil {
 					return err
 				}
-				logging.InfoContext(cmd.Context(), "registered skill repository %s → %s", alias, target)
+				if ref != "" {
+					logging.InfoContext(cmd.Context(), "registered skill repository %s → %s (pinned to %s)", alias, target, ref)
+				} else {
+					logging.InfoContext(cmd.Context(), "registered skill repository %s → %s", alias, target)
+				}
 				if err := mgr.EnsureRepositoriesCloned(); err != nil {
 					// The config row was written, so registration succeeded and we
 					// exit 0 — but the catalog is empty until the clone lands, so
@@ -265,6 +280,55 @@ registration so the catalog is immediately discoverable.`,
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&ref, "ref", "", "Pin to commit SHA, tag, or branch (defaults to tracking the default branch)")
+	return cmd
+}
+
+func newSkillPinCmd() *cobra.Command {
+	var unset bool
+	cmd := &cobra.Command{
+		Use:   "pin <alias> <ref>",
+		Short: "Pin a skill catalog to a specific ref",
+		Long: `Pin an existing skill repository to a specific commit SHA, tag, or branch.
+
+Subsequent 'squad skill update' calls skip pinned catalogs unless --force
+is supplied. To unpin, run with --unset.`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cfg := configFromContext(cmd)
+			if cfg == nil {
+				return fmt.Errorf("config not available in context")
+			}
+			mgr, err := source.NewSkillsManager(cfg)
+			if err != nil {
+				return err
+			}
+			alias := args[0]
+			ref := ""
+			switch {
+			case unset:
+				if len(args) > 1 {
+					return fmt.Errorf("cannot combine --unset with a ref argument")
+				}
+			case len(args) == 2:
+				ref = args[1]
+			default:
+				return fmt.Errorf("usage: squad skill pin <alias> <ref> | squad skill pin <alias> --unset")
+			}
+			if err := mgr.PinRepository(alias, ref); err != nil {
+				return err
+			}
+			if ref == "" {
+				logging.InfoContext(cmd.Context(), "unpinned %s (now tracking the default branch)", alias)
+			} else {
+				logging.InfoContext(cmd.Context(), "pinned %s to %s", alias, ref)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&unset, "unset", false, "Remove an existing pin (alias for empty ref)")
+	return cmd
 }
 
 func newSkillRemoveCmd() *cobra.Command {
@@ -293,10 +357,15 @@ func newSkillRemoveCmd() *cobra.Command {
 }
 
 func newSkillUpdateCmd() *cobra.Command {
-	return &cobra.Command{
+	var force bool
+	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "git pull every registered skill catalog repository",
-		Args:  cobra.NoArgs,
+		Long: `Pull the latest changes for every registered skill catalog repository.
+
+Pinned catalogs (registered with --ref or 'squad skill pin') are skipped
+by default — use --force to re-resolve their refs against the remote.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
 			cfg := configFromContext(cmd)
@@ -307,13 +376,15 @@ func newSkillUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := mgr.UpdateRepositories(); err != nil {
+			if err := mgr.UpdateRepositories(force); err != nil {
 				return err
 			}
 			logging.InfoContext(cmd.Context(), "all skill repositories updated")
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&force, "force", false, "Re-resolve and update pinned catalogs too")
+	return cmd
 }
 
 func newSkillSourcesCmd() *cobra.Command {
@@ -330,9 +401,14 @@ func newSkillSourcesCmd() *cobra.Command {
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			if len(cfg.Skills.Repositories) > 0 {
 				_, _ = fmt.Fprintln(w, "REPOSITORIES:")
-				_, _ = fmt.Fprintln(w, "NAME\tURL")
-				for _, name := range sortedKeys(cfg.Skills.Repositories) {
-					_, _ = fmt.Fprintf(w, "%s\t%s\n", name, cfg.Skills.Repositories[name])
+				_, _ = fmt.Fprintln(w, "NAME\tURL\tREF")
+				for _, name := range sortedRepoKeys(cfg.Skills.Repositories) {
+					spec := cfg.Skills.Repositories[name]
+					ref := spec.Ref
+					if ref == "" {
+						ref = "-"
+					}
+					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", name, spec.URL, ref)
 				}
 				_, _ = fmt.Fprintln(w)
 			}
@@ -513,7 +589,7 @@ func reportLoadErrors(cmd *cobra.Command, cat *skill.Catalog) {
 	}
 }
 
-func sortedKeys(m map[string]string) []string {
+func sortedRepoKeys(m map[string]config.RepoSpec) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/cmd/squad/skill_pin_test.go
+++ b/cmd/squad/skill_pin_test.go
@@ -101,6 +101,44 @@ func TestSkillUpdate_forceAttemptsPinned(t *testing.T) {
 	}
 }
 
+func TestSkillUpdate_unpinnedFailureSurfaced(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["bad"] = config.RepoSpec{
+		URL: "https://example.invalid/no-such-repo.git",
+	}
+	if _, err := runSkillSubcmd(t, cfg, newSkillUpdateCmd); err == nil {
+		t.Fatal("expected error from unpinned bad URL")
+	}
+}
+
+func TestSkillAdd_bogusURLWarnsButRegisters(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	// A URL that fails to clone still registers in config; the warning
+	// goes to stderr and the command exits 0.
+	out, err := runSkillSubcmd(t, cfg, newSkillAddCmd, "team",
+		"https://example.invalid/no-such-repo.git")
+	if err != nil {
+		t.Fatalf("add should succeed even when clone fails, got: %v", err)
+	}
+	if _, ok := cfg.Skills.Repositories["team"]; !ok {
+		t.Fatal("team should be registered despite clone failure")
+	}
+	if !strings.Contains(out, "warning") || !strings.Contains(out, "initial clone failed") {
+		t.Fatalf("expected clone-failure warning, got:\n%s", out)
+	}
+}
+
+func TestSkillAdd_localPathDuplicateRejected(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	dir := t.TempDir()
+	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, dir); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, dir); err == nil {
+		t.Fatal("expected duplicate local-path error")
+	}
+}
+
 func TestSkillSources_rendersRefColumn(t *testing.T) {
 	cfg := newSkillTestCfg(t)
 	cfg.Skills.Repositories["pinned"] = config.RepoSpec{

--- a/cmd/squad/skill_pin_test.go
+++ b/cmd/squad/skill_pin_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/config"
+)
+
+func TestSkillAdd_withRefStoresPinnedSpec(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	url := seedSkillRepo(t, "echo", "An echo skill.")
+	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, "team", url, "--ref", "v1.2.0"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got := cfg.Skills.Repositories["team"]
+	if got.URL != url {
+		t.Errorf("URL = %q, want %q", got.URL, url)
+	}
+	if got.Ref != "v1.2.0" {
+		t.Errorf("Ref = %q, want v1.2.0", got.Ref)
+	}
+}
+
+func TestSkillAdd_refOnLocalPathRejected(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	dir := t.TempDir()
+	_, err := runSkillSubcmd(t, cfg, newSkillAddCmd, dir, "--ref", "main")
+	if err == nil {
+		t.Fatal("expected --ref on local path to error")
+	}
+	if !strings.Contains(err.Error(), "--ref only applies to git repositories") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillPin_setsAndUnsets(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["team"] = config.RepoSpec{URL: "https://example.com/skills.git"}
+	if _, err := runSkillSubcmd(t, cfg, newSkillPinCmd, "team", "v0.3.0"); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	if got := cfg.Skills.Repositories["team"].Ref; got != "v0.3.0" {
+		t.Fatalf("Ref = %q, want v0.3.0", got)
+	}
+
+	if _, err := runSkillSubcmd(t, cfg, newSkillPinCmd, "team", "--unset"); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+	if cfg.Skills.Repositories["team"].IsPinned() {
+		t.Fatal("expected unpinned after --unset")
+	}
+}
+
+func TestSkillPin_unsetWithRefArgRejected(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["team"] = config.RepoSpec{URL: "https://x.test/skills.git"}
+	_, err := runSkillSubcmd(t, cfg, newSkillPinCmd, "team", "v1", "--unset")
+	if err == nil {
+		t.Fatal("expected error when combining --unset with a ref")
+	}
+}
+
+func TestSkillPin_missingRefArgRejected(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["team"] = config.RepoSpec{URL: "https://x.test/skills.git"}
+	_, err := runSkillSubcmd(t, cfg, newSkillPinCmd, "team")
+	if err == nil {
+		t.Fatal("expected usage error when ref is missing and --unset is not set")
+	}
+}
+
+func TestSkillPin_missingCatalogErrors(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	_, err := runSkillSubcmd(t, cfg, newSkillPinCmd, "ghost", "v1")
+	if err == nil {
+		t.Fatal("expected error when pinning a catalog that does not exist")
+	}
+}
+
+func TestSkillUpdate_skipsPinnedWithoutForce(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.invalid/never.git",
+		Ref: "v1",
+	}
+	if _, err := runSkillSubcmd(t, cfg, newSkillUpdateCmd); err != nil {
+		t.Fatalf("expected pinned catalog to be skipped, got: %v", err)
+	}
+}
+
+func TestSkillUpdate_forceAttemptsPinned(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.invalid/never.git",
+		Ref: "v1",
+	}
+	_, err := runSkillSubcmd(t, cfg, newSkillUpdateCmd, "--force")
+	if err == nil {
+		t.Fatal("expected --force to attempt the upstream and surface the failure")
+	}
+}
+
+func TestSkillSources_rendersRefColumn(t *testing.T) {
+	cfg := newSkillTestCfg(t)
+	cfg.Skills.Repositories["pinned"] = config.RepoSpec{
+		URL: "https://example.com/pinned.git",
+		Ref: "v1.0.0",
+	}
+	cfg.Skills.Repositories["floating"] = config.RepoSpec{
+		URL: "https://example.com/floating.git",
+	}
+	out, err := runSkillSubcmd(t, cfg, newSkillSourcesCmd)
+	if err != nil {
+		t.Fatalf("sources: %v", err)
+	}
+	if !strings.Contains(out, "REF") {
+		t.Errorf("expected REF column in output:\n%s", out)
+	}
+	if !strings.Contains(out, "v1.0.0") {
+		t.Errorf("expected pinned ref v1.0.0 in output:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "floating") {
+			if !strings.HasSuffix(strings.TrimRight(line, " \t"), "-") {
+				t.Errorf("unpinned catalog should render '-' for ref: %q", line)
+			}
+		}
+	}
+}

--- a/cmd/squad/skill_test.go
+++ b/cmd/squad/skill_test.go
@@ -301,7 +301,7 @@ func newSkillTestCfg(t *testing.T) *config.Config {
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), ".cache"))
 	return &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   nil,
 		},
 	}
@@ -410,7 +410,7 @@ func TestSkillAddRepository(t *testing.T) {
 	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, "team", url); err != nil {
 		t.Fatalf("add repo: %v", err)
 	}
-	if cfg.Skills.Repositories["team"] != url {
+	if cfg.Skills.Repositories["team"].URL != url {
 		t.Fatalf("repo not registered: %v", cfg.Skills.Repositories)
 	}
 }
@@ -502,7 +502,7 @@ func TestSkillSourcesEmpty(t *testing.T) {
 
 func TestSkillSourcesPopulated(t *testing.T) {
 	cfg := newSkillTestCfg(t)
-	cfg.Skills.Repositories["team"] = "https://example.com/a.git"
+	cfg.Skills.Repositories["team"] = config.RepoSpec{URL: "https://example.com/a.git"}
 	cfg.Skills.LocalPaths = []string{"/tmp/skills"}
 	out, err := runSkillSubcmd(t, cfg, newSkillSourcesCmd)
 	if err != nil {
@@ -643,7 +643,7 @@ func TestSkillAddDuplicateRepositoryErrors(t *testing.T) {
 
 func TestSkillUpdateBadRepoErrors(t *testing.T) {
 	cfg := newSkillTestCfg(t)
-	cfg.Skills.Repositories["bad"] = "https://example.invalid/no-such-repo.git"
+	cfg.Skills.Repositories["bad"] = config.RepoSpec{URL: "https://example.invalid/no-such-repo.git"}
 	if _, err := runSkillSubcmd(t, cfg, newSkillUpdateCmd); err == nil {
 		t.Fatal("expected error from bad upstream")
 	}
@@ -791,7 +791,7 @@ func TestSkillCatalogPathsManagerError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -809,7 +809,7 @@ func TestSkillAddRepositoryNewMgrError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -825,7 +825,7 @@ func TestSkillRemoveNewMgrError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -841,7 +841,7 @@ func TestSkillUpdateNewMgrError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -860,7 +860,7 @@ func TestSkillAddRepositoryCloneFailureWarns(t *testing.T) {
 	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, "team", bogus); err != nil {
 		t.Fatalf("add should not return error even if clone fails (warning path), got %v", err)
 	}
-	if cfg.Skills.Repositories["team"] != bogus {
+	if cfg.Skills.Repositories["team"].URL != bogus {
 		t.Fatalf("repo should still be registered, got %v", cfg.Skills.Repositories)
 	}
 }
@@ -871,7 +871,7 @@ func TestSkillListDiscoverError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -886,7 +886,7 @@ func TestSkillShowDiscoverError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -902,7 +902,7 @@ func TestSkillNew_GlobalResolveError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -72,12 +72,17 @@ type OtelConfig struct {
 type AgentsConfig struct {
 	// CacheDir is where cloned git repositories are cached.
 	CacheDir string `mapstructure:"cache_dir" yaml:"cache_dir"`
-	// Repositories maps repository names to Git URLs.
+	// Repositories maps repository names to Git sources. Each entry is
+	// either a plain URL (the legacy form, tracks the default branch) or
+	// a {url, ref} mapping that pins the source to a specific commit,
+	// tag, or branch. See [RepoSpec].
 	// Example:
 	//   repositories:
 	//     official: https://github.com/cowdogmoo/squad-agents.git
-	//     private: git@github.com:myorg/private-agents.git
-	Repositories map[string]string `mapstructure:"repositories" yaml:"repositories"`
+	//     private:
+	//       url: git@github.com:myorg/private-agents.git
+	//       ref: v1.2.0
+	Repositories map[string]RepoSpec `mapstructure:"repositories" yaml:"repositories"`
 	// LocalPaths lists local directories to search for agents.
 	// Example:
 	//   local_paths:
@@ -95,9 +100,11 @@ type SkillsConfig struct {
 	// CacheDir is where cloned skill catalog repositories are cached.
 	// Empty falls through to config.SkillsCacheDir().
 	CacheDir string `mapstructure:"cache_dir" yaml:"cache_dir"`
-	// Repositories maps a catalog alias to its Git URL. squad skill add /
-	// update operate on this map.
-	Repositories map[string]string `mapstructure:"repositories" yaml:"repositories"`
+	// Repositories maps a catalog alias to its Git source. Like
+	// [AgentsConfig.Repositories], entries accept either a plain URL
+	// string or a {url, ref} mapping that pins the catalog to a commit,
+	// tag, or branch.
+	Repositories map[string]RepoSpec `mapstructure:"repositories" yaml:"repositories"`
 	// LocalPaths lists additional directories to search for skill
 	// subdirectories. Each path is treated as a catalog root and its
 	// immediate subdirectories are scanned for SKILL.md files.
@@ -156,7 +163,7 @@ func Defaults() *Config {
 	v := viper.New()
 	SetDefaults(v)
 	cfg := &Config{}
-	_ = v.Unmarshal(cfg)
+	_ = v.Unmarshal(cfg, DecodeHooks())
 	return cfg
 }
 
@@ -210,7 +217,7 @@ func loadConfigWithViper(setup func(*viper.Viper) error) (*Config, *viper.Viper,
 	}
 
 	cfg := &Config{}
-	if err := v.Unmarshal(cfg); err != nil {
+	if err := v.Unmarshal(cfg, DecodeHooks()); err != nil {
 		return nil, nil, fmt.Errorf("config unmarshal failed: %w", err)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -228,8 +228,8 @@ func TestLoadFromPath_SkillsLocalPathsListForm(t *testing.T) {
 			t.Errorf("LocalPaths[%d] = %q, want %q", i, cfg.Skills.LocalPaths[i], p)
 		}
 	}
-	if cfg.Skills.Repositories["personal"] != "https://github.com/CowDogMoo/squad-skills.git" {
-		t.Errorf("Repositories[personal] = %q", cfg.Skills.Repositories["personal"])
+	if cfg.Skills.Repositories["personal"].URL != "https://github.com/CowDogMoo/squad-skills.git" {
+		t.Errorf("Repositories[personal] = %+v", cfg.Skills.Repositories["personal"])
 	}
 }
 

--- a/config/reposource.go
+++ b/config/reposource.go
@@ -83,7 +83,7 @@ func DecodeHooks() viper.DecoderConfigOption {
 
 // repoSpecDecodeHook lets viper / mapstructure consume both the legacy
 // `string` form and the `{url, ref}` mapping form when decoding YAML into a
-// Config. Used inside Unmarshal via [decodeHooks].
+// Config. Wired into viper.Unmarshal calls via [DecodeHooks].
 func repoSpecDecodeHook() mapstructure.DecodeHookFunc {
 	target := reflect.TypeOf(RepoSpec{})
 	return func(from reflect.Type, to reflect.Type, data any) (any, error) {

--- a/config/reposource.go
+++ b/config/reposource.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// RepoSpec describes a git-hosted agent or skill repository. URL is required;
+// Ref optionally pins the source to a commit SHA, tag, or branch so the same
+// agent/skill resolves to the same content on every clone or update. An empty
+// Ref tracks the default branch — the original pre-pinning behavior.
+type RepoSpec struct {
+	URL string `yaml:"url" mapstructure:"url"`
+	Ref string `yaml:"ref,omitempty" mapstructure:"ref"`
+}
+
+// IsPinned reports whether the spec is locked to a specific ref. Pinned
+// sources are skipped by `update` unless the caller forces a re-resolve.
+func (r RepoSpec) IsPinned() bool {
+	return r.Ref != ""
+}
+
+// UnmarshalYAML accepts both the legacy plain-string form
+// (`official: https://...`) and the explicit struct form
+// (`official: {url: ..., ref: v1.0.0}`). The string form is the historical
+// configuration; the struct form is opt-in for pinning.
+func (r *RepoSpec) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		r.URL = node.Value
+		r.Ref = ""
+		return nil
+	case yaml.MappingNode:
+		type rawSpec struct {
+			URL string `yaml:"url"`
+			Ref string `yaml:"ref"`
+		}
+		var raw rawSpec
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		r.URL = raw.URL
+		r.Ref = raw.Ref
+		return nil
+	default:
+		return fmt.Errorf("RepoSpec: expected string or mapping, got %v", node.Tag)
+	}
+}
+
+// MarshalYAML keeps the on-disk config compact: a spec with no Ref serializes
+// back to a plain string, matching configs that pre-date the pinning feature.
+// Specs with a Ref serialize as a mapping.
+func (r RepoSpec) MarshalYAML() (any, error) {
+	if r.Ref == "" {
+		return r.URL, nil
+	}
+	return struct {
+		URL string `yaml:"url"`
+		Ref string `yaml:"ref"`
+	}{URL: r.URL, Ref: r.Ref}, nil
+}
+
+// DecodeHooks returns the viper.DecoderConfigOption that registers every
+// custom mapstructure hook the loader needs. The default viper hooks
+// (StringToTimeDurationHookFunc, StringToSliceHookFunc) are re-installed
+// alongside repoSpecDecodeHook so env-var slice expansion still works.
+//
+// Callers that re-unmarshal viper state into a Config — typically to apply
+// late CLI-flag overrides — must thread this option through their
+// v.Unmarshal call, otherwise repository entries written as plain strings
+// will fail to decode.
+func DecodeHooks() viper.DecoderConfigOption {
+	return viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		repoSpecDecodeHook(),
+	))
+}
+
+// repoSpecDecodeHook lets viper / mapstructure consume both the legacy
+// `string` form and the `{url, ref}` mapping form when decoding YAML into a
+// Config. Used inside Unmarshal via [decodeHooks].
+func repoSpecDecodeHook() mapstructure.DecodeHookFunc {
+	target := reflect.TypeOf(RepoSpec{})
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to != target {
+			return data, nil
+		}
+		switch v := data.(type) {
+		case string:
+			return RepoSpec{URL: v}, nil
+		case map[string]any:
+			spec := RepoSpec{}
+			if url, ok := v["url"].(string); ok {
+				spec.URL = url
+			}
+			if ref, ok := v["ref"].(string); ok {
+				spec.Ref = ref
+			}
+			return spec, nil
+		}
+		return data, nil
+	}
+}

--- a/config/reposource.go
+++ b/config/reposource.go
@@ -83,8 +83,10 @@ func DecodeHooks() viper.DecoderConfigOption {
 
 // repoSpecDecodeHook lets viper / mapstructure consume both the legacy
 // `string` form and the `{url, ref}` mapping form when decoding YAML into a
-// Config. Wired into viper.Unmarshal calls via [DecodeHooks].
-func repoSpecDecodeHook() mapstructure.DecodeHookFunc {
+// Config. Wired into viper.Unmarshal calls via [DecodeHooks]. Returns the
+// concrete DecodeHookFuncType so tests can invoke it without a sloppy
+// type assertion.
+func repoSpecDecodeHook() mapstructure.DecodeHookFuncType {
 	target := reflect.TypeOf(RepoSpec{})
 	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
 		if to != target {

--- a/config/reposource_test.go
+++ b/config/reposource_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRepoSpec_unmarshalsPlainString(t *testing.T) {
+	t.Parallel()
+	input := `repositories:
+  official: https://github.com/cowdogmoo/squad-agents.git
+`
+	var got struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}
+	if err := yaml.Unmarshal([]byte(input), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	spec := got.Repositories["official"]
+	if spec.URL != "https://github.com/cowdogmoo/squad-agents.git" {
+		t.Fatalf("URL = %q", spec.URL)
+	}
+	if spec.Ref != "" {
+		t.Fatalf("Ref = %q, want empty", spec.Ref)
+	}
+	if spec.IsPinned() {
+		t.Fatal("plain-string spec should not be pinned")
+	}
+}
+
+func TestRepoSpec_unmarshalsMapping(t *testing.T) {
+	t.Parallel()
+	input := `repositories:
+  pinned:
+    url: https://github.com/cowdogmoo/squad-agents.git
+    ref: v0.4.2
+`
+	var got struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}
+	if err := yaml.Unmarshal([]byte(input), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	spec := got.Repositories["pinned"]
+	if spec.URL != "https://github.com/cowdogmoo/squad-agents.git" {
+		t.Fatalf("URL = %q", spec.URL)
+	}
+	if spec.Ref != "v0.4.2" {
+		t.Fatalf("Ref = %q", spec.Ref)
+	}
+	if !spec.IsPinned() {
+		t.Fatal("mapping spec with ref should be pinned")
+	}
+}
+
+func TestRepoSpec_marshalsUnpinnedAsString(t *testing.T) {
+	t.Parallel()
+	in := struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}{Repositories: map[string]RepoSpec{
+		"official": {URL: "https://github.com/cowdogmoo/squad-agents.git"},
+	}}
+	out, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "official: https://github.com/cowdogmoo/squad-agents.git") {
+		t.Fatalf("expected compact string form, got:\n%s", got)
+	}
+	if strings.Contains(got, "url:") {
+		t.Fatalf("unpinned spec should not serialize as a mapping, got:\n%s", got)
+	}
+}
+
+func TestRepoSpec_marshalsPinnedAsMapping(t *testing.T) {
+	t.Parallel()
+	in := struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}{Repositories: map[string]RepoSpec{
+		"pinned": {URL: "https://example.com/repo.git", Ref: "v1.2.0"},
+	}}
+	out, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "url: https://example.com/repo.git") {
+		t.Fatalf("expected mapping form with url:, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ref: v1.2.0") {
+		t.Fatalf("expected mapping form with ref:, got:\n%s", got)
+	}
+}
+
+func TestRepoSpec_roundTrip(t *testing.T) {
+	t.Parallel()
+	original := map[string]RepoSpec{
+		"unpinned": {URL: "https://example.com/a.git"},
+		"pinned":   {URL: "https://example.com/b.git", Ref: "deadbeef"},
+	}
+	wrapper := struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}{Repositories: original}
+
+	yamlBytes, err := yaml.Marshal(wrapper)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}
+	if err := yaml.Unmarshal(yamlBytes, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for name, want := range original {
+		got := decoded.Repositories[name]
+		if got != want {
+			t.Errorf("%s: got %+v, want %+v", name, got, want)
+		}
+	}
+}

--- a/config/reposource_test.go
+++ b/config/reposource_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -161,6 +162,55 @@ skills:
 	}
 	if got.Ref != "v1.2.0" {
 		t.Errorf("Ref = %q, want v1.2.0", got.Ref)
+	}
+}
+
+func TestRepoSpec_unmarshalMappingPropagatesInnerError(t *testing.T) {
+	t.Parallel()
+	// url must decode into a string; a sequence here forces yaml.Node.Decode
+	// to fail, exercising the mapping-form error path.
+	input := `repositories:
+  bad:
+    url: [/not, /a, /string]
+`
+	var got struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}
+	if err := yaml.Unmarshal([]byte(input), &got); err == nil {
+		t.Fatal("expected error when mapping fields have wrong inner types")
+	}
+}
+
+// callHook invokes the repo-spec decode hook directly.
+func callHook(t *testing.T, from, to reflect.Type, data any) any {
+	t.Helper()
+	got, err := repoSpecDecodeHook()(from, to, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return got
+}
+
+func TestRepoSpecDecodeHook_fallsThroughForOtherTypes(t *testing.T) {
+	t.Parallel()
+	// The hook only converts string and map[string]any into RepoSpec.
+	// Other source types must pass through untouched so other hooks can
+	// see them.
+	intVal := 42
+	got := callHook(t, reflect.TypeOf(intVal), reflect.TypeOf(RepoSpec{}), intVal)
+	if got != intVal {
+		t.Fatalf("got %v, want %v", got, intVal)
+	}
+}
+
+func TestRepoSpecDecodeHook_noopWhenTargetIsNotRepoSpec(t *testing.T) {
+	t.Parallel()
+	// When the destination is not RepoSpec, the hook must hand the data
+	// back untouched even when the source type is string.
+	other := reflect.TypeOf("")
+	got := callHook(t, other, other, "passthrough")
+	if got != "passthrough" {
+		t.Fatalf("got %v (%T)", got, got)
 	}
 }
 

--- a/config/reposource_test.go
+++ b/config/reposource_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -92,6 +93,74 @@ func TestRepoSpec_marshalsPinnedAsMapping(t *testing.T) {
 	}
 	if !strings.Contains(got, "ref: v1.2.0") {
 		t.Fatalf("expected mapping form with ref:, got:\n%s", got)
+	}
+}
+
+func TestRepoSpec_unmarshalRejectsSequence(t *testing.T) {
+	t.Parallel()
+	// A sequence node is neither the legacy string form nor the pinned
+	// mapping form; UnmarshalYAML must surface that as an error.
+	input := `repositories:
+  bad:
+    - https://example.com/a.git
+    - https://example.com/b.git
+`
+	var got struct {
+		Repositories map[string]RepoSpec `yaml:"repositories"`
+	}
+	err := yaml.Unmarshal([]byte(input), &got)
+	if err == nil {
+		t.Fatal("expected error for sequence-shaped RepoSpec")
+	}
+}
+
+func TestDecodeHooks_acceptsStringForm(t *testing.T) {
+	t.Parallel()
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(`
+agents:
+  repositories:
+    official: https://github.com/cowdogmoo/squad-agents.git
+`)); err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	var cfg Config
+	if err := v.Unmarshal(&cfg, DecodeHooks()); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	got := cfg.Agents.Repositories["official"]
+	if got.URL != "https://github.com/cowdogmoo/squad-agents.git" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if got.Ref != "" {
+		t.Errorf("plain-string form should not pin, got Ref=%q", got.Ref)
+	}
+}
+
+func TestDecodeHooks_acceptsMappingForm(t *testing.T) {
+	t.Parallel()
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(`
+skills:
+  repositories:
+    team:
+      url: https://example.com/team-skills.git
+      ref: v1.2.0
+`)); err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	var cfg Config
+	if err := v.Unmarshal(&cfg, DecodeHooks()); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	got := cfg.Skills.Repositories["team"]
+	if got.URL != "https://example.com/team-skills.git" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if got.Ref != "v1.2.0" {
+		t.Errorf("Ref = %q, want v1.2.0", got.Ref)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ squad run --agent go-review --provider openai --model gpt-4.1-mini
 ### Anthropic
 
 ```bash
-squad run --agent go-review --provider anthropic --model claude-sonnet-4-20250514
+squad run --agent go-review --provider anthropic --model claude-sonnet-4-6
 ```
 
 ### Google AI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,8 +107,43 @@ the corresponding CLI flag.
 | Key | Type | Default | Description |
 | ------------------------- | ----------- | ------------------------------- | ------------------------------------------------ |
 | `agents.cache_dir` | string | `~/.cache/squad/agents` | Directory where cloned agent git repos are cached |
-| `agents.repositories` | map | `{official: <squad-agents>}` | Named git URLs to fetch agents from |
+| `agents.repositories` | map | `{official: <squad-agents>}` | Named git sources to fetch agents from — see [Repository pinning](#repository-pinning) |
 | `agents.local_paths` | []string | `[]` | Local directories searched for agents |
+
+#### Repository pinning
+
+Each entry under `agents.repositories` (and `skills.repositories`) accepts
+two shapes. The plain-string form tracks the default branch, the mapping
+form pins the source to a specific commit, tag, or branch:
+
+```yaml
+agents:
+  repositories:
+    # Legacy form: tracks the default branch (origin/HEAD)
+    official: https://github.com/cowdogmoo/squad-agents.git
+
+    # Pinned form: locked to a specific ref
+    private:
+      url: git@github.com:myorg/private-agents.git
+      ref: v1.2.0
+```
+
+`ref` accepts a commit SHA (full or abbreviated), an annotated or
+lightweight tag, or a branch name. Resolution order is SHA → tag →
+remote-tracking branch → local branch.
+
+Use the CLI to add or change pins without editing YAML by hand:
+
+```bash
+squad agents add official https://github.com/cowdogmoo/squad-agents.git --ref v0.4.2
+squad agents pin official v0.5.0
+squad agents pin official --unset           # back to tracking the default branch
+squad agents update                          # skips pinned repositories
+squad agents update --force                  # re-resolves and updates pinned ones too
+```
+
+The same `--ref` flag and `pin`/`unset` semantics work for
+`squad skill add` and `squad skill pin`.
 
 ### otel
 
@@ -399,3 +434,4 @@ When you integrate squad into a production workflow:
 - **Sandbox writes** with `--isolate worktree` (separate dir + branch) or the `environment: docker` execution backend ([docs/execution-backends.md](./execution-backends.md)) so a bad edit lands in a throwaway tree, not your working copy.
 - **Review `agent.yaml` and the prompt files like code.** The `Bash` tool runs arbitrary shell; treat every manifest change in PR review the same way you'd treat a change to a CI workflow.
 - **Never hard-code API keys** in `agent.yaml` or shell history. Use `$VAR` or `$(command)` token resolution to pull from a secret manager — see [Token resolution](#token-resolution) above.
+- **Pin agent and skill sources by SHA when it matters.** Routines fire unattended; an unpinned `agents.repositories` entry runs whatever HEAD happens to be at trigger time. Pass `--ref <sha-or-tag>` to `squad agents add`/`squad skill add` or use `squad agents pin <name> <ref>` to lock in a reviewed version — see [Repository pinning](#repository-pinning).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -387,3 +387,15 @@ squad run --agent go-review \
   --base-url https://ollama.example.com/v1 \
   --model qwen2.5-coder:7b-instruct
 ```
+
+## Running Squad Safely
+
+`squad` is dual-use software: it drives LLM agents through filesystem, shell, and network tools. A misbehaving agent (whether hallucinating, prompt-injected, or misconfigured) can mutate files, run shell commands, or burn budget unless you constrain it at config time.
+
+When you integrate squad into a production workflow:
+
+- **Cap cost on every run.** Set `--max-cost` (or `run.max_cost` in the config file) to a sane USD ceiling. A budget cap is the only universally reliable stop.
+- **Pick an explicit `--auto-confirm` policy** for unattended execution. The default `abort` is correct for interactive runs; for routines, choose `yes` only when you've audited the agent's tool surface.
+- **Sandbox writes** with `--isolate worktree` (separate dir + branch) or the `environment: docker` execution backend ([docs/execution-backends.md](./execution-backends.md)) so a bad edit lands in a throwaway tree, not your working copy.
+- **Review `agent.yaml` and the prompt files like code.** The `Bash` tool runs arbitrary shell; treat every manifest change in PR review the same way you'd treat a change to a CI workflow.
+- **Never hard-code API keys** in `agent.yaml` or shell history. Use `$VAR` or `$(command)` token resolution to pull from a secret manager — see [Token resolution](#token-resolution) above.

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -43,11 +43,27 @@ references:
   - references/criteria.md
 task: task.md
 
+# Optional: ranked model preferences. First entry is primary; later entries
+# are fallbacks when their provider credentials are detected.
+models:
+  - model: claude-sonnet-4-6
+    provider: anthropic
+  - model: gpt-4.1-mini
+    provider: openai
+
+# Optional: per-agent run policy
+max_iterations: 100        # iteration cap (0 = use CLI default)
+edit_deadline: 25          # stop after N iterations with no Edit calls
+disable_task: false        # when true, the Task tool is not registered
+comments_only: false       # when true, Edit/MultiEdit reject non-comment changes
+isolation: ""              # "worktree" | "branch" | "commit" | "staged" | ""
+working_dir: ""             # set "none" for remote-only agents (no local FS tools)
+
 # Optional: execution environment (local, docker, ssm, kubectl)
 environment:
   type: docker
   options:
-    image: golang:1.23
+    image: golang:1.26
     volumes: ".:/workspace"
     working_dir: /workspace
 
@@ -78,10 +94,23 @@ mcp_servers:
   - name: mytools
     command: npx
     args: ["@myorg/mcp-server"]
+
+# Optional: Agent Skills catalog control. See docs/skills.md.
+skills:
+  enabled: true                # nil = auto-enable when any skill is discovered
+  scopes: [repo, catalog]      # which scopes to surface
+  allow: []                    # exclusive allowlist of skill names
+  deny: []                     # remove skills by name (only when allow is empty)
 ```
 
-Only `name`, `entrypoint`, `wrapper`, and `task` are required. Everything
-else is optional.
+Only `name`, `entrypoint`, `wrapper`, and `task` are required. Everything else is optional.
+
+**Notable manifest options:**
+
+- `comments_only` is for cleanup agents (e.g. `go-scrub-comments`). When set, the Edit and MultiEdit tools reject any change that touches non-comment lines, so an LLM hallucinating new code can't silently mutate the codebase.
+- `disable_task` removes the `Task` tool from the agent, useful for leaf agents that shouldn't dispatch child runs.
+- `edit_deadline` enters a grace period after N iterations without an Edit; reads are blocked so the model is forced to commit pending fixes.
+- `isolation` defers to the CLI `--isolate` flag and, ultimately, the config default. `worktree` is the safest for agents that apply diffs.
 
 ### system.md (Main Prompt)
 

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -96,8 +96,9 @@ mcp_servers:
     args: ["@myorg/mcp-server"]
 
 # Optional: Agent Skills catalog control. See docs/skills.md.
+# Omit the whole block to auto-enable whenever any skill is discovered.
 skills:
-  enabled: true                # nil = auto-enable when any skill is discovered
+  enabled: true                # set false to disable skills for this agent
   scopes: [repo, catalog]      # which scopes to surface
   allow: []                    # exclusive allowlist of skill names
   deny: []                     # remove skills by name (only when allow is empty)

--- a/docs/execution-backends.md
+++ b/docs/execution-backends.md
@@ -19,7 +19,7 @@ declared in the agent's `agent.yaml` manifest.
 environment:
   type: docker
   options:
-    image: golang:1.23
+    image: golang:1.26
     volumes: ".:/workspace"
     working_dir: /workspace
     shell: /bin/bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,7 +38,7 @@ Each line is a JSON object with a timestamp, an event type, and a payload:
 ```jsonl
 {"ts":"2026-05-07T14:30:22Z","type":"run_start","payload":{"agent":"go-review","model":"gpt-4o","provider":"openai"}}
 {"ts":"2026-05-07T14:30:23Z","type":"prompt","payload":{"content":"Review the authentication changes in this PR..."}}
-{"ts":"2026-05-07T14:30:25Z","type":"tool_call","payload":{"name":"read_file","input":{"path":"auth/middleware.go"}}}
+{"ts":"2026-05-07T14:30:25Z","type":"tool_call","payload":{"name":"Read","input":{"path":"auth/middleware.go"}}}
 {"ts":"2026-05-07T14:30:25Z","type":"tool_result","payload":{"tool_call_id":"tc_01","content":"package auth\n..."}}
 {"ts":"2026-05-07T14:30:48Z","type":"iteration","payload":{"iteration":1}}
 {"ts":"2026-05-07T14:31:10Z","type":"run_end","payload":{"status":"completed"}}
@@ -152,9 +152,9 @@ Spans are created for each layer of execution. A typical run produces a tree lik
 ```
 agent.run (go-review)
 ├── model.invoke
-├── tool.call (read_file)
+├── tool.call (Read)
 ├── model.invoke
-├── tool.call (bash)
+├── tool.call (Bash)
 │   └── executor.local
 ├── model.invoke
 └── tool.call (mcp/filesystem/read)

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -87,7 +87,7 @@ id: nightly-audit             # required, user-supplied slug
 agent: go-security-audit      # required
 schedule: "0 2 * * *"         # required, see schedule syntax above
 prompt: "Audit pending changes since last run"
-working_dir: /Users/l/code/api  # required for global; defaults to repo root for per-repo
+working_dir: ~/code/my-project  # required for global; defaults to repo root for per-repo
 provider: anthropic           # optional, falls back to squad config default
 model: claude-sonnet-4-6      # optional
 max_cost: 5.00                # optional per-fire USD cap

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/openai/openai-go/v3 v3.17.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/tmc/langchaingo v0.1.14
 	go.opentelemetry.io/otel v1.43.0
@@ -136,7 +137,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/go-git/go-git/v5 v5.17.1
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/mattn/go-isatty v0.0.20
@@ -92,7 +93,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/generative-ai-go v0.15.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect

--- a/source/git.go
+++ b/source/git.go
@@ -125,8 +125,9 @@ func (g *GitOperations) checkoutRef(repoPath, gitURL, ref string) error {
 	}
 	if err := repo.Fetch(fetchOpts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		// Fetch failure is non-fatal — the ref may still resolve against
-		// what's already in the cache.
-		_ = err
+		// what's already in the cache — but surface it so a pinned ref
+		// that fails to resolve later isn't silently masked.
+		fmt.Fprintf(os.Stderr, "warning: fetch %s for ref %q: %v\n", gitURL, ref, err)
 	}
 
 	hash, err := resolveRef(repo, ref)
@@ -144,24 +145,17 @@ func (g *GitOperations) checkoutRef(repoPath, gitURL, ref string) error {
 	})
 }
 
-// resolveRef walks the standard reference layouts to convert a user-supplied
-// ref to a commit hash. Order: literal SHA → annotated/lightweight tag →
-// remote-tracking branch (origin/<ref>) → local branch.
+// resolveRef converts a user-supplied ref to a commit hash. go-git's
+// ResolveRevision handles SHA prefixes, tags, and HEAD natively; we add
+// an explicit remote-tracking-branch fallback because a freshly-cloned
+// repository only has `refs/remotes/origin/<branch>` for non-default
+// branches, and `ResolveRevision("<branch>")` does not consult that
+// namespace on its own.
 func resolveRef(repo *git.Repository, ref string) (plumbing.Hash, error) {
-	// Try as a literal commit (full or abbreviated SHA).
 	if h, err := repo.ResolveRevision(plumbing.Revision(ref)); err == nil {
 		return *h, nil
 	}
-	// Try as a tag.
-	if h, err := repo.ResolveRevision(plumbing.Revision("refs/tags/" + ref)); err == nil {
-		return *h, nil
-	}
-	// Try as a remote-tracking branch.
 	if h, err := repo.ResolveRevision(plumbing.Revision("refs/remotes/origin/" + ref)); err == nil {
-		return *h, nil
-	}
-	// Try as a local branch.
-	if h, err := repo.ResolveRevision(plumbing.Revision("refs/heads/" + ref)); err == nil {
 		return *h, nil
 	}
 	return plumbing.ZeroHash, fmt.Errorf("ref %q does not resolve to a commit, tag, or branch", ref)

--- a/source/git.go
+++ b/source/git.go
@@ -25,12 +25,14 @@ package source
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -57,19 +59,30 @@ func (g *GitOperations) CachePath(gitURL string) (string, bool) {
 	return "", false
 }
 
-// CloneOrUpdate clones a repository if it doesn't exist, or updates it if it does.
-func (g *GitOperations) CloneOrUpdate(gitURL string) (string, error) {
+// CloneOrUpdate clones a repository if it doesn't exist, or updates it if
+// it does, then checks out ref. An empty ref leaves the working tree on the
+// default branch (the historical behavior).
+func (g *GitOperations) CloneOrUpdate(gitURL, ref string) (string, error) {
 	repoPath := g.getCachePath(gitURL)
 
 	if stat, err := os.Stat(repoPath); err == nil && stat.IsDir() {
-		if err := g.pull(repoPath); err != nil {
-			// Pull failed, but we have a cached copy - use it
-			return repoPath, nil
+		// Re-fetch so any new tags/branches are available for checkout,
+		// then ignore pull errors so a transient network blip still
+		// lets us serve the cached copy.
+		_ = g.pull(repoPath)
+		if err := g.checkoutRef(repoPath, gitURL, ref); err != nil {
+			return repoPath, err
 		}
 		return repoPath, nil
 	}
 
-	return g.clone(gitURL, repoPath)
+	if _, err := g.clone(gitURL, repoPath); err != nil {
+		return "", err
+	}
+	if err := g.checkoutRef(repoPath, gitURL, ref); err != nil {
+		return repoPath, err
+	}
+	return repoPath, nil
 }
 
 // clone clones a repository to the specified path.
@@ -85,6 +98,73 @@ func (g *GitOperations) clone(gitURL, repoPath string) (string, error) {
 	}
 
 	return repoPath, nil
+}
+
+// checkoutRef resolves ref to a commit and checks it out. ref may be a
+// commit SHA (full or abbreviated), an annotated or lightweight tag, or a
+// branch name. An empty ref is a no-op so unpinned repos keep their
+// default-branch HEAD.
+//
+// Resolution order matches `git checkout <ref>` semantics: try as a SHA
+// first, then as a tag, then as a remote-tracking branch, then as a local
+// branch. Returns a wrapped error when ref does not resolve.
+func (g *GitOperations) checkoutRef(repoPath, gitURL, ref string) error {
+	if ref == "" {
+		return nil
+	}
+	repo, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return fmt.Errorf("open repository for checkout: %w", err)
+	}
+
+	// Fetch tags so freshly-pushed pins resolve without a manual pull.
+	fetchOpts := &git.FetchOptions{
+		RemoteName: "origin",
+		Tags:       git.AllTags,
+		Auth:       httpAuthFromEnv(gitURL),
+	}
+	if err := repo.Fetch(fetchOpts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		// Fetch failure is non-fatal — the ref may still resolve against
+		// what's already in the cache.
+		_ = err
+	}
+
+	hash, err := resolveRef(repo, ref)
+	if err != nil {
+		return err
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("get worktree for checkout: %w", err)
+	}
+	return w.Checkout(&git.CheckoutOptions{
+		Hash:  hash,
+		Force: true,
+	})
+}
+
+// resolveRef walks the standard reference layouts to convert a user-supplied
+// ref to a commit hash. Order: literal SHA → annotated/lightweight tag →
+// remote-tracking branch (origin/<ref>) → local branch.
+func resolveRef(repo *git.Repository, ref string) (plumbing.Hash, error) {
+	// Try as a literal commit (full or abbreviated SHA).
+	if h, err := repo.ResolveRevision(plumbing.Revision(ref)); err == nil {
+		return *h, nil
+	}
+	// Try as a tag.
+	if h, err := repo.ResolveRevision(plumbing.Revision("refs/tags/" + ref)); err == nil {
+		return *h, nil
+	}
+	// Try as a remote-tracking branch.
+	if h, err := repo.ResolveRevision(plumbing.Revision("refs/remotes/origin/" + ref)); err == nil {
+		return *h, nil
+	}
+	// Try as a local branch.
+	if h, err := repo.ResolveRevision(plumbing.Revision("refs/heads/" + ref)); err == nil {
+		return *h, nil
+	}
+	return plumbing.ZeroHash, fmt.Errorf("ref %q does not resolve to a commit, tag, or branch", ref)
 }
 
 // remoteURL returns the URL of the named-or-first remote on repo, or empty

--- a/source/git_ref_test.go
+++ b/source/git_ref_test.go
@@ -1,0 +1,186 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cowdogmoo/squad/source"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// fixtureRepo builds a local git repository with three commits, one tag,
+// and a non-default branch so the checkout tests can exercise SHA-, tag-,
+// and branch-style refs without any network access.
+func fixtureRepo(t *testing.T) (path, firstSHA, tagName, branchName, branchSHA string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	sig := &object.Signature{Name: "Tester", Email: "t@example.com", When: time.Now()}
+
+	write := func(name, body string) plumbing.Hash {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if _, err := wt.Add(name); err != nil {
+			t.Fatalf("add %s: %v", name, err)
+		}
+		h, err := wt.Commit("commit "+name, &git.CommitOptions{Author: sig})
+		if err != nil {
+			t.Fatalf("commit %s: %v", name, err)
+		}
+		return h
+	}
+
+	first := write("a.txt", "one")
+	_ = write("b.txt", "two")
+
+	// Lightweight tag on the first commit.
+	if _, err := repo.CreateTag("v0.1.0", first, nil); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+
+	// Branch with its own commit.
+	branchRef := plumbing.NewBranchReferenceName("topic")
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(branchRef, head.Hash())); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: branchRef, Force: true}); err != nil {
+		t.Fatalf("checkout topic: %v", err)
+	}
+	branchHead := write("c.txt", "three")
+
+	// Return HEAD to default branch so clone gets it.
+	defaultBranch := plumbing.NewBranchReferenceName("master")
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: defaultBranch, Force: true}); err != nil {
+		t.Fatalf("checkout master: %v", err)
+	}
+
+	return dir, first.String(), "v0.1.0", "topic", branchHead.String()
+}
+
+func cloneFromFixture(t *testing.T, fixtureDir string) (cacheDir string, gitURL string, ops *source.GitOperations) {
+	t.Helper()
+	cacheDir = t.TempDir()
+	ops = source.NewGitOperations(cacheDir)
+	gitURL = "file://" + fixtureDir
+	return cacheDir, gitURL, ops
+}
+
+func headHash(t *testing.T, repoPath string) string {
+	t.Helper()
+	repo, err := git.PlainOpen(repoPath)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	return head.Hash().String()
+}
+
+func TestCloneOrUpdate_emptyRefLeavesDefaultBranchHEAD(t *testing.T) {
+	t.Parallel()
+	fixture, _, _, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	repoPath, err := ops.CloneOrUpdate(url, "")
+	if err != nil {
+		t.Fatalf("CloneOrUpdate: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "b.txt")); err != nil {
+		t.Fatalf("default branch tip should include b.txt: %v", err)
+	}
+}
+
+func TestCloneOrUpdate_checksOutSHA(t *testing.T) {
+	t.Parallel()
+	fixture, firstSHA, _, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	repoPath, err := ops.CloneOrUpdate(url, firstSHA)
+	if err != nil {
+		t.Fatalf("CloneOrUpdate(SHA): %v", err)
+	}
+	if got := headHash(t, repoPath); got != firstSHA {
+		t.Fatalf("HEAD = %s, want %s", got, firstSHA)
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "b.txt")); !os.IsNotExist(err) {
+		t.Fatalf("first commit shouldn't have b.txt; got err=%v", err)
+	}
+}
+
+func TestCloneOrUpdate_checksOutTag(t *testing.T) {
+	t.Parallel()
+	fixture, firstSHA, tag, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	repoPath, err := ops.CloneOrUpdate(url, tag)
+	if err != nil {
+		t.Fatalf("CloneOrUpdate(tag): %v", err)
+	}
+	if got := headHash(t, repoPath); got != firstSHA {
+		t.Fatalf("tag %q resolved to %s, want %s", tag, got, firstSHA)
+	}
+}
+
+func TestCloneOrUpdate_checksOutRemoteBranch(t *testing.T) {
+	t.Parallel()
+	fixture, _, _, branch, branchSHA := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	repoPath, err := ops.CloneOrUpdate(url, branch)
+	if err != nil {
+		t.Fatalf("CloneOrUpdate(branch): %v", err)
+	}
+	if got := headHash(t, repoPath); got != branchSHA {
+		t.Fatalf("branch %q resolved to %s, want %s", branch, got, branchSHA)
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "c.txt")); err != nil {
+		t.Fatalf("topic branch tip should include c.txt: %v", err)
+	}
+}
+
+func TestCloneOrUpdate_unknownRefIsError(t *testing.T) {
+	t.Parallel()
+	fixture, _, _, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	if _, err := ops.CloneOrUpdate(url, "does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown ref")
+	}
+}
+
+func TestCloneOrUpdate_followupUpdateSwitchesRef(t *testing.T) {
+	t.Parallel()
+	fixture, firstSHA, tag, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	// First clone tracks the default branch.
+	if _, err := ops.CloneOrUpdate(url, ""); err != nil {
+		t.Fatalf("initial CloneOrUpdate: %v", err)
+	}
+	// Subsequent CloneOrUpdate with a ref must rewind to that ref.
+	repoPath, err := ops.CloneOrUpdate(url, tag)
+	if err != nil {
+		t.Fatalf("CloneOrUpdate(tag) on existing clone: %v", err)
+	}
+	if got := headHash(t, repoPath); got != firstSHA {
+		t.Fatalf("after switching to tag, HEAD = %s, want %s", got, firstSHA)
+	}
+}

--- a/source/git_ref_test.go
+++ b/source/git_ref_test.go
@@ -166,6 +166,28 @@ func TestCloneOrUpdate_unknownRefIsError(t *testing.T) {
 	}
 }
 
+func TestCloneOrUpdate_corruptCacheDirErrors(t *testing.T) {
+	t.Parallel()
+	fixture, _, _, _, _ := fixtureRepo(t)
+	cacheDir, url, ops := cloneFromFixture(t, fixture)
+
+	// First clone succeeds.
+	repoPath, err := ops.CloneOrUpdate(url, "")
+	if err != nil {
+		t.Fatalf("initial CloneOrUpdate: %v", err)
+	}
+
+	// Corrupt the cache by removing the .git dir; subsequent calls with
+	// a non-empty ref should surface a PlainOpen error from checkoutRef.
+	if err := os.RemoveAll(filepath.Join(repoPath, ".git")); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if _, err := ops.CloneOrUpdate(url, "v0.1.0"); err == nil {
+		t.Fatal("expected PlainOpen failure on corrupt cache dir")
+	}
+	_ = cacheDir
+}
+
 func TestCloneOrUpdate_followupUpdateSwitchesRef(t *testing.T) {
 	t.Parallel()
 	fixture, firstSHA, tag, _, _ := fixtureRepo(t)

--- a/source/git_test.go
+++ b/source/git_test.go
@@ -130,7 +130,7 @@ func TestGitOperationsCloneOrUpdate(t *testing.T) {
 			gitURL, cacheDir, expectedPath := tt.setup(t)
 			ops := source.NewGitOperations(cacheDir)
 
-			path, err := ops.CloneOrUpdate(gitURL)
+			path, err := ops.CloneOrUpdate(gitURL, "")
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q", tt.wantErr)

--- a/source/manager.go
+++ b/source/manager.go
@@ -62,24 +62,38 @@ func NewManager(cfg *config.Config) (*Manager, error) {
 	}, nil
 }
 
-// AddRepository adds a git repository as an agent source.
-func (m *Manager) AddRepository(name, gitURL string) error {
+// AddRepository adds a git repository as an agent source. An empty ref
+// tracks the default branch; a non-empty ref pins the source to that
+// commit SHA, tag, or branch.
+func (m *Manager) AddRepository(name, gitURL, ref string) error {
 	if !IsGitURL(gitURL) {
 		return fmt.Errorf("invalid git URL: %s", gitURL)
 	}
 
 	if m.cfg.Agents.Repositories == nil {
-		m.cfg.Agents.Repositories = make(map[string]string)
+		m.cfg.Agents.Repositories = make(map[string]config.RepoSpec)
 	}
 
 	if existing, ok := m.cfg.Agents.Repositories[name]; ok {
-		if existing == gitURL {
+		if existing.URL == gitURL && existing.Ref == ref {
 			return fmt.Errorf("repository %q already configured with URL %s", name, gitURL)
 		}
-		return fmt.Errorf("repository %q already exists with URL %s (use remove first)", name, existing)
+		return fmt.Errorf("repository %q already exists with URL %s (use remove first)", name, existing.URL)
 	}
 
-	m.cfg.Agents.Repositories[name] = gitURL
+	m.cfg.Agents.Repositories[name] = config.RepoSpec{URL: gitURL, Ref: ref}
+	return m.saveConfig()
+}
+
+// PinRepository sets or replaces the pinned ref for an existing repository.
+// An empty ref unpins (returns to tracking the default branch).
+func (m *Manager) PinRepository(name, ref string) error {
+	spec, ok := m.cfg.Agents.Repositories[name]
+	if !ok {
+		return fmt.Errorf("repository not found: %s", name)
+	}
+	spec.Ref = ref
+	m.cfg.Agents.Repositories[name] = spec
 	return m.saveConfig()
 }
 
@@ -131,12 +145,19 @@ func (m *Manager) RemoveSource(nameOrPath string) error {
 	return fmt.Errorf("source not found: %s", nameOrPath)
 }
 
-// UpdateRepositories pulls latest from all configured git repositories.
-func (m *Manager) UpdateRepositories() error {
+// UpdateRepositories pulls latest from configured git repositories.
+// Pinned repositories (Ref != "") are skipped unless force is true, in
+// which case the ref is re-resolved against the remote (useful when a
+// tag has been re-pointed or a branch has advanced).
+func (m *Manager) UpdateRepositories(force bool) error {
 	var errs []string
-	for name, url := range m.cfg.Agents.Repositories {
-		fmt.Printf("Updating %s (%s)...\n", name, url)
-		if _, err := m.gitOps.CloneOrUpdate(url); err != nil {
+	for name, spec := range m.cfg.Agents.Repositories {
+		if spec.IsPinned() && !force {
+			fmt.Printf("Skipping %s (pinned to %s) — use --force to re-resolve\n", name, spec.Ref)
+			continue
+		}
+		fmt.Printf("Updating %s (%s)...\n", name, spec.URL)
+		if _, err := m.gitOps.CloneOrUpdate(spec.URL, spec.Ref); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
 		}
 	}
@@ -169,8 +190,8 @@ func (m *Manager) GetSearchPaths() ([]string, error) {
 	}
 
 	// 3. Cached git repositories (use local cache only, no network access)
-	for _, url := range m.cfg.Agents.Repositories {
-		if repoPath, ok := m.gitOps.CachePath(url); ok {
+	for _, spec := range m.cfg.Agents.Repositories {
+		if repoPath, ok := m.gitOps.CachePath(spec.URL); ok {
 			paths = append(paths, repoPath)
 		}
 	}

--- a/source/manager_test.go
+++ b/source/manager_test.go
@@ -176,15 +176,15 @@ func TestManagerAddRepository(t *testing.T) {
 			cfg := config.Defaults()
 			cfg.Agents.Repositories = nil
 			if tt.existing != nil {
-				cfg.Agents.Repositories = map[string]string{}
+				cfg.Agents.Repositories = map[string]config.RepoSpec{}
 				for key, value := range tt.existing {
-					cfg.Agents.Repositories[key] = value
+					cfg.Agents.Repositories[key] = config.RepoSpec{URL: value}
 				}
 			}
 			cfg.Agents.LocalPaths = []string{}
 
 			manager := newTestManager(t, cfg)
-			err := manager.AddRepository("repo", tt.gitURL)
+			err := manager.AddRepository("repo", tt.gitURL, "")
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -208,9 +208,9 @@ func TestManagerAddRepository(t *testing.T) {
 			}
 
 			if tt.wantStored != "" {
-				if cfg.Agents.Repositories["repo"] != tt.wantStored {
+				if cfg.Agents.Repositories["repo"].URL != tt.wantStored {
 					t.Fatalf("stored url = %q, want %q",
-						cfg.Agents.Repositories["repo"], tt.wantStored)
+						cfg.Agents.Repositories["repo"].URL, tt.wantStored)
 				}
 			}
 		})
@@ -264,7 +264,7 @@ func TestManagerAddLocalPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := config.Defaults()
-			cfg.Agents.Repositories = map[string]string{}
+			cfg.Agents.Repositories = map[string]config.RepoSpec{}
 			cfg.Agents.LocalPaths = []string{}
 
 			pathValue := tt.setupPath(t)
@@ -321,8 +321,8 @@ func TestManagerRemoveSource(t *testing.T) {
 			name: "remove repository",
 			setup: func(t *testing.T) (*config.Config, string) {
 				cfg := config.Defaults()
-				cfg.Agents.Repositories = map[string]string{
-					"repo": "https://github.com/org/repo.git",
+				cfg.Agents.Repositories = map[string]config.RepoSpec{
+					"repo": {URL: "https://github.com/org/repo.git"},
 				}
 				cfg.Agents.LocalPaths = []string{}
 				return cfg, "repo"
@@ -334,7 +334,7 @@ func TestManagerRemoveSource(t *testing.T) {
 			name: "remove local path",
 			setup: func(t *testing.T) (*config.Config, string) {
 				cfg := config.Defaults()
-				cfg.Agents.Repositories = map[string]string{}
+				cfg.Agents.Repositories = map[string]config.RepoSpec{}
 				localPath := t.TempDir()
 				cfg.Agents.LocalPaths = []string{localPath}
 				return cfg, localPath
@@ -346,7 +346,7 @@ func TestManagerRemoveSource(t *testing.T) {
 			name: "not found",
 			setup: func(t *testing.T) (*config.Config, string) {
 				cfg := config.Defaults()
-				cfg.Agents.Repositories = map[string]string{}
+				cfg.Agents.Repositories = map[string]config.RepoSpec{}
 				cfg.Agents.LocalPaths = []string{}
 				return cfg, "missing"
 			},
@@ -401,18 +401,18 @@ func TestManagerRemoveSource(t *testing.T) {
 
 func TestManagerUpdateRepositoriesEmpty(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{}
+	cfg.Agents.Repositories = map[string]config.RepoSpec{}
 	cfg.Agents.LocalPaths = []string{}
 	manager := newTestManager(t, cfg)
 
-	if err := manager.UpdateRepositories(); err != nil {
+	if err := manager.UpdateRepositories(false); err != nil {
 		t.Fatalf("UpdateRepositories() error = %v", err)
 	}
 }
 
 func TestManagerGetSearchPaths(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{}
+	cfg.Agents.Repositories = map[string]config.RepoSpec{}
 	cfg.Agents.LocalPaths = []string{}
 
 	manager := newTestManager(t, cfg)
@@ -461,7 +461,7 @@ func TestManagerGetSearchPaths(t *testing.T) {
 
 func TestManagerListAgents(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{}
+	cfg.Agents.Repositories = map[string]config.RepoSpec{}
 	cfg.Agents.LocalPaths = []string{}
 
 	manager := newTestManager(t, cfg)
@@ -519,7 +519,7 @@ func TestManagerFindAgent(t *testing.T) {
 			name: "found",
 			setup: func(t *testing.T) (*config.Config, string, string) {
 				cfg := config.Defaults()
-				cfg.Agents.Repositories = map[string]string{}
+				cfg.Agents.Repositories = map[string]config.RepoSpec{}
 				cfg.Agents.LocalPaths = []string{}
 				workDir := t.TempDir()
 				agentsDir := filepath.Join(workDir, "agents")
@@ -542,7 +542,7 @@ func TestManagerFindAgent(t *testing.T) {
 			name: "missing",
 			setup: func(t *testing.T) (*config.Config, string, string) {
 				cfg := config.Defaults()
-				cfg.Agents.Repositories = map[string]string{}
+				cfg.Agents.Repositories = map[string]config.RepoSpec{}
 				cfg.Agents.LocalPaths = []string{}
 				return cfg, t.TempDir(), ""
 			},
@@ -612,13 +612,13 @@ func TestNewManagerConfigPathError(t *testing.T) {
 
 func TestManagerUpdateRepositoriesError(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{
-		"broken": filepath.Join(t.TempDir(), "missing"),
+	cfg.Agents.Repositories = map[string]config.RepoSpec{
+		"broken": {URL: filepath.Join(t.TempDir(), "missing")},
 	}
 	cfg.Agents.LocalPaths = []string{}
 	manager := newTestManager(t, cfg)
 
-	err := manager.UpdateRepositories()
+	err := manager.UpdateRepositories(false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -632,8 +632,8 @@ func TestManagerUpdateRepositoriesError(t *testing.T) {
 
 func TestManagerGetSearchPathsWithRepoAndConfigDir(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{
-		"broken": filepath.Join(t.TempDir(), "missing"),
+	cfg.Agents.Repositories = map[string]config.RepoSpec{
+		"broken": {URL: filepath.Join(t.TempDir(), "missing")},
 	}
 	cfg.Agents.LocalPaths = []string{}
 
@@ -673,8 +673,8 @@ func TestManagerGetSearchPathsWithRepoAndConfigDir(t *testing.T) {
 
 func TestManagerGetSearchPathsCachedRepo(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{
-		"test-agents": "https://example.com/org/test-agents.git",
+	cfg.Agents.Repositories = map[string]config.RepoSpec{
+		"test-agents": {URL: "https://example.com/org/test-agents.git"},
 	}
 	cfg.Agents.LocalPaths = []string{}
 
@@ -721,7 +721,7 @@ func TestManagerGetSearchPathsCachedRepo(t *testing.T) {
 
 func TestManagerSaveConfigWriteError(t *testing.T) {
 	cfg := config.Defaults()
-	cfg.Agents.Repositories = map[string]string{}
+	cfg.Agents.Repositories = map[string]config.RepoSpec{}
 	cfg.Agents.LocalPaths = []string{}
 	manager := newTestManager(t, cfg)
 
@@ -730,7 +730,7 @@ func TestManagerSaveConfigWriteError(t *testing.T) {
 		t.Fatalf("create config file dir: %v", err)
 	}
 
-	err := manager.AddRepository("repo", "https://example.com/org/repo.git")
+	err := manager.AddRepository("repo", "https://example.com/org/repo.git", "")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/source/pin_test.go
+++ b/source/pin_test.go
@@ -1,0 +1,201 @@
+package source
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/config"
+)
+
+// newAgentsCfg returns a config with an isolated XDG layout so manager
+// tests don't touch the developer's real ~/.config when saveConfig fires.
+func newAgentsCfg(t *testing.T) *config.Config {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, ".cache"))
+	t.Setenv("HOME", tmp)
+	return &config.Config{
+		Agents: config.AgentsConfig{
+			Repositories: map[string]config.RepoSpec{},
+			LocalPaths:   []string{},
+		},
+	}
+}
+
+func TestManager_PinRepository_setsAndUpdatesRef(t *testing.T) {
+	cfg := newAgentsCfg(t)
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const url = "https://example.com/org/agents.git"
+	if err := mgr.AddRepository("official", url, ""); err != nil {
+		t.Fatalf("AddRepository: %v", err)
+	}
+	if spec := cfg.Agents.Repositories["official"]; spec.IsPinned() {
+		t.Fatalf("freshly-added repo should not be pinned, got %+v", spec)
+	}
+
+	if err := mgr.PinRepository("official", "v1.0.0"); err != nil {
+		t.Fatalf("PinRepository: %v", err)
+	}
+	if got := cfg.Agents.Repositories["official"]; got.Ref != "v1.0.0" || !got.IsPinned() {
+		t.Fatalf("after pin, spec = %+v", got)
+	}
+
+	// Pinning again replaces the ref rather than appending.
+	if err := mgr.PinRepository("official", "v1.1.0"); err != nil {
+		t.Fatalf("PinRepository (replace): %v", err)
+	}
+	if got := cfg.Agents.Repositories["official"].Ref; got != "v1.1.0" {
+		t.Fatalf("replaced ref = %q, want v1.1.0", got)
+	}
+
+	// Empty ref unpins.
+	if err := mgr.PinRepository("official", ""); err != nil {
+		t.Fatalf("PinRepository (unset): %v", err)
+	}
+	if got := cfg.Agents.Repositories["official"]; got.IsPinned() {
+		t.Fatalf("after unset, spec should be unpinned, got %+v", got)
+	}
+}
+
+func TestManager_PinRepository_missingRepoErrors(t *testing.T) {
+	cfg := newAgentsCfg(t)
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = mgr.PinRepository("ghost", "v1.0.0")
+	if err == nil {
+		t.Fatal("expected error for unknown repo")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("error %q should mention the repo name", err.Error())
+	}
+}
+
+func TestManager_AddRepository_withRefStoresRef(t *testing.T) {
+	cfg := newAgentsCfg(t)
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const url = "https://example.com/org/agents.git"
+	if err := mgr.AddRepository("official", url, "v0.4.2"); err != nil {
+		t.Fatalf("AddRepository: %v", err)
+	}
+	got := cfg.Agents.Repositories["official"]
+	if got.URL != url || got.Ref != "v0.4.2" {
+		t.Fatalf("stored spec = %+v", got)
+	}
+}
+
+func TestManager_UpdateRepositories_skipsPinnedWithoutForce(t *testing.T) {
+	cfg := newAgentsCfg(t)
+	cfg.Agents.Repositories = map[string]config.RepoSpec{
+		// A bogus URL would normally fail the update; if the entry is
+		// pinned and force is false we expect it to be skipped instead.
+		"pinned": {URL: "https://example.invalid/never-resolved.git", Ref: "v1"},
+	}
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.UpdateRepositories(false); err != nil {
+		t.Fatalf("expected pinned repo to be skipped, got: %v", err)
+	}
+}
+
+func TestManager_UpdateRepositories_forceAttemptsPinned(t *testing.T) {
+	cfg := newAgentsCfg(t)
+	cfg.Agents.Repositories = map[string]config.RepoSpec{
+		"pinned": {URL: "https://example.invalid/never-resolved.git", Ref: "v1"},
+	}
+	mgr, err := NewManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.UpdateRepositories(true); err == nil {
+		t.Fatal("expected --force to attempt the update and report the upstream failure")
+	}
+}
+
+func TestSkillsManager_PinRepository_setsAndUnsets(t *testing.T) {
+	cfg := newSkillsCfg(t)
+	mgr, err := NewSkillsManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.AddRepository("team", "https://example.com/skills.git", ""); err != nil {
+		t.Fatalf("AddRepository: %v", err)
+	}
+	if err := mgr.PinRepository("team", "v0.2.0"); err != nil {
+		t.Fatalf("PinRepository: %v", err)
+	}
+	if got := cfg.Skills.Repositories["team"].Ref; got != "v0.2.0" {
+		t.Fatalf("Ref = %q", got)
+	}
+	if err := mgr.PinRepository("team", ""); err != nil {
+		t.Fatalf("unpin: %v", err)
+	}
+	if cfg.Skills.Repositories["team"].IsPinned() {
+		t.Fatal("expected unpinned after empty ref")
+	}
+}
+
+func TestSkillsManager_PinRepository_missingErrors(t *testing.T) {
+	cfg := newSkillsCfg(t)
+	mgr, err := NewSkillsManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.PinRepository("ghost", "v1"); err == nil {
+		t.Fatal("expected error for unknown catalog")
+	}
+}
+
+func TestSkillsManager_AddRepository_withRefStoresRef(t *testing.T) {
+	cfg := newSkillsCfg(t)
+	mgr, err := NewSkillsManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.AddRepository("team", "https://example.com/skills.git", "v1.2.0"); err != nil {
+		t.Fatalf("AddRepository: %v", err)
+	}
+	if got := cfg.Skills.Repositories["team"].Ref; got != "v1.2.0" {
+		t.Fatalf("Ref = %q", got)
+	}
+}
+
+func TestSkillsManager_UpdateRepositories_skipsPinned(t *testing.T) {
+	cfg := newSkillsCfg(t)
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"pinned": {URL: "https://example.invalid/never.git", Ref: "v1"},
+	}
+	mgr, err := NewSkillsManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.UpdateRepositories(false); err != nil {
+		t.Fatalf("pinned catalog should be skipped, got %v", err)
+	}
+}
+
+func TestSkillsManager_UpdateRepositories_forceTriesPinned(t *testing.T) {
+	cfg := newSkillsCfg(t)
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"pinned": {URL: "https://example.invalid/never.git", Ref: "v1"},
+	}
+	mgr, err := NewSkillsManager(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.UpdateRepositories(true); err == nil {
+		t.Fatal("expected --force to attempt the upstream and report the failure")
+	}
+}

--- a/source/skills.go
+++ b/source/skills.go
@@ -43,22 +43,36 @@ func NewSkillsManager(cfg *config.Config) (*SkillsManager, error) {
 	}, nil
 }
 
-// AddRepository registers a git URL under name. Cloning happens on the
-// next call to UpdateRepositories (or implicitly on first list).
-func (m *SkillsManager) AddRepository(name, gitURL string) error {
+// AddRepository registers a git URL under name. An empty ref tracks the
+// default branch; a non-empty ref pins the catalog to a specific commit,
+// tag, or branch. Cloning happens on the next call to UpdateRepositories
+// (or implicitly on first list).
+func (m *SkillsManager) AddRepository(name, gitURL, ref string) error {
 	if !IsGitURL(gitURL) {
 		return fmt.Errorf("invalid git URL: %s", gitURL)
 	}
 	if m.cfg.Skills.Repositories == nil {
-		m.cfg.Skills.Repositories = make(map[string]string)
+		m.cfg.Skills.Repositories = make(map[string]config.RepoSpec)
 	}
 	if existing, ok := m.cfg.Skills.Repositories[name]; ok {
-		if existing == gitURL {
+		if existing.URL == gitURL && existing.Ref == ref {
 			return fmt.Errorf("skill repository %q already configured with URL %s", name, gitURL)
 		}
-		return fmt.Errorf("skill repository %q already exists with URL %s (use remove first)", name, existing)
+		return fmt.Errorf("skill repository %q already exists with URL %s (use remove first)", name, existing.URL)
 	}
-	m.cfg.Skills.Repositories[name] = gitURL
+	m.cfg.Skills.Repositories[name] = config.RepoSpec{URL: gitURL, Ref: ref}
+	return m.saveConfig()
+}
+
+// PinRepository sets or replaces the pinned ref for an existing catalog.
+// An empty ref unpins (returns to tracking the default branch).
+func (m *SkillsManager) PinRepository(name, ref string) error {
+	spec, ok := m.cfg.Skills.Repositories[name]
+	if !ok {
+		return fmt.Errorf("skill repository not found: %s", name)
+	}
+	spec.Ref = ref
+	m.cfg.Skills.Repositories[name] = spec
 	return m.saveConfig()
 }
 
@@ -102,8 +116,8 @@ func (m *SkillsManager) RemoveSource(nameOrPath string) error {
 		delete(m.cfg.Skills.Repositories, nameOrPath)
 		removed++
 	}
-	for name, url := range m.cfg.Skills.Repositories {
-		if url == nameOrPath || url == fileURL {
+	for name, spec := range m.cfg.Skills.Repositories {
+		if spec.URL == nameOrPath || spec.URL == fileURL {
 			delete(m.cfg.Skills.Repositories, name)
 			removed++
 		}
@@ -125,13 +139,18 @@ func (m *SkillsManager) RemoveSource(nameOrPath string) error {
 	return m.saveConfig()
 }
 
-// UpdateRepositories pulls latest from every configured git repository
-// and reports any failures collectively without aborting the batch.
-func (m *SkillsManager) UpdateRepositories() error {
+// UpdateRepositories pulls latest from configured git repositories.
+// Pinned repositories (Ref != "") are skipped unless force is true, in
+// which case the ref is re-resolved against the remote.
+func (m *SkillsManager) UpdateRepositories(force bool) error {
 	var errs []string
-	for name, url := range m.cfg.Skills.Repositories {
-		fmt.Printf("Updating skill repo %s (%s)...\n", name, url)
-		if _, err := m.gitOps.CloneOrUpdate(url); err != nil {
+	for name, spec := range m.cfg.Skills.Repositories {
+		if spec.IsPinned() && !force {
+			fmt.Printf("Skipping skill repo %s (pinned to %s) — use --force to re-resolve\n", name, spec.Ref)
+			continue
+		}
+		fmt.Printf("Updating skill repo %s (%s)...\n", name, spec.URL)
+		if _, err := m.gitOps.CloneOrUpdate(spec.URL, spec.Ref); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
 		}
 	}
@@ -152,8 +171,8 @@ func (m *SkillsManager) CatalogPaths() []string {
 			paths = append(paths, path)
 		}
 	}
-	for _, url := range m.cfg.Skills.Repositories {
-		if repoPath, ok := m.gitOps.CachePath(url); ok {
+	for _, spec := range m.cfg.Skills.Repositories {
+		if repoPath, ok := m.gitOps.CachePath(spec.URL); ok {
 			paths = append(paths, repoPath)
 		}
 	}
@@ -165,11 +184,11 @@ func (m *SkillsManager) CatalogPaths() []string {
 // any single repo is reported but does not abort the batch.
 func (m *SkillsManager) EnsureRepositoriesCloned() error {
 	var errs []string
-	for name, url := range m.cfg.Skills.Repositories {
-		if _, ok := m.gitOps.CachePath(url); ok {
+	for name, spec := range m.cfg.Skills.Repositories {
+		if _, ok := m.gitOps.CachePath(spec.URL); ok {
 			continue
 		}
-		if _, err := m.gitOps.CloneOrUpdate(url); err != nil {
+		if _, err := m.gitOps.CloneOrUpdate(spec.URL, spec.Ref); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
 		}
 	}

--- a/source/skills_test.go
+++ b/source/skills_test.go
@@ -56,7 +56,7 @@ func newSkillsCfg(t *testing.T) *config.Config {
 	t.Setenv("HOME", tmp)
 	return &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -70,7 +70,7 @@ func TestSkillsManager_AddRepositoryClonesAndDiscovers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", url); err != nil {
+	if err := mgr.AddRepository("team", url, ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := mgr.EnsureRepositoriesCloned(); err != nil {
@@ -129,7 +129,7 @@ func TestSkillsManager_UpdateRefetchesNewContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", url); err != nil {
+	if err := mgr.AddRepository("team", url, ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := mgr.EnsureRepositoriesCloned(); err != nil {
@@ -155,7 +155,7 @@ func TestSkillsManager_UpdateRefetchesNewContent(t *testing.T) {
 		}
 	}
 
-	if err := mgr.UpdateRepositories(); err != nil {
+	if err := mgr.UpdateRepositories(false); err != nil {
 		t.Fatal(err)
 	}
 	cat, err := skill.Discover("", mgr.CatalogPaths()...)
@@ -179,7 +179,7 @@ func TestSkillsManager_RemoveSourceUnregisters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", url); err != nil {
+	if err := mgr.AddRepository("team", url, ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := mgr.RemoveSource("team"); err != nil {
@@ -212,8 +212,8 @@ func TestSkillsManager_RemoveLocalPathByPath(t *testing.T) {
 func TestSkillsManager_RemoveSourceClearsDualRegistration(t *testing.T) {
 	cfg := newSkillsCfg(t)
 	catalogPath := t.TempDir()
-	cfg.Skills.Repositories = map[string]string{
-		"humanizer": "file://" + catalogPath,
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"humanizer": {URL: "file://" + catalogPath},
 	}
 	cfg.Skills.LocalPaths = []string{catalogPath}
 
@@ -236,8 +236,8 @@ func TestSkillsManager_RemoveSourceClearsDualRegistration(t *testing.T) {
 // the exact registered URL (not the alias) removes the repository entry.
 func TestSkillsManager_RemoveByRepositoryURL(t *testing.T) {
 	cfg := newSkillsCfg(t)
-	cfg.Skills.Repositories = map[string]string{
-		"team": "https://example.com/team-skills.git",
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"team": {URL: "https://example.com/team-skills.git"},
 	}
 	mgr, err := NewSkillsManager(cfg)
 	if err != nil {
@@ -257,13 +257,13 @@ func TestSkillsManager_AddRejectsDuplicate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", "https://example.com/a.git"); err != nil {
+	if err := mgr.AddRepository("team", "https://example.com/a.git", ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", "https://example.com/a.git"); err == nil {
+	if err := mgr.AddRepository("team", "https://example.com/a.git", ""); err == nil {
 		t.Error("expected error on duplicate same-URL registration")
 	}
-	if err := mgr.AddRepository("team", "https://example.com/b.git"); err == nil {
+	if err := mgr.AddRepository("team", "https://example.com/b.git", ""); err == nil {
 		t.Error("expected error on duplicate alias with different URL")
 	}
 }
@@ -316,7 +316,7 @@ func TestSkillsManager_AddRepositoryRejectsNonGitURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("local", "/not/a/url"); err == nil {
+	if err := mgr.AddRepository("local", "/not/a/url", ""); err == nil {
 		t.Fatal("expected error for non-git URL")
 	}
 }
@@ -339,10 +339,10 @@ func TestSkillsManager_AddRepoCreatesMapWhenNil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", "https://example.com/a.git"); err != nil {
+	if err := mgr.AddRepository("team", "https://example.com/a.git", ""); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Skills.Repositories["team"] == "" {
+	if cfg.Skills.Repositories["team"].URL == "" {
 		t.Errorf("expected team registered, got %v", cfg.Skills.Repositories)
 	}
 }
@@ -362,22 +362,22 @@ func TestSkillsManager_NewWithCacheDirOverride(t *testing.T) {
 
 func TestSkillsManager_UpdateBadURLReportsError(t *testing.T) {
 	cfg := newSkillsCfg(t)
-	cfg.Skills.Repositories = map[string]string{
-		"bad": "https://example.invalid/nope.git",
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"bad": {URL: "https://example.invalid/nope.git"},
 	}
 	mgr, err := NewSkillsManager(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.UpdateRepositories(); err == nil {
+	if err := mgr.UpdateRepositories(false); err == nil {
 		t.Fatal("expected error from bad upstream")
 	}
 }
 
 func TestSkillsManager_EnsureClonedBadURLErrors(t *testing.T) {
 	cfg := newSkillsCfg(t)
-	cfg.Skills.Repositories = map[string]string{
-		"bad": "https://example.invalid/nope.git",
+	cfg.Skills.Repositories = map[string]config.RepoSpec{
+		"bad": {URL: "https://example.invalid/nope.git"},
 	}
 	mgr, err := NewSkillsManager(cfg)
 	if err != nil {
@@ -396,7 +396,7 @@ func TestSkillsManager_EnsureClonedSkipsAlreadyCached(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", url); err != nil {
+	if err := mgr.AddRepository("team", url, ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := mgr.EnsureRepositoriesCloned(); err != nil {
@@ -415,7 +415,7 @@ func TestSkillsManager_SaveConfigCreatesDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Drive saveConfig via AddRepository, then check that the config file exists.
-	if err := mgr.AddRepository("team", "https://example.com/a.git"); err != nil {
+	if err := mgr.AddRepository("team", "https://example.com/a.git", ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(mgr.configPath); err != nil {
@@ -437,7 +437,7 @@ func TestSkillsManager_SaveConfigFailsWhenParentBlocked(t *testing.T) {
 	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := mgr.AddRepository("team", "https://example.com/a.git"); err == nil {
+	if err := mgr.AddRepository("team", "https://example.com/a.git", ""); err == nil {
 		t.Fatal("expected save failure when parent dir is a file")
 	}
 }
@@ -450,7 +450,7 @@ func TestNewSkillsManager_FailsWithoutXDG(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}
@@ -470,7 +470,7 @@ func TestNewSkillsManager_SkillsCacheDirError(t *testing.T) {
 	t.Setenv("HOME", "")
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{
-			Repositories: map[string]string{},
+			Repositories: map[string]config.RepoSpec{},
 			LocalPaths:   []string{},
 		},
 	}


### PR DESCRIPTION
**Key Changes:**

- Introduces ref pinning for agent and skill git sources so unattended runs can resolve reviewed commits, tags, or branches deterministically
- Adds CLI support to pin, unpin, and force-update pinned agent and skill repositories
- Updates git source management to checkout explicit refs while preserving default-branch behavior for unpinned sources
- Expands documentation, security guidance, and test coverage for repository pinning and safer production usage

**Added:**

- Repository pinning model - Added a shared repository spec with URL and optional ref fields, backwards-compatible plain-string config support, compact YAML marshaling, and Viper decode hooks for config reloads
- Agent source pinning commands - Added --ref to agent repository registration, a new agents pin command with --unset support, update --force behavior, and ref visibility in source listings
- Skill catalog pinning commands - Added matching --ref, pin, --unset, update --force, and source listing support for skill repositories
- Git checkout support for pinned refs - Added ref resolution for commit SHAs, tags, remote-tracking branches, and local branches after clone or update
- Security policy documentation - Added private vulnerability reporting guidance, Semgrep ruleset coverage, dependency scanning notes, and supply-chain controls
- Regression coverage - Added tests for repository spec YAML behavior, pinned git checkout behavior, and updated agent/skill source manager flows

**Changed:**

- Repository configuration storage - Changed agent and skill repository maps from plain URL strings to structured repository specs while preserving legacy config compatibility
- Update behavior for pinned sources - Changed agent and skill repository updates to skip pinned entries by default, requiring --force to re-resolve pinned refs against the remote
- Config unmarshalling path - Updated config loading, config set, and root command override handling to consistently use custom decode hooks for repository specs
- Documentation coverage - Expanded the README and configuration docs with architecture, CLI reference, repository pinning, routines, skills, MCP, execution backends, browser profiles, development workflow, and safe operation guidance
- Examples and references - Refreshed model names, Docker image versions, routine examples, and observability tool naming to match current behavior