### PR TITLE
build: update goreleaser target to squad

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,11 +7,11 @@ snapshot:
   version_template: "{{ .Version }}-next"
 
 builds:
-  - id: "warpgate"
+  - id: "squad"
 
-    binary: warpgate
+    binary: squad
 
-    main: ./cmd/warpgate
+    main: ./cmd/squad
 
     # Inject version info via ldflags
     # Use {{.Summary}} to get git describe format (e.g., v3.0.0-1-gc1b0525)


### PR DESCRIPTION
**Key Changes:**

- Renamed the GoReleaser build target from warpgate to squad
- Updated the release binary name so generated artifacts use the squad naming
- Pointed GoReleaser at the squad command entrypoint for builds

**Changed:**

- Release build configuration - Updated .goreleaser.yaml to use the squad build id, produce a squad binary, and build from ./cmd/squad instead of the previous warpgate command path