### PR TITLE
fix: cap responses input token growth

### DIFF
--- a/responses/responses.go
+++ b/responses/responses.go
@@ -49,6 +49,17 @@ type Config struct {
 // visible response, so the model exhausts its budget on thinking alone.
 const DefaultMaxOutputTokens = 16384
 
+// MaxResponsesInputTokens caps server-billed input tokens per iteration.
+// OpenAI re-bills the full previous_response_id chain on every call, so
+// unbounded server-side context translates directly to unbounded cost.
+// When a response reports more input tokens than this, the loop returns
+// with [ErrInputTokenCapReached].
+const MaxResponsesInputTokens = 250_000
+
+// ErrInputTokenCapReached signals the input-token watchdog tripped in the
+// Responses API tool loop.
+var ErrInputTokenCapReached = errors.New("input token cap reached")
+
 func (rc *Config) applyOptionals(params *oairesponses.ResponseNewParams) {
 	if rc.Temperature >= 0 && !IsReasoningModel(rc.Model, rc.ReasoningPrefixes) {
 		params.Temperature = openai.Float(rc.Temperature)
@@ -212,7 +223,12 @@ func toolLoop(ctx context.Context, client openai.Client, resp *oairesponses.Resp
 		}
 
 		logEvent(logger, session.EventIteration, map[string]any{"index": i + 1, "tool_calls": len(calls)})
-		logging.InfoContext(ctx, "responses API: iteration %d with %d tool call(s)", i+1, len(calls))
+		if m != nil {
+			logging.InfoContext(ctx, "responses API: iteration %d/%d with %d tool call(s) (cost=$%.4f, tokens=%d/%d)",
+				i+1, maxIter, len(calls), m.TotalCostWithChildren(), m.InputTokens(), m.OutputTokens())
+		} else {
+			logging.InfoContext(ctx, "responses API: iteration %d/%d with %d tool call(s)", i+1, maxIter, len(calls))
+		}
 		if checkRepeat(ctx, &repeat, calls) {
 			break
 		}
@@ -259,6 +275,12 @@ func toolLoop(ctx context.Context, client openai.Client, resp *oairesponses.Resp
 			logging.InfoContext(ctx, "responses API: budget exceeded ($%.4f >= $%.4f max), stopping", m.TotalCostWithChildren(), m.MaxCost)
 			text := resp.OutputText()
 			return resp, text, metrics.ErrBudgetExceeded
+		}
+
+		if resp.Usage.InputTokens > MaxResponsesInputTokens {
+			logging.InfoContext(ctx, "responses API: input token cap reached (%d > %d), stopping", resp.Usage.InputTokens, MaxResponsesInputTokens)
+			text := resp.OutputText()
+			return resp, text, ErrInputTokenCapReached
 		}
 	}
 
@@ -546,7 +568,7 @@ func executeAndBuildOutputs(ctx context.Context, calls []FunctionCall, handlers 
 			}
 		}
 
-		output = tools.TruncateToolOutputHeadTail(output, 32*1024)
+		output = tools.TruncateToolOutputHeadTail(output, 16*1024)
 
 		logEvent(logger, session.EventToolResult, map[string]any{
 			"call_id":     call.CallID,

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -887,6 +887,82 @@ func TestRunWithToolsBudgetExceededDuringLoop(t *testing.T) {
 	_ = text
 }
 
+func TestRunWithToolsInputTokenCapReached(t *testing.T) {
+	t.Parallel()
+
+	callCount := int32(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		var payload map[string]any
+		switch count {
+		case 1:
+			payload = map[string]any{
+				"id": "resp-1", "object": "response", "created_at": 0,
+				"model": "gpt-4o", "parallel_tool_calls": false,
+				"temperature": 0, "tool_choice": "auto", "tools": []any{},
+				"top_p":              1,
+				"error":              map[string]any{"code": "server_error", "message": ""},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"output": []map[string]any{
+					{
+						"id": "fc-1", "type": "function_call",
+						"call_id": "call-1", "name": "Echo", "arguments": `{"msg":"hi"}`,
+					},
+				},
+			}
+		default:
+			payload = map[string]any{
+				"id": "resp-2", "object": "response", "created_at": 0,
+				"model": "gpt-4o", "parallel_tool_calls": false,
+				"temperature": 0, "tool_choice": "auto", "tools": []any{},
+				"top_p":              1,
+				"error":              map[string]any{"code": "server_error", "message": ""},
+				"incomplete_details": map[string]any{"reason": ""},
+				"instructions":       "system",
+				"metadata":           map[string]any{},
+				"usage":              map[string]any{"input_tokens": MaxResponsesInputTokens + 1, "output_tokens": 1000},
+				"output": []map[string]any{
+					{
+						"id": "fc-2", "type": "function_call",
+						"call_id": "call-2", "name": "Echo", "arguments": `{"msg":"again"}`,
+					},
+				},
+			}
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	td := t.TempDir()
+	_, err := RunWithTools(
+		context.Background(),
+		"key",
+		server.URL,
+		"gpt-4o",
+		"system",
+		"user",
+		td,
+		"",
+		"",
+		0.4,
+		0,
+		10,
+		0,
+		nil,
+		nil,
+		nil,
+		&executor.LocalExecutor{WorkingDir: td},
+		nil,
+		nil,
+	)
+	if !errors.Is(err, ErrInputTokenCapReached) {
+		t.Fatalf("expected ErrInputTokenCapReached, got: %v", err)
+	}
+}
+
 func TestExecuteAndBuildOutputsWithResultAndError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
**Key Changes:**

- Added an input-token watchdog for Responses API tool loops to prevent unbounded server-billed context costs
- Returned a dedicated error when the input token cap is exceeded so callers can distinguish this stop condition
- Improved iteration logging with max iteration count, accumulated cost, and token usage when metrics are available
- Reduced tool output truncation size to limit context growth between iterations

**Added:**

- Input token cap handling - Introduced MaxResponsesInputTokens and ErrInputTokenCapReached to stop tool loops once reported input usage exceeds 250,000 tokens
- Regression coverage - Added a test that simulates Responses API usage exceeding the cap and verifies ErrInputTokenCapReached is returned

**Changed:**

- Responses tool loop safeguards - Added a post-response usage check that returns the current response text before stopping when input tokens exceed the configured cap
- Iteration observability - Expanded logging to include current and maximum iteration counts, plus cost and token metrics when available
- Tool output budgeting - Reduced head/tail truncation from 32 KiB to 16 KiB to lower repeated context size and help control API costs