### PR TITLE
docs: document official skills catalog setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,13 @@ squad skill list
 
 Per-agent control lives under `agent.yaml`'s `skills:` block (allow/deny lists, scope filters); CLI flags `--allow-skill`/`--deny-skill`/`--skills-disabled` override per run.
 
+```bash
+# Add the official skills catalog
+squad skill add official https://github.com/cowdogmoo/squad-skills.git
+```
+
+The [official skills repo](https://github.com/CowDogMoo/squad-skills) is the shared home for production-tuned skills, mirroring the layout of the official agents repo.
+
 Full reference: [docs/skills.md](docs/skills.md).
 
 ## Browser Profiles
@@ -631,9 +638,10 @@ CI rejects any commit that fails the hooks.
 - **[Agent Quality Guide](docs/agent-quality.md)** — tuning methodology and grading rubric
 - **[Agents Engineering Pipeline](docs/agents-engineering-pipeline-basics.md)** — agent-engineering CI/CD with squad
 
-### Agents
+### Agents & Skills
 
 - **[Official Agents](https://github.com/CowDogMoo/squad-agents)** — production-ready agents for Go, Python, Ansible, and Molecule
+- **[Official Skills](https://github.com/CowDogMoo/squad-skills)** — shared Agent Skills catalog consumed via `squad skill add`
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,21 @@ squad agents update --force                  # re-resolves and updates pinned on
 The same `--ref` flag and `pin`/`unset` semantics work for
 `squad skill add` and `squad skill pin`.
 
+### skills
+
+| Key | Type | Default | Description |
+| ------------------------- | ----------- | ------- | ------------------------------------------------ |
+| `skills.cache_dir` | string | `~/.cache/squad/skills` | Directory where cloned skill catalog repos are cached |
+| `skills.repositories` | map | `{}` | Named git sources to fetch skills from — same shape as `agents.repositories`, see [Repository pinning](#repository-pinning) |
+| `skills.local_paths` | []string | `[]` | Local catalog directories searched for skills |
+
+The official catalog lives at
+<https://github.com/cowdogmoo/squad-skills>; register it with:
+
+```bash
+squad skill add official https://github.com/cowdogmoo/squad-skills.git
+```
+
 ### otel
 
 | Key | Type | Default | Description |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -70,6 +70,9 @@ Three places skills can live, in precedence order. When the same `name` appears 
 Skill catalogs are git-backed. Register one and squad clones it into the local cache; `squad skill update` pulls the latest.
 
 ```bash
+# Add the official squad-skills catalog.
+squad skill add official https://github.com/cowdogmoo/squad-skills.git
+
 # Add a team-shared skills repo.
 squad skill add myteam https://github.com/example/squad-skills.git
 


### PR DESCRIPTION
**Key Changes:**

- Added guidance for registering the official squad-skills catalog with the skill CLI
- Documented skills configuration options, including cache directory, repositories, and local paths
- Updated project resource links to include the official shared skills catalog alongside agents

**Added:**

- Official skills catalog setup instructions in the README and skills documentation, giving users a clear command for adding the shared production-tuned skills repository
- Skills configuration reference covering cache location, git-backed repositories, local catalog paths, and the official catalog registration command

**Changed:**

- Project resources section now groups agents and skills together to reflect that both official catalogs are available for reuse across squad workflows