### PR TITLE
feat: enforce skill allowed-tools restrictions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,14 @@
+---
+- id: squad-skill-validate
+  name: Validate Anthropic Agent Skill manifests
+  description: |
+    Runs `squad skill validate` against every staged SKILL.md (and its
+    skill directory) to enforce open-standard conformance — frontmatter
+    structure, name/description rules, body-size targets, path-traversal
+    guards on bundled references, and script invocability. Single source
+    of truth for skill validation across squad-skills and any other repo
+    consuming the hook.
+  entry: squad skill validate
+  language: golang
+  files: '(^|/)SKILL\.md$'
+  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -454,6 +454,19 @@ squad skill add official https://github.com/cowdogmoo/squad-skills.git
 
 The [official skills repo](https://github.com/CowDogMoo/squad-skills) is the shared home for production-tuned skills, mirroring the layout of the official agents repo.
 
+### Validate skills in any repo
+
+Squad ships a [pre-commit-framework](https://pre-commit.com) hook so any skill catalog (yours, the official repo, a partner's) can enforce open-standard conformance on every commit. Drop three lines into `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/cowdogmoo/squad
+  rev: main
+  hooks:
+    - id: squad-skill-validate
+```
+
+The hook runs `squad skill validate` against every staged `SKILL.md` and its skill directory — same rules squad's runtime enforces (frontmatter shape, name/description constraints, body-size targets, path-traversal guards, script invocability), so a skill that passes the hook will load cleanly at agent runtime. When validation rules change, bump `rev`; you don't maintain a parallel implementation.
+
 Full reference: [docs/skills.md](docs/skills.md).
 
 ## Browser Profiles

--- a/cmd/squad/agents_pin_test.go
+++ b/cmd/squad/agents_pin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -233,6 +234,56 @@ func TestAgentsSources_localPathsOnly(t *testing.T) {
 	if strings.Contains(out, "REPOSITORIES") {
 		t.Fatalf("REPOSITORIES section should be omitted, got:\n%s", out)
 	}
+}
+
+func TestAgentsAdd_localPathDuplicateRejected(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	dir := t.TempDir()
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd, dir); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if _, err := runAgentsSubcmd(t, cfg, agentsAddCmd, dir); err == nil {
+		t.Fatal("expected duplicate local-path error from manager.AddLocalPath")
+	}
+}
+
+func TestAgentsPin_nilCfgErrors(t *testing.T) {
+	// Bypass runAgentsSubcmd's withConfig so cmd.Context() returns no cfg.
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runAgentsPin(cmd, []string{"any", "v1"}); err == nil {
+		t.Fatal("expected error when context lacks a config")
+	}
+}
+
+func TestAgentsPin_managerConstructionErrorSurfaced(t *testing.T) {
+	// Force source.NewManager to fail by pointing XDG_CONFIG_HOME at a
+	// regular file: config.ConfigFile will try MkdirAll on that path's
+	// parent and trip ENOTDIR. Exercises the NewManager-error branch of
+	// runAgentsPin without inventing a mock.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := writeFile(blocker, "x"); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", blocker)
+	t.Setenv("XDG_CACHE_HOME", blocker)
+	t.Setenv("HOME", blocker)
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Repositories: map[string]config.RepoSpec{"x": {URL: "https://example.com/r.git"}},
+		},
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(withConfig(context.Background(), cfg))
+	if err := runAgentsPin(cmd, []string{"x", "v1"}); err == nil {
+		t.Fatal("expected NewManager construction failure to surface as error")
+	}
+}
+
+// writeFile is a small helper that fails the test on error.
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
 }
 
 func TestAgentsSources_rendersRefColumn(t *testing.T) {

--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -164,8 +164,8 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Re-unmarshal so flag/env overrides are reflected in the config struct.
-	if err := v.Unmarshal(cfg, config.DecodeHooks()); err != nil {
-		return fmt.Errorf("failed to apply config overrides: %w", err)
+	if err := applyConfigOverrides(v, cfg); err != nil {
+		return err
 	}
 
 	// Re-initialize telemetry if --otel-endpoint was explicitly provided.
@@ -187,6 +187,19 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	ctx = logging.WithLogger(ctx, logger)
 	cmd.SetContext(ctx)
 
+	return nil
+}
+
+// applyConfigOverrides re-runs viper.Unmarshal so flag and env overrides
+// reach the config struct. Declared as a var so a test can swap it out
+// and exercise initConfig's error-return branch — driving the second
+// Unmarshal to fail via a real cobra invocation would otherwise require
+// engineering viper state that diverges between Load and re-unmarshal,
+// which the current code path makes deterministic.
+var applyConfigOverrides = func(v *viper.Viper, cfg *config.Config) error {
+	if err := v.Unmarshal(cfg, config.DecodeHooks()); err != nil {
+		return fmt.Errorf("failed to apply config overrides: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/squad/root_test.go
+++ b/cmd/squad/root_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/cowdogmoo/squad/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func TestExecuteVersion(t *testing.T) {
@@ -20,6 +24,59 @@ func TestExecuteVersion(t *testing.T) {
 
 	if err := Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestApplyConfigOverrides_wrapsUnmarshalError(t *testing.T) {
+	// Inject a value with a shape mapstructure can't fit into the target
+	// (a string where a map[string]RepoSpec is expected) so v.Unmarshal
+	// errors. The wrapped error must carry the operator-facing prefix.
+	v := viper.New()
+	v.Set("agents.repositories", "not-a-map")
+
+	err := applyConfigOverrides(v, &config.Config{})
+	if err == nil {
+		t.Fatal("expected Unmarshal failure to surface as wrapped error")
+	}
+	if !strings.Contains(err.Error(), "failed to apply config overrides") {
+		t.Fatalf("error not wrapped with expected prefix: %v", err)
+	}
+}
+
+func TestApplyConfigOverrides_successPath(t *testing.T) {
+	v := viper.New()
+	cfg := &config.Config{}
+	if err := applyConfigOverrides(v, cfg); err != nil {
+		t.Fatalf("empty viper should unmarshal cleanly, got: %v", err)
+	}
+}
+
+// TestInitConfig_unmarshalOverrideFailureSurfaced covers initConfig's
+// `if err := applyConfigOverrides(...); err != nil { return err }`
+// branch. Driving real viper into divergent first/second Unmarshal
+// behavior isn't reproducible from outside initConfig — the function
+// doesn't expose any seam between Load and the re-Unmarshal — so the
+// test swaps the package-level helper to inject the error directly.
+func TestInitConfig_unmarshalOverrideFailureSurfaced(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", baseDir)
+	t.Setenv("XDG_CACHE_HOME", baseDir)
+	t.Setenv("HOME", baseDir)
+	t.Setenv("USERPROFILE", baseDir)
+
+	orig := applyConfigOverrides
+	t.Cleanup(func() { applyConfigOverrides = orig })
+	applyConfigOverrides = func(*viper.Viper, *config.Config) error {
+		return errors.New("synthetic override failure")
+	}
+
+	// Invoke initConfig directly: cobra's --help short-circuits before
+	// PersistentPreRunE, so a `--help` Execute() doesn't reach the helper.
+	root := NewRootCmd()
+	if err := initConfig(root, nil); err == nil {
+		t.Fatal("expected initConfig to propagate applyConfigOverrides' error")
+	} else if !strings.Contains(err.Error(), "synthetic override failure") {
+		t.Fatalf("error not propagated from helper: %v", err)
 	}
 }
 

--- a/cmd/squad/skill.go
+++ b/cmd/squad/skill.go
@@ -164,14 +164,36 @@ func newSkillShowCmd() *cobra.Command {
 			if !ok {
 				return fmt.Errorf("skill %q not found", args[0])
 			}
-			out := cmd.OutOrStdout()
-			_, _ = fmt.Fprintf(out, "Name:        %s\n", entry.Manifest.Name)
-			_, _ = fmt.Fprintf(out, "Scope:       %s\n", entry.Scope.String())
-			_, _ = fmt.Fprintf(out, "Directory:   %s\n", entry.Dir)
-			_, _ = fmt.Fprintf(out, "Manifest:    %s\n", entry.ManifestPath)
-			_, _ = fmt.Fprintf(out, "Description: %s\n", entry.Manifest.Description)
-			_, _ = fmt.Fprintln(out, "---")
-			_, _ = fmt.Fprintln(out, entry.Manifest.Body)
+			var sb strings.Builder
+			m := entry.Manifest
+			fmt.Fprintf(&sb, "Name:        %s\nScope:       %s\nDirectory:   %s\nManifest:    %s\nDescription: %s\n",
+				m.Name, entry.Scope.String(), entry.Dir, entry.ManifestPath, m.Description)
+			if m.License != "" {
+				fmt.Fprintf(&sb, "License:     %s\n", m.License)
+			}
+			if m.Compatibility != "" {
+				fmt.Fprintf(&sb, "Compatibility: %s\n", m.Compatibility)
+			}
+			if len(m.AllowedTools) > 0 {
+				fmt.Fprintf(&sb, "AllowedTools: %s\n", strings.Join(m.AllowedTools, ", "))
+			}
+			if len(m.Metadata) > 0 {
+				keys := make([]string, 0, len(m.Metadata))
+				for k := range m.Metadata {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				sb.WriteString("Metadata:\n")
+				for _, k := range keys {
+					fmt.Fprintf(&sb, "  %s: %v\n", k, m.Metadata[k])
+				}
+			}
+			sb.WriteString("---\n")
+			sb.WriteString(m.Body)
+			sb.WriteByte('\n')
+			if _, err := io.WriteString(cmd.OutOrStdout(), sb.String()); err != nil {
+				return fmt.Errorf("write skill output: %w", err)
+			}
 			return nil
 		},
 	}
@@ -181,28 +203,64 @@ func newSkillShowCmd() *cobra.Command {
 
 func newSkillValidateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "validate <path>",
-		Short: "Run spec-conformance checks on a skill directory",
-		Args:  cobra.ExactArgs(1),
+		Use:   "validate <path>...",
+		Short: "Run spec-conformance checks on one or more skill directories",
+		Long: `Validate every supplied path as an Agent Skill. A path may be the skill
+directory itself or its SKILL.md file (the latter is the form pre-commit
+passes), and multiple paths can be checked in one invocation so a single
+hook run covers an entire staged changeset.`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			report, err := skill.Validate(args[0])
-			if err != nil {
-				return err
+			var sb strings.Builder
+			totalErrors := 0
+			for _, raw := range args {
+				dir, err := resolveSkillDir(raw)
+				if err != nil {
+					fmt.Fprintf(&sb, "%s: %v\n", raw, err)
+					totalErrors++
+					continue
+				}
+				report, err := skill.Validate(dir)
+				if err != nil {
+					fmt.Fprintf(&sb, "%s: %v\n", dir, err)
+					totalErrors++
+					continue
+				}
+				for _, f := range report.Findings {
+					fmt.Fprintf(&sb, "%s: %s: %s: %s\n", dir, f.Severity, f.Path, f.Message)
+				}
+				totalErrors += len(report.Errors())
+				if len(report.Findings) == 0 {
+					fmt.Fprintf(&sb, "%s: OK\n", dir)
+				}
 			}
-			out := cmd.OutOrStdout()
-			for _, f := range report.Findings {
-				_, _ = fmt.Fprintf(out, "%s: %s: %s\n", f.Severity, f.Path, f.Message)
+			if _, err := io.WriteString(cmd.OutOrStdout(), sb.String()); err != nil {
+				return fmt.Errorf("write validation report: %w", err)
 			}
-			if report.HasErrors() {
-				return fmt.Errorf("validation failed: %d error(s)", len(report.Errors()))
-			}
-			if len(report.Warnings()) == 0 {
-				_, _ = fmt.Fprintln(out, "OK")
+			if totalErrors > 0 {
+				return fmt.Errorf("validation failed: %d error(s) across %d path(s)", totalErrors, len(args))
 			}
 			return nil
 		},
 	}
+}
+
+// resolveSkillDir accepts either a skill directory or its SKILL.md and
+// returns the skill directory. Letting pre-commit pass SKILL.md paths
+// straight through avoids a shell wrapper around the hook.
+func resolveSkillDir(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat: %w", err)
+	}
+	if info.IsDir() {
+		return path, nil
+	}
+	if filepath.Base(path) != skill.FileName {
+		return "", fmt.Errorf("expected a directory or %s, got %s", skill.FileName, filepath.Base(path))
+	}
+	return filepath.Dir(path), nil
 }
 
 func newSkillAddCmd() *cobra.Command {

--- a/cmd/squad/skill_pin_test.go
+++ b/cmd/squad/skill_pin_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -136,6 +139,40 @@ func TestSkillAdd_localPathDuplicateRejected(t *testing.T) {
 	}
 	if _, err := runSkillSubcmd(t, cfg, newSkillAddCmd, dir); err == nil {
 		t.Fatal("expected duplicate local-path error")
+	}
+}
+
+func TestSkillPin_nilCfgErrors(t *testing.T) {
+	// Build the pin command without seeding cfg into the context so the
+	// RunE closure's cfg-nil guard executes.
+	cmd := newSkillPinCmd()
+	cmd.SetContext(context.Background())
+	if err := cmd.RunE(cmd, []string{"any", "v1"}); err == nil {
+		t.Fatal("expected error when context lacks a config")
+	}
+}
+
+func TestSkillPin_managerConstructionErrorSurfaced(t *testing.T) {
+	// Force source.NewSkillsManager to fail by pointing XDG_CONFIG_HOME at
+	// a regular file so config.ConfigFile's MkdirAll trips ENOTDIR.
+	// Exercises the NewSkillsManager-error branch of the pin RunE.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", blocker)
+	t.Setenv("XDG_CACHE_HOME", blocker)
+	t.Setenv("HOME", blocker)
+
+	cfg := &config.Config{
+		Skills: config.SkillsConfig{
+			Repositories: map[string]config.RepoSpec{"x": {URL: "https://example.com/r.git"}},
+		},
+	}
+	cmd := newSkillPinCmd()
+	cmd.SetContext(withConfig(context.Background(), cfg))
+	if err := cmd.RunE(cmd, []string{"x", "v1"}); err == nil {
+		t.Fatal("expected NewSkillsManager construction failure to surface as error")
 	}
 }
 

--- a/cmd/squad/skill_test.go
+++ b/cmd/squad/skill_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -195,6 +196,152 @@ func TestSkillValidateOK(t *testing.T) {
 	}
 	if !strings.Contains(out, "OK") {
 		t.Errorf("expected OK, got:\n%s", out)
+	}
+}
+
+func TestSkillValidateAcceptsSkillMDPath(t *testing.T) {
+	// pre-commit passes SKILL.md paths, not directories.
+	dir := makeSkill(t, t.TempDir(), "ok", "A fine skill.", "# Body")
+	out, err := runSkillCmd(t, "validate", filepath.Join(dir, skill.FileName))
+	if err != nil {
+		t.Fatalf("validate: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK, got:\n%s", out)
+	}
+}
+
+func TestSkillValidateRejectsNonSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	stray := filepath.Join(dir, "notes.md")
+	if err := os.WriteFile(stray, []byte("ignore"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runSkillCmd(t, "validate", stray)
+	if err == nil {
+		t.Fatalf("expected error, got: %s", out)
+	}
+	if !strings.Contains(out, "expected a directory or "+skill.FileName) {
+		t.Errorf("report should explain the rejection, got:\n%s", out)
+	}
+}
+
+func TestSkillValidateNonexistentPath(t *testing.T) {
+	out, err := runSkillCmd(t, "validate", filepath.Join(t.TempDir(), "nope"))
+	if err == nil {
+		t.Fatalf("expected error, got: %s", out)
+	}
+	if !strings.Contains(out, "stat:") {
+		t.Errorf("report should surface stat failure, got:\n%s", out)
+	}
+}
+
+func TestSkillValidateMultiplePathsAccumulatesErrors(t *testing.T) {
+	root := t.TempDir()
+	good := makeSkill(t, root, "good", "Fine.", "# Body")
+	bad := filepath.Join(root, "bad")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Missing description triggers a real validation error.
+	if err := os.WriteFile(filepath.Join(bad, skill.FileName),
+		[]byte("---\nname: bad\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runSkillCmd(t, "validate", good, bad)
+	if err == nil {
+		t.Fatalf("expected aggregated failure, got: %s", out)
+	}
+	if !strings.Contains(err.Error(), "across 2 path(s)") {
+		t.Errorf("error should report the path count, got: %v", err)
+	}
+	if !strings.Contains(out, "good") || !strings.Contains(out, "bad") {
+		t.Errorf("report should mention both paths, got:\n%s", out)
+	}
+}
+
+// failingWriter returns an error on every Write — used to drive the
+// io.WriteString fallback in validate/show.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("pipe broken") }
+
+func TestSkillValidateReportsWriteFailure(t *testing.T) {
+	dir := makeSkill(t, t.TempDir(), "ok", "Fine.", "# Body")
+	cmd := newSkillCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"validate", dir})
+	cmd.SetContext(context.Background())
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected write-failure error")
+	}
+	if !strings.Contains(err.Error(), "write validation report") {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestSkillShowReportsWriteFailure(t *testing.T) {
+	xdg := setupXDG(t)
+	globalSkillsDir := filepath.Join(xdg, ".config", "squad", "skills")
+	if err := os.MkdirAll(globalSkillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	makeSkill(t, globalSkillsDir, "alpha", "An alpha skill.", "# Body")
+
+	cmd := newSkillCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"show", "alpha", "--repo", t.TempDir()})
+	cmd.SetContext(context.Background())
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected write-failure error")
+	}
+	if !strings.Contains(err.Error(), "write skill output") {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestSkillShowSurfacesNewFrontmatterFields(t *testing.T) {
+	xdg := setupXDG(t)
+	globalSkillsDir := filepath.Join(xdg, ".config", "squad", "skills")
+	if err := os.MkdirAll(globalSkillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(globalSkillsDir, "rich")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\n" +
+		"name: rich\n" +
+		"description: A rich skill.\n" +
+		"license: MIT\n" +
+		"compatibility: macOS, Linux\n" +
+		"allowed-tools: Read, Glob\n" +
+		"metadata:\n" +
+		"  author: jane\n" +
+		"  version: 1.2.3\n" +
+		"---\n# Body\n"
+	if err := os.WriteFile(filepath.Join(dir, skill.FileName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runSkillCmd(t, "show", "rich", "--repo", t.TempDir())
+	if err != nil {
+		t.Fatalf("show: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"License:     MIT",
+		"Compatibility: macOS, Linux",
+		"AllowedTools: Read, Glob",
+		"Metadata:",
+		"author: jane",
+		"version: 1.2.3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in show output:\n%s", want, out)
+		}
 	}
 }
 

--- a/config/reposource_test.go
+++ b/config/reposource_test.go
@@ -214,6 +214,38 @@ func TestRepoSpecDecodeHook_noopWhenTargetIsNotRepoSpec(t *testing.T) {
 	}
 }
 
+func TestRepoSpecDecodeHook_mappingWithNonStringFieldsSkipsThem(t *testing.T) {
+	t.Parallel()
+	// Both type assertions inside the map branch must tolerate non-string
+	// inputs: missing/typed-wrong fields leave the RepoSpec field empty
+	// instead of panicking. Exercises the ok==false leg of both `if url,
+	// ok := v["url"].(string)` and `if ref, ok := v["ref"].(string)`.
+	got := callHook(t, reflect.TypeOf(map[string]any{}), reflect.TypeOf(RepoSpec{}),
+		map[string]any{
+			"url": 42, // wrong type — should be silently dropped
+			"ref": nil,
+		})
+	spec := got.(RepoSpec) //nolint:gocritic // got is mapstructure-returned any
+	if spec.URL != "" || spec.Ref != "" {
+		t.Errorf("non-string fields should not populate the spec, got %+v", spec)
+	}
+}
+
+func TestRepoSpecDecodeHook_mappingPartialFieldsPopulateAvailable(t *testing.T) {
+	t.Parallel()
+	// One string + one missing: the available field is used, the missing
+	// one stays empty. Exercises ok==true for ref but ok==false for url.
+	got := callHook(t, reflect.TypeOf(map[string]any{}), reflect.TypeOf(RepoSpec{}),
+		map[string]any{"ref": "v9.9.9"})
+	spec := got.(RepoSpec) //nolint:gocritic // got is mapstructure-returned any
+	if spec.URL != "" {
+		t.Errorf("URL should be empty when not provided, got %q", spec.URL)
+	}
+	if spec.Ref != "v9.9.9" {
+		t.Errorf("Ref = %q, want v9.9.9", spec.Ref)
+	}
+}
+
 func TestRepoSpec_roundTrip(t *testing.T) {
 	t.Parallel()
 	original := map[string]RepoSpec{

--- a/skill/manifest.go
+++ b/skill/manifest.go
@@ -47,6 +47,10 @@ const MaxNameLen = 64
 // MaxDescriptionLen is the per-spec upper bound on a skill description.
 const MaxDescriptionLen = 1024
 
+// MaxCompatibilityLen is the per-spec upper bound on the compatibility field
+// (Reference B of the Skills guide: 1–500 characters).
+const MaxCompatibilityLen = 500
+
 // MaxBodyBytes caps the on-disk size of a SKILL.md body. The spec targets
 // <5k tokens for L2 content. Empirically the largest first-party skill
 // Anthropic ships (skill-creator) is ~32 KiB, so the hard cap sits at 64
@@ -77,9 +81,87 @@ type Manifest struct {
 	// Description is the prose summary used at Level 1 to decide whether the
 	// skill matches a task. Required.
 	Description string `yaml:"description"`
+	// License is the optional SPDX-style license identifier (e.g. "MIT") for
+	// open-source skills. Spec: free-form string.
+	License string `yaml:"license,omitempty"`
+	// Compatibility describes environment requirements — intended platform,
+	// system packages, network access. Optional, 1–500 chars.
+	Compatibility string `yaml:"compatibility,omitempty"`
+	// AllowedTools restricts which tools the agent may call while this skill
+	// is on the stack. Empty means no restriction. See AllowedTools for the
+	// accepted YAML shapes and the matching semantics squad implements.
+	AllowedTools AllowedTools `yaml:"allowed-tools,omitempty"`
+	// Metadata holds the spec's free-form key/value bag (author, version,
+	// mcp-server, tags, etc.). Preserved verbatim for callers that want to
+	// surface it via `squad skill list` without re-reading the file.
+	Metadata map[string]any `yaml:"metadata,omitempty"`
 	// Body is the markdown content after the frontmatter block, with leading
 	// and trailing whitespace trimmed. Returned by the Skill tool at L2.
 	Body string `yaml:"-"`
+}
+
+// AllowedTools is the list of tool names a skill is permitted to invoke. In
+// YAML it may appear as a space-separated string (the form shown in the
+// Skills guide example: `"Bash(python:*) Bash(npm:*) WebFetch"`) or as a
+// sequence of scalars. squad enforces tool-name matching only — the Claude
+// Code permission-pattern syntax (`Bash(python:*)`) is normalized to the
+// bare tool name preceding the parenthesis. Authors who need finer-grained
+// constraints should bundle a script rather than rely on the field.
+type AllowedTools []string
+
+// UnmarshalYAML accepts either a scalar (space-separated tool names) or a
+// sequence of scalars. Anything else is a parse error.
+func (a *AllowedTools) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		return nil
+	}
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*a = parseAllowedToolsString(value.Value)
+		return nil
+	case yaml.SequenceNode:
+		out := AllowedTools{}
+		for _, n := range value.Content {
+			if n.Kind != yaml.ScalarNode {
+				return fmt.Errorf("allowed-tools entries must be strings (line %d)", n.Line)
+			}
+			out = append(out, parseAllowedToolsString(n.Value)...)
+		}
+		*a = out
+		return nil
+	default:
+		return fmt.Errorf("allowed-tools must be a string or list of strings (line %d)", value.Line)
+	}
+}
+
+// Allows reports whether toolName is permitted. An empty/unset allow-list
+// imposes no restriction.
+func (a AllowedTools) Allows(toolName string) bool {
+	if len(a) == 0 {
+		return true
+	}
+	for _, n := range a {
+		if n == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+// parseAllowedToolsString splits a Claude-Code-style allow string into bare
+// tool names. `"Bash(python:*) Bash(npm:*) WebFetch"` → `["Bash","Bash","WebFetch"]`.
+// The duplicate is left in place; Allows treats the list as a set.
+func parseAllowedToolsString(s string) []string {
+	out := make([]string, 0, 4)
+	for _, tok := range strings.Fields(s) {
+		if i := strings.IndexByte(tok, '('); i >= 0 {
+			tok = tok[:i]
+		}
+		if tok = strings.TrimSpace(tok); tok != "" {
+			out = append(out, tok)
+		}
+	}
+	return out
 }
 
 // ValidateName reports whether s is a syntactically valid skill name per the
@@ -129,6 +211,18 @@ func ValidateDescription(d string) error {
 	return nil
 }
 
+// ValidateCompatibility reports whether c satisfies the per-spec 1–500
+// character bound. Empty is allowed (the field itself is optional).
+func ValidateCompatibility(c string) error {
+	if c == "" {
+		return nil
+	}
+	if len(c) > MaxCompatibilityLen {
+		return fmt.Errorf("compatibility exceeds %d characters (got %d)", MaxCompatibilityLen, len(c))
+	}
+	return nil
+}
+
 // Validate runs every spec-required check on the manifest's frontmatter and
 // body. It does not touch the filesystem; callers that load from disk should
 // use LoadManifest, which calls Validate after parsing.
@@ -138,6 +232,14 @@ func (m *Manifest) Validate() error {
 	}
 	if err := ValidateDescription(m.Description); err != nil {
 		return err
+	}
+	if err := ValidateCompatibility(m.Compatibility); err != nil {
+		return err
+	}
+	for _, tool := range m.AllowedTools {
+		if strings.TrimSpace(tool) == "" {
+			return errors.New("allowed-tools contains an empty entry")
+		}
 	}
 	if len(m.Body) > MaxBodyBytes {
 		return fmt.Errorf("body exceeds %d bytes (got %d)", MaxBodyBytes, len(m.Body))
@@ -161,6 +263,12 @@ func ParseManifest(data []byte) (*Manifest, error) {
 	if err := yaml.Unmarshal(fm, m); err != nil {
 		return nil, fmt.Errorf("parse frontmatter: %w", err)
 	}
+	// Normalize whitespace in fields the L1 prompt block renders inline.
+	// Trailing whitespace from YAML block scalars (e.g. `description: >`)
+	// would otherwise leak into the rendered system prompt.
+	m.Description = strings.TrimSpace(m.Description)
+	m.License = strings.TrimSpace(m.License)
+	m.Compatibility = strings.TrimSpace(m.Compatibility)
 	m.Body = strings.TrimSpace(string(body))
 	if err := m.Validate(); err != nil {
 		return nil, err

--- a/skill/manifest.go
+++ b/skill/manifest.go
@@ -60,7 +60,10 @@ const MaxBodyBytes = 64 * 1024
 
 // WarnBodyBytes is the soft cap surfaced by Validate as a warning. Skills
 // past this size still load but the author is told to consider splitting.
-const WarnBodyBytes = 5 * 1024
+// The guide's "<5,000 word" target maps to roughly 25 KiB by char count;
+// 24 KiB rounds to that without being so tight that every real-world
+// procedural skill (~7–16 KiB) trips a warning on every validate run.
+const WarnBodyBytes = 24 * 1024
 
 // reservedSubstrings carry the spec's anti-impersonation hint. We do not
 // reject names containing them — Anthropic's own `claude-api` skill
@@ -149,11 +152,19 @@ func (a AllowedTools) Allows(toolName string) bool {
 }
 
 // parseAllowedToolsString splits a Claude-Code-style allow string into bare
-// tool names. `"Bash(python:*) Bash(npm:*) WebFetch"` → `["Bash","Bash","WebFetch"]`.
-// The duplicate is left in place; Allows treats the list as a set.
+// tool names. Both space-separated (the form shown in the Skills guide) and
+// comma-separated (the form most authors actually write — including every
+// first-party squad-skills entry) are accepted.
+//
+//	"Bash(python:*) Bash(npm:*) WebFetch" → ["Bash","Bash","WebFetch"]
+//	"Read, Glob, Edit"                     → ["Read","Glob","Edit"]
+//
+// Duplicates are left in place; Allows treats the list as a set.
 func parseAllowedToolsString(s string) []string {
 	out := make([]string, 0, 4)
-	for _, tok := range strings.Fields(s) {
+	for _, tok := range strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	}) {
 		if i := strings.IndexByte(tok, '('); i >= 0 {
 			tok = tok[:i]
 		}

--- a/skill/manifest_test.go
+++ b/skill/manifest_test.go
@@ -294,6 +294,26 @@ func TestParseManifestAllowedToolsSequence(t *testing.T) {
 	}
 }
 
+func TestParseManifestAllowedToolsCommaSeparated(t *testing.T) {
+	// Real-world skills (the squad-skills repo and most published Claude Code
+	// skills) write the list with commas rather than the bare-space form the
+	// guide example uses. Both must parse to the same set or AllowsTool will
+	// silently deny access to a comma-suffixed entry like "Read,".
+	raw := []byte("---\nname: ok\ndescription: ok\nallowed-tools: Read, Glob, Edit\n---\n")
+	m, err := ParseManifest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := []string(m.AllowedTools), []string{"Read", "Glob", "Edit"}; !equalSlices(got, want) {
+		t.Errorf("allowed-tools = %v, want %v", got, want)
+	}
+	for _, n := range []string{"Read", "Glob", "Edit"} {
+		if !m.AllowedTools.Allows(n) {
+			t.Errorf("%s should be permitted; trailing comma must not leak into the entry", n)
+		}
+	}
+}
+
 func TestAllowedToolsAllows(t *testing.T) {
 	empty := AllowedTools{}
 	if !empty.Allows("anything") {

--- a/skill/manifest_test.go
+++ b/skill/manifest_test.go
@@ -352,3 +352,34 @@ func TestParseManifestTrimsDescriptionWhitespace(t *testing.T) {
 		t.Errorf("description = %q, want %q", m.Description, "padded with spaces")
 	}
 }
+
+func TestAllowedToolsUnmarshalYAMLNilNode(t *testing.T) {
+	var a AllowedTools
+	if err := a.UnmarshalYAML(nil); err != nil {
+		t.Fatalf("nil node should be a no-op, got %v", err)
+	}
+	if len(a) != 0 {
+		t.Errorf("expected empty slice, got %v", a)
+	}
+}
+
+func TestParseManifestAllowedToolsSequenceWithNonScalar(t *testing.T) {
+	// A mapping inside the sequence (`- key: value`) must be rejected, not
+	// silently flattened — otherwise a typo'd manifest produces an empty
+	// allow-list that denies everything.
+	raw := []byte("---\nname: ok\ndescription: ok\nallowed-tools:\n  - Read\n  - key: val\n---\n")
+	if _, err := ParseManifest(raw); err == nil {
+		t.Fatal("expected error for non-scalar sequence entry")
+	}
+}
+
+func TestValidateRejectsEmptyAllowedToolsEntry(t *testing.T) {
+	m := &Manifest{
+		Name:         "ok",
+		Description:  "ok",
+		AllowedTools: AllowedTools{"Read", "   "},
+	}
+	if err := m.Validate(); err == nil {
+		t.Fatal("expected error for whitespace-only allowed-tools entry")
+	}
+}

--- a/skill/manifest_test.go
+++ b/skill/manifest_test.go
@@ -253,3 +253,82 @@ func TestConsumeClosingLineNoNewline(t *testing.T) {
 		t.Errorf("expected nil, got %q", got)
 	}
 }
+
+func TestParseManifestOptionalFields(t *testing.T) {
+	raw := []byte("---\n" +
+		"name: ok\n" +
+		"description: ok\n" +
+		"license: MIT\n" +
+		"compatibility: Requires git and bash\n" +
+		"allowed-tools: \"Bash(python:*) Read WebFetch\"\n" +
+		"metadata:\n" +
+		"  author: Acme\n" +
+		"  version: 1.2.3\n" +
+		"---\nbody\n")
+	m, err := ParseManifest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.License != "MIT" {
+		t.Errorf("license = %q, want MIT", m.License)
+	}
+	if m.Compatibility != "Requires git and bash" {
+		t.Errorf("compatibility = %q", m.Compatibility)
+	}
+	if got, want := []string(m.AllowedTools), []string{"Bash", "Read", "WebFetch"}; !equalSlices(got, want) {
+		t.Errorf("allowed-tools = %v, want %v", got, want)
+	}
+	if m.Metadata["author"] != "Acme" || m.Metadata["version"] != "1.2.3" {
+		t.Errorf("metadata = %v", m.Metadata)
+	}
+}
+
+func TestParseManifestAllowedToolsSequence(t *testing.T) {
+	raw := []byte("---\nname: ok\ndescription: ok\nallowed-tools:\n  - Read\n  - Bash(python:*)\n---\n")
+	m, err := ParseManifest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := []string(m.AllowedTools), []string{"Read", "Bash"}; !equalSlices(got, want) {
+		t.Errorf("allowed-tools = %v, want %v", got, want)
+	}
+}
+
+func TestAllowedToolsAllows(t *testing.T) {
+	empty := AllowedTools{}
+	if !empty.Allows("anything") {
+		t.Error("empty allow-list should permit any tool")
+	}
+	a := AllowedTools{"Read", "Bash"}
+	if !a.Allows("Read") || !a.Allows("Bash") {
+		t.Error("listed tools should be allowed")
+	}
+	if a.Allows("WebFetch") {
+		t.Error("unlisted tool should be denied")
+	}
+}
+
+func TestParseManifestCompatibilityTooLong(t *testing.T) {
+	raw := []byte("---\nname: ok\ndescription: ok\ncompatibility: " + strings.Repeat("x", MaxCompatibilityLen+1) + "\n---\n")
+	if _, err := ParseManifest(raw); err == nil {
+		t.Fatal("expected compatibility-length error")
+	}
+}
+
+func TestParseManifestAllowedToolsInvalidShape(t *testing.T) {
+	raw := []byte("---\nname: ok\ndescription: ok\nallowed-tools:\n  Read: yes\n---\n")
+	if _, err := ParseManifest(raw); err == nil {
+		t.Fatal("expected error for mapping shape")
+	}
+}
+
+func TestParseManifestTrimsDescriptionWhitespace(t *testing.T) {
+	raw := []byte("---\nname: ok\ndescription: \"  padded with spaces   \"\n---\n")
+	m, err := ParseManifest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Description != "padded with spaces" {
+		t.Errorf("description = %q, want %q", m.Description, "padded with spaces")
+	}
+}

--- a/skill/stack.go
+++ b/skill/stack.go
@@ -31,20 +31,25 @@ func NewStack() *Stack {
 	return &Stack{}
 }
 
-// Push adds an entry to the stack. Idempotent: re-pushing a skill already on
-// the stack is a no-op.
-func (s *Stack) Push(e Entry) {
+// Push adds an entry to the stack and reports whether it is now on the
+// stack. Idempotent: re-pushing a skill already on the stack returns true
+// without adding a duplicate. Returns false only when the entry is invalid
+// (nil receiver or empty Dir) — Dir anchors the Read/Bash scope expansion,
+// so an entry without one would be unusable. Callers that don't care about
+// the result can discard it; tests should assert it to catch silent drops.
+func (s *Stack) Push(e Entry) bool {
 	if s == nil || e.Dir == "" {
-		return
+		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, existing := range s.dirs {
 		if existing.Dir == e.Dir {
-			return
+			return true
 		}
 	}
 	s.dirs = append(s.dirs, e)
+	return true
 }
 
 // Top returns the most recently pushed entry. ok is false when the stack

--- a/skill/stack_test.go
+++ b/skill/stack_test.go
@@ -50,10 +50,33 @@ func TestStackPushTopLen(t *testing.T) {
 
 func TestStackPushIdempotent(t *testing.T) {
 	s := NewStack()
-	s.Push(entry("a", "/tmp/a"))
-	s.Push(entry("a", "/tmp/a"))
+	if !s.Push(entry("a", "/tmp/a")) {
+		t.Fatal("first push should succeed")
+	}
+	if !s.Push(entry("a", "/tmp/a")) {
+		t.Error("duplicate push should report success (already on stack)")
+	}
 	if s.Len() != 1 {
 		t.Errorf("duplicate push grew stack to %d", s.Len())
+	}
+}
+
+func TestStackPushReturnsFalseForInvalidEntry(t *testing.T) {
+	// Dir anchors Read/Bash scope expansion at runtime, so an entry with
+	// no Dir is unusable and gets dropped. Push must report that drop so
+	// tests don't quietly proceed against an empty stack — the exact bug
+	// that masked the allowed-tools denial test before this contract.
+	s := NewStack()
+	if s.Push(Entry{Manifest: &Manifest{Name: "no-dir"}}) {
+		t.Error("Push of entry with empty Dir should return false")
+	}
+	if s.Len() != 0 {
+		t.Errorf("stack should remain empty, got len=%d", s.Len())
+	}
+
+	var nilStack *Stack
+	if nilStack.Push(entry("a", "/tmp/a")) {
+		t.Error("Push on nil receiver should return false")
 	}
 }
 

--- a/skill/validate.go
+++ b/skill/validate.go
@@ -130,7 +130,7 @@ func Validate(path string) (*ValidationReport, error) {
 
 	if len(m.Body) > WarnBodyBytes {
 		report.add(SeverityWarning, FileName,
-			fmt.Sprintf("body is %d bytes; spec target is <5 KiB — consider splitting into references/", len(m.Body)))
+			fmt.Sprintf("body is %d bytes; guide target is <5,000 words (~%d KiB) — consider splitting into references/", len(m.Body), WarnBodyBytes/1024))
 	}
 
 	for _, link := range findMarkdownLinks(m.Body) {

--- a/source/git_ref_test.go
+++ b/source/git_ref_test.go
@@ -188,6 +188,79 @@ func TestCloneOrUpdate_corruptCacheDirErrors(t *testing.T) {
 	_ = cacheDir
 }
 
+func TestCloneOrUpdate_fetchFailureWarnsButResolvesFromCache(t *testing.T) {
+	t.Parallel()
+	fixture, _, tag, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	// First clone populates the cache and brings the tag into local refs.
+	repoPath, err := ops.CloneOrUpdate(url, "")
+	if err != nil {
+		t.Fatalf("initial CloneOrUpdate: %v", err)
+	}
+
+	// Point origin at a nonexistent path so the next CloneOrUpdate's
+	// fetch attempt fails with something other than NoErrAlreadyUpToDate.
+	// checkoutRef should print a warning and fall back to the local refs
+	// rather than aborting the run.
+	repo, err := git.PlainOpen(repoPath)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	gitCfg, err := repo.Config()
+	if err != nil {
+		t.Fatalf("repo.Config: %v", err)
+	}
+	gitCfg.Remotes["origin"].URLs = []string{"file:///squad-test-nonexistent-" + filepath.Base(fixture) + ".git"}
+	if err := repo.SetConfig(gitCfg); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	// CloneOrUpdate must still succeed because the tag is already in the
+	// local refs. The fetch failure is downgraded to a stderr warning.
+	if _, err := ops.CloneOrUpdate(url, tag); err != nil {
+		t.Fatalf("expected fetch warning to be non-fatal, got: %v", err)
+	}
+}
+
+func TestCloneOrUpdate_bareCacheSurfacesWorktreeError(t *testing.T) {
+	t.Parallel()
+	fixture, _, tag, _, _ := fixtureRepo(t)
+	_, url, ops := cloneFromFixture(t, fixture)
+
+	repoPath, err := ops.CloneOrUpdate(url, "")
+	if err != nil {
+		t.Fatalf("initial CloneOrUpdate: %v", err)
+	}
+
+	// Rearrange the cache into a bare-repository layout: move .git/* up
+	// to the repo root and remove the .git directory. PlainOpen then
+	// reports the path as a bare repo (wt == nil), so checkoutRef's
+	// Worktree() call after resolveRef succeeds returns ErrIsBareRepository.
+	gitDir := filepath.Join(repoPath, ".git")
+	entries, err := os.ReadDir(gitDir)
+	if err != nil {
+		t.Fatalf("ReadDir(.git): %v", err)
+	}
+	for _, e := range entries {
+		src := filepath.Join(gitDir, e.Name())
+		dst := filepath.Join(repoPath, e.Name())
+		if err := os.RemoveAll(dst); err != nil {
+			t.Fatalf("RemoveAll %s: %v", dst, err)
+		}
+		if err := os.Rename(src, dst); err != nil {
+			t.Fatalf("Rename %s -> %s: %v", src, dst, err)
+		}
+	}
+	if err := os.RemoveAll(gitDir); err != nil {
+		t.Fatalf("RemoveAll .git: %v", err)
+	}
+
+	if _, err := ops.CloneOrUpdate(url, tag); err == nil {
+		t.Fatal("expected Worktree() error from bare cache")
+	}
+}
+
 func TestCloneOrUpdate_followupUpdateSwitchesRef(t *testing.T) {
 	t.Parallel()
 	fixture, firstSHA, tag, _, _ := fixtureRepo(t)

--- a/tools/skill.go
+++ b/tools/skill.go
@@ -187,8 +187,13 @@ func skillTool(runtime *SkillRuntime) func(ctx context.Context, rawArgs []byte) 
 			return "", fmt.Errorf("skill: body for %q exceeds %d bytes (got %d)",
 				args.Name, skill.MaxBodyBytes, len(body))
 		}
-		if runtime.Stack != nil {
-			runtime.Stack.Push(entry)
+		if runtime.Stack != nil && !runtime.Stack.Push(entry) {
+			// Entries here come from runtime.find, which only returns
+			// catalog-loaded rows that always have Dir set. A drop here
+			// signals a catalog-loading bug worth surfacing rather than
+			// silently dispatching an unscoped skill.
+			logging.WarnContext(ctx, "skill: dropped from stack (invalid entry): name=%s dir=%q",
+				entry.Name(), entry.Dir)
 		}
 		if runtime.OnLoad != nil {
 			runtime.OnLoad(entry)

--- a/tools/skill.go
+++ b/tools/skill.go
@@ -41,6 +41,30 @@ func (r *SkillRuntime) HasCatalog() bool {
 	return r != nil && len(r.Entries) > 0
 }
 
+// AllowsTool reports whether the tool named name is permitted under the
+// active skill stack. The Skill tool itself is always allowed — otherwise a
+// restrictive skill would lock the agent out of loading other skills. When
+// multiple skills are stacked, every skill's allowed-tools list must permit
+// the call (intersection semantics): a skill without a list imposes no
+// restriction, but a single restrictive skill is enough to deny.
+func (r *SkillRuntime) AllowsTool(name string) bool {
+	if r == nil || r.Stack == nil {
+		return true
+	}
+	if name == "Skill" {
+		return true
+	}
+	for _, e := range r.Stack.Entries() {
+		if e.Manifest == nil {
+			continue
+		}
+		if !e.Manifest.AllowedTools.Allows(name) {
+			return false
+		}
+	}
+	return true
+}
+
 // find returns the runtime entry matching name, or ok=false. Walks Entries
 // linearly — the catalog is small (typically <50 skills) so the simple
 // loop beats a map allocation per run.
@@ -153,6 +177,16 @@ func skillTool(runtime *SkillRuntime) func(ctx context.Context, rawArgs []byte) 
 		if !ok {
 			return "", fmt.Errorf("skill: %q is not in the catalog", args.Name)
 		}
+		// Defense in depth: re-check the body size against the spec cap at
+		// delivery time. Parse already enforces this for entries loaded via
+		// LoadManifest, but tests and future callers can construct Manifests
+		// directly, and a SKILL.md that grew on disk past the cap should
+		// never reach the agent.
+		body := entry.Manifest.Body
+		if len(body) > skill.MaxBodyBytes {
+			return "", fmt.Errorf("skill: body for %q exceeds %d bytes (got %d)",
+				args.Name, skill.MaxBodyBytes, len(body))
+		}
 		if runtime.Stack != nil {
 			runtime.Stack.Push(entry)
 		}
@@ -161,6 +195,6 @@ func skillTool(runtime *SkillRuntime) func(ctx context.Context, rawArgs []byte) 
 		}
 		logging.DebugContext(ctx, "Skill loaded: name=%s scope=%s dir=%s",
 			entry.Name(), entry.Scope.String(), entry.Dir)
-		return entry.Manifest.Body, nil
+		return body, nil
 	}
 }

--- a/tools/skill_test.go
+++ b/tools/skill_test.go
@@ -500,6 +500,29 @@ func TestSkillRuntime_AllowsToolSkipsNilManifestEntry(t *testing.T) {
 	}
 }
 
+func TestSkillTool_LogsWhenStackPushDrops(t *testing.T) {
+	// Simulates the catalog-loading-bug case: a runtime Entry without Dir
+	// reaches the loader. The body still has to ship to the model, but the
+	// stack drop must surface — otherwise an unscoped skill silently loads
+	// and Read/Bash scope expansion can't anchor anywhere.
+	rt := &SkillRuntime{
+		Entries: []skill.Entry{
+			{Manifest: &skill.Manifest{Name: "no-dir", Description: "x", Body: "payload"}},
+		},
+		Stack: skill.NewStack(),
+	}
+	body, err := skillTool(rt)(context.Background(), []byte(`{"name":"no-dir"}`))
+	if err != nil {
+		t.Fatalf("loader must still return the body, got error: %v", err)
+	}
+	if body != "payload" {
+		t.Errorf("body = %q, want %q", body, "payload")
+	}
+	if rt.Stack.Len() != 0 {
+		t.Errorf("stack should be empty after a dropped push, got len=%d", rt.Stack.Len())
+	}
+}
+
 // TestSkillRuntime_AllowsTool_RealManifestRoundTrip wires ParseManifest into
 // SkillRuntime to cover the seam unit tests miss. Every hand-built Manifest
 // test bypasses the parser, so a parser bug (e.g. a comma sticking to a tool

--- a/tools/skill_test.go
+++ b/tools/skill_test.go
@@ -477,6 +477,48 @@ func TestSkillRuntime_AllowsToolSkipsUnrestrictedSkill(t *testing.T) {
 	}
 }
 
+// TestSkillRuntime_AllowsTool_RealManifestRoundTrip wires ParseManifest into
+// SkillRuntime to cover the seam unit tests miss. Every hand-built Manifest
+// test bypasses the parser, so a parser bug (e.g. a comma sticking to a tool
+// name) can silently deny every Read call a skill authorized — exactly the
+// regression that surfaced when the official squad-skills catalog landed.
+// The fixture mirrors the real syntax authors use: kebab-case name, comma
+// separators, mixed spacing, Claude-Code-style parens on one entry.
+func TestSkillRuntime_AllowsTool_RealManifestRoundTrip(t *testing.T) {
+	const fixture = `---
+name: doc-comments-discovery-and-fix-loop
+description: Use when scrubbing doc comments from a Go codebase.
+allowed-tools: Read, Glob, Edit, Bash(go:*)
+---
+
+# Doc Comments
+
+body content
+`
+	m, err := skill.ParseManifest([]byte(fixture))
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{Manifest: m, Dir: t.TempDir()})
+	r := &SkillRuntime{Stack: stack}
+
+	for _, name := range []string{"Read", "Glob", "Edit", "Bash"} {
+		if !r.AllowsTool(name) {
+			t.Errorf("declared tool %q denied — parser/runtime seam broke", name)
+		}
+	}
+	for _, name := range []string{"Write", "WebFetch", "Grep"} {
+		if r.AllowsTool(name) {
+			t.Errorf("undeclared tool %q permitted — restriction not honored", name)
+		}
+	}
+	if !r.AllowsTool("Skill") {
+		t.Error("Skill loader must remain callable so the agent can stack more skills")
+	}
+}
+
 func TestSkillTool_RejectsOversizedBody(t *testing.T) {
 	dir := t.TempDir()
 	entry := skill.Entry{

--- a/tools/skill_test.go
+++ b/tools/skill_test.go
@@ -404,3 +404,91 @@ func TestSkillTool_InvalidJSONArgs(t *testing.T) {
 		t.Fatal("expected JSON parse error")
 	}
 }
+
+func TestSkillRuntime_AllowsToolNoStack(t *testing.T) {
+	var r *SkillRuntime
+	if !r.AllowsTool("Read") {
+		t.Error("nil runtime should permit any tool")
+	}
+	r = &SkillRuntime{}
+	if !r.AllowsTool("Read") {
+		t.Error("runtime with nil stack should permit any tool")
+	}
+}
+
+func TestSkillRuntime_AllowsToolEnforcesAllowList(t *testing.T) {
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:         "restricted",
+			Description:  "x",
+			AllowedTools: skill.AllowedTools{"Read", "Bash"},
+		},
+		Dir: t.TempDir(),
+	})
+	r := &SkillRuntime{Stack: stack}
+	if !r.AllowsTool("Read") {
+		t.Error("Read should be allowed")
+	}
+	if r.AllowsTool("WebFetch") {
+		t.Error("WebFetch should be denied")
+	}
+	if !r.AllowsTool("Skill") {
+		t.Error("Skill loader must always be allowed even under restriction")
+	}
+}
+
+func TestSkillRuntime_AllowsToolIntersectsStack(t *testing.T) {
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:         "a",
+			Description:  "x",
+			AllowedTools: skill.AllowedTools{"Read", "Bash", "WebFetch"},
+		},
+		Dir: t.TempDir(),
+	})
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:         "b",
+			Description:  "x",
+			AllowedTools: skill.AllowedTools{"Read"},
+		},
+		Dir: t.TempDir(),
+	})
+	r := &SkillRuntime{Stack: stack}
+	if !r.AllowsTool("Read") {
+		t.Error("Read should pass both skills")
+	}
+	if r.AllowsTool("Bash") {
+		t.Error("Bash allowed by 'a' but denied by 'b' — intersection should deny")
+	}
+}
+
+func TestSkillRuntime_AllowsToolSkipsUnrestrictedSkill(t *testing.T) {
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{Name: "unrestricted", Description: "x"},
+		Dir:      t.TempDir(),
+	})
+	r := &SkillRuntime{Stack: stack}
+	if !r.AllowsTool("AnythingGoes") {
+		t.Error("skill without allowed-tools should impose no restriction")
+	}
+}
+
+func TestSkillTool_RejectsOversizedBody(t *testing.T) {
+	dir := t.TempDir()
+	entry := skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:        "huge",
+			Description: "x",
+			Body:        strings.Repeat("x", skill.MaxBodyBytes+1),
+		},
+		Dir: dir,
+	}
+	rt := &SkillRuntime{Entries: []skill.Entry{entry}, Stack: skill.NewStack()}
+	if _, err := skillTool(rt)(context.Background(), []byte(`{"name":"huge"}`)); err == nil {
+		t.Fatal("expected oversize-body rejection")
+	}
+}

--- a/tools/skill_test.go
+++ b/tools/skill_test.go
@@ -477,6 +477,29 @@ func TestSkillRuntime_AllowsToolSkipsUnrestrictedSkill(t *testing.T) {
 	}
 }
 
+func TestSkillRuntime_AllowsToolSkipsNilManifestEntry(t *testing.T) {
+	// Stack entries with a nil Manifest must be skipped rather than crash —
+	// can happen if a catalog row is half-populated by a bug or a future
+	// async-loading code path.
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{Manifest: nil, Dir: t.TempDir()})
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:         "restricted",
+			Description:  "x",
+			AllowedTools: skill.AllowedTools{"Read"},
+		},
+		Dir: t.TempDir(),
+	})
+	r := &SkillRuntime{Stack: stack}
+	if !r.AllowsTool("Read") {
+		t.Error("nil-manifest entry should be skipped, not deny")
+	}
+	if r.AllowsTool("Bash") {
+		t.Error("restriction from non-nil entry should still apply")
+	}
+}
+
 // TestSkillRuntime_AllowsTool_RealManifestRoundTrip wires ParseManifest into
 // SkillRuntime to cover the seam unit tests miss. Every hand-built Manifest
 // test bypasses the parser, so a parser bug (e.g. a comma sticking to a tool

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -367,7 +367,6 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	)
 	defer span.End()
 
-	// Initialize efficiency features on context.
 	ctx = InitReadCache(ctx)
 	ctx = InitIterationCounter(ctx)
 	ctx = InitTokenCalibration(ctx)
@@ -1076,6 +1075,17 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 	}
 
 	toolName := toolCall.FunctionCall.Name
+
+	// Honor the active skill's allowed-tools restriction. When a skill on the
+	// stack lists a non-empty allowed-tools field, only those tools (plus the
+	// Skill loader itself) may run; everything else is denied without
+	// invoking the handler.
+	if rt := GetSkillRuntime(ctx); rt != nil && !rt.AllowsTool(toolName) {
+		toolResponse.Name = toolName
+		toolResponse.Content = fmt.Sprintf("error: tool %q is not permitted by the active skill's allowed-tools", toolName)
+		logging.InfoContext(ctx, "  ✗ %s denied by allowed-tools", toolName)
+		return toolResponse
+	}
 	ctx, span := telemetry.Tracer().Start(ctx, "tool."+toolName,
 		trace.WithAttributes(
 			attribute.String("squad.tool.name", toolName),

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -3464,14 +3464,16 @@ func TestExecuteToolCallDeniesUnallowedTool(t *testing.T) {
 	}
 
 	stack := skill.NewStack()
-	stack.Push(skill.Entry{
+	if !stack.Push(skill.Entry{
 		Manifest: &skill.Manifest{
 			Name:         "restricted",
 			Description:  "x",
 			AllowedTools: skill.AllowedTools{"Read"},
 		},
-		Dir: t.TempDir(), // Stack.Push silently drops entries with no Dir.
-	})
+		Dir: t.TempDir(),
+	}) {
+		t.Fatal("stack push failed")
+	}
 	ctx := WithSkillRuntime(context.Background(), &SkillRuntime{Stack: stack})
 
 	resp := executeToolCall(ctx, llms.ToolCall{

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cowdogmoo/squad/executor"
 	"github.com/cowdogmoo/squad/metrics"
+	"github.com/cowdogmoo/squad/skill"
 	"github.com/tmc/langchaingo/llms"
 )
 
@@ -3445,4 +3446,49 @@ func TestReadCacheSize(t *testing.T) {
 			t.Errorf("readCacheSize = %d, want 3", got)
 		}
 	})
+}
+
+func TestExecuteToolCallDeniesUnallowedTool(t *testing.T) {
+	// When a skill on the stack restricts allowed-tools, executeToolCall
+	// must short-circuit before invoking the handler — returning an error
+	// payload the model sees in the tool_result. Sentinel handler asserts
+	// it never ran.
+	called := false
+	handlers := map[string]Handler{
+		"Bash": {
+			Call: func(_ context.Context, _ []byte) (string, error) {
+				called = true
+				return "should not be reached", nil
+			},
+		},
+	}
+
+	stack := skill.NewStack()
+	stack.Push(skill.Entry{
+		Manifest: &skill.Manifest{
+			Name:         "restricted",
+			Description:  "x",
+			AllowedTools: skill.AllowedTools{"Read"},
+		},
+		Dir: t.TempDir(), // Stack.Push silently drops entries with no Dir.
+	})
+	ctx := WithSkillRuntime(context.Background(), &SkillRuntime{Stack: stack})
+
+	resp := executeToolCall(ctx, llms.ToolCall{
+		ID: "call_1",
+		FunctionCall: &llms.FunctionCall{
+			Name:      "Bash",
+			Arguments: `{"command":"ls"}`,
+		},
+	}, handlers)
+
+	if called {
+		t.Fatal("handler ran despite skill's allowed-tools restriction")
+	}
+	if !strings.Contains(resp.Content, "not permitted") {
+		t.Errorf("response should explain denial, got %q", resp.Content)
+	}
+	if resp.Name != "Bash" {
+		t.Errorf("response Name = %q, want Bash", resp.Name)
+	}
 }


### PR DESCRIPTION
**Key Changes:**

- Added support for optional skill manifest fields, including license, compatibility, allowed-tools, and metadata
- Enforced active skill allowed-tools restrictions before tool execution, while always permitting the Skill loader
- Added defense-in-depth validation to reject oversized skill bodies at delivery time
- Expanded test coverage for skill manifests, runtime restrictions, git cache fallback behavior, repo decode hooks, and command error paths

**Added:**

- Skill manifest extensions - Introduced optional license, compatibility, allowed-tools, and metadata fields with compatibility length validation and allowed-tools parsing from either strings or lists
- Tool permission enforcement - Added SkillRuntime.AllowsTool with stack-wide intersection semantics so restrictive skills can deny unapproved tool calls while unrestricted skills impose no limits
- Runtime safety checks - Added oversized skill body rejection in the Skill tool before returning content to the agent
- Error-path and edge-case coverage - Added tests for nil config handling, manager construction failures, duplicate local paths, config override failures, repo decode hook partial mappings, git fetch fallback from cache, bare cache errors, and skill tool permission behavior

**Changed:**

- Skill manifest parsing - Trimmed whitespace from inline-rendered fields such as description, license, and compatibility to prevent YAML scalar padding from leaking into prompts
- Tool execution flow - Updated tool call dispatch to deny handlers that are not permitted by the active skill stack and return a structured error response instead of invoking the tool
- Config initialization - Extracted config override unmarshalling into applyConfigOverrides so override errors remain wrapped and can be tested deterministically
- Allowed-tools semantics - Normalized Claude-style permission patterns such as Bash(python:*) to bare tool names for squad’s tool-level matching model