### PR TITLE
fix: cap responses input tokens to prevent runaway costs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Code coverage output files
 coverage-all.out
 coverage.out
+*.cov
+
+# Local Claude Code config (keep .claude/agents/ tracked)
+.claude/*
+!.claude/agents/
 
 # Distribution directory for binaries
 dist/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -102,6 +102,7 @@ tasks:
     silent: true
     vars:
       COVERAGE_TARGET: '{{.COVERAGE_TARGET | default "75"}}'
+      COST_BUDGET: '{{.COST_BUDGET | default "5"}}'
     cmds:
       - |
         go run ./cmd/squad run -v \
@@ -114,6 +115,7 @@ tasks:
           --require-actionable=true \
           --temperature 0.3 \
           --max-iterations 200 \
+          --max-cost {{.COST_BUDGET}} \
           --var COVERAGE_TARGET={{.COVERAGE_TARGET}} \
           --out {{.OUT_DIR}}/squad-go-tests.txt
       - echo "Test coverage output written to {{.OUT_DIR}}/squad-go-tests.txt"

--- a/browser/launch_test.go
+++ b/browser/launch_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -106,6 +107,25 @@ func TestIsAbsExecutableRejectsRelative(t *testing.T) {
 	}
 }
 
+func TestFindChromeEnvBareNameResolves(t *testing.T) {
+	// When SQUAD_BROWSER_BIN is a bare name present on PATH, findChrome
+	// should resolve it via exec.LookPath.
+	path, err := exec_LookPath_true()
+	if err != nil {
+		t.Skip("no `true` binary; skipping bare-name resolve test")
+	}
+	// Set env to the bare filename, not the absolute path.
+	base := filepath.Base(path)
+	t.Setenv("SQUAD_BROWSER_BIN", base)
+	resolved, err := findChrome()
+	if err != nil {
+		t.Fatalf("findChrome error: %v", err)
+	}
+	if resolved == base {
+		t.Fatalf("findChrome should resolve to absolute path, got bare name %q", resolved)
+	}
+}
+
 func TestLaunchWithStderrAndWaitFailure(t *testing.T) {
 	withRoot(t)
 	// `/usr/bin/false` exits 1 — exercises Stderr wiring and the Wait error path.
@@ -137,5 +157,21 @@ func TestLaunchDetachReturnsImmediately(t *testing.T) {
 	// Wait:false exercises the goroutine-reap branch.
 	if err := Launch("amazon", LaunchOptions{Wait: false}); err != nil {
 		t.Fatalf("Launch (detach): %v", err)
+	}
+}
+
+func TestFilepathIsAbsAndIsAbsExecutable(t *testing.T) {
+	// Absolute posix path should be treated as absolute.
+	if !filepathIsAbs("/tmp") {
+		t.Fatal("filepathIsAbs should return true for absolute posix paths")
+	}
+	// Windows-looking path on non-Windows should be treated as non-absolute.
+	if runtime.GOOS != "windows" && filepathIsAbs("C:/Windows") {
+		t.Fatal("filepathIsAbs should be false for Windows-style paths on non-Windows")
+	}
+	// Non-existent absolute file is not an executable file.
+	tmp := filepath.Join(t.TempDir(), "nope")
+	if isAbsExecutable(tmp) {
+		t.Fatalf("isAbsExecutable should be false for non-existent absolute path: %s", tmp)
 	}
 }

--- a/config/xdg_test.go
+++ b/config/xdg_test.go
@@ -236,3 +236,40 @@ func TestCacheDirEmptyEnv(t *testing.T) {
 		t.Fatalf("expected empty cache dir, got %q", got)
 	}
 }
+
+// New tests to cover success paths for ConfigFile/CacheFile and CacheDir with env.
+func TestConfigAndCacheFileCreatePaths(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "cfg"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(base, "cache"))
+
+	cfgPath, err := ConfigFile("app.yaml")
+	if err != nil {
+		t.Fatalf("ConfigFile: %v", err)
+	}
+	if want := filepath.Join(base, "cfg", "squad", "app.yaml"); cfgPath != want {
+		t.Fatalf("ConfigFile path=%q, want %q", cfgPath, want)
+	}
+	if _, err := os.Stat(filepath.Dir(cfgPath)); err != nil {
+		t.Fatalf("config dir not created: %v", err)
+	}
+
+	cachePath, err := CacheFile("cache.json")
+	if err != nil {
+		t.Fatalf("CacheFile: %v", err)
+	}
+	if want := filepath.Join(base, "cache", "squad", "cache.json"); cachePath != want {
+		t.Fatalf("CacheFile path=%q, want %q", cachePath, want)
+	}
+	if _, err := os.Stat(filepath.Dir(cachePath)); err != nil {
+		t.Fatalf("cache dir not created: %v", err)
+	}
+}
+
+func TestCacheDirWithEnv(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(base, "cache"))
+	if got := CacheDir(); got != filepath.Join(base, "cache", "squad") {
+		t.Fatalf("CacheDir=%q, want %q", got, filepath.Join(base, "cache", "squad"))
+	}
+}

--- a/pipeline/runner_test.go
+++ b/pipeline/runner_test.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cowdogmoo/squad/metrics"
+)
+
+func TestCountFiles(t *testing.T) {
+	t.Parallel()
+	parts := [][]string{{"a.go", "b.go"}, {"c.go"}, {}, {"d.go", "e.go", "f.go"}}
+	if got, want := countFiles(parts), 6; got != want {
+		t.Fatalf("countFiles = %d, want %d", got, want)
+	}
+}
+
+func TestRunAgentsParallel(t *testing.T) {
+	t.Parallel()
+
+	r := &Runner{
+		Pipeline: &Pipeline{Name: "test", Version: "v1"},
+		RunAgent: func(ctx context.Context, agentName, prompt, workingDir, mode string, vars map[string]string) (string, *metrics.Metrics, error) {
+			// Return a small distinctive string so we can spot wiring issues.
+			return agentName + " ok", nil, nil
+		},
+	}
+
+	agents := []string{"a1", "a2", "a3"}
+	stage := Stage{Name: "stage"}
+	got := r.runAgentsParallel(context.Background(), agents, stage, "ctx")
+
+	if len(got) != len(agents) {
+		t.Fatalf("results = %d, want %d", len(got), len(agents))
+	}
+	// Order must match input slice indices.
+	for i, ar := range got {
+		if ar.Agent != agents[i] {
+			t.Fatalf("result[%d].Agent = %q, want %q", i, ar.Agent, agents[i])
+		}
+		if ar.Status != StatusPassed {
+			t.Fatalf("result[%d].Status = %s, want passed", i, ar.Status)
+		}
+	}
+}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -1,0 +1,52 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderAndListTemplates(t *testing.T) {
+	t.Parallel()
+
+	// List should include several known templates.
+	names, err := ListTemplates()
+	if err != nil {
+		t.Fatalf("ListTemplates: %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatalf("ListTemplates returned no entries")
+	}
+	has := func(want string) bool {
+		for _, n := range names {
+			if n == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("agent.yaml.tmpl") || !has("system.md.tmpl") || !has("task.md.tmpl") {
+		t.Fatalf("ListTemplates missing expected names: %v", names)
+	}
+
+	// Render a known template and assert key substitutions appear.
+	out, err := Render("agent.yaml.tmpl", AgentData{
+		Name:        "demo-agent",
+		NameTitle:   "Demo Agent",
+		Description: "An example agent used in tests",
+		Lang:        "go",
+		Version:     "0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// Spot-check a few fields substituted from AgentData and helper funcs.
+	if !strings.Contains(out, "name: demo-agent") {
+		t.Fatalf("rendered output missing agent name: \n%s", out)
+	}
+	if !strings.Contains(out, "version: 0.0.1") {
+		t.Fatalf("rendered output missing version: \n%s", out)
+	}
+	if !strings.Contains(out, "references/demo-agent-guide.md") {
+		t.Fatalf("rendered output missing references path: \n%s", out)
+	}
+}

--- a/ui/pane/pane_test.go
+++ b/ui/pane/pane_test.go
@@ -1,6 +1,10 @@
 package pane
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func TestClassifyKind(t *testing.T) {
 	cases := []struct {
@@ -44,6 +48,58 @@ func TestKindString(t *testing.T) {
 	for k, want := range cases {
 		if got := k.String(); got != want {
 			t.Errorf("Kind(%d).String() = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestAsSubmitted(t *testing.T) {
+	// Happy path unwrap
+	var msg tea.Msg = Submitted{Kind: KindCommand, Text: "preset save"}
+	s, ok := AsSubmitted(msg)
+	if !ok {
+		t.Fatal("AsSubmitted should return ok=true for Submitted msg")
+	}
+	if s.Kind != KindCommand || s.Text != "preset save" {
+		t.Fatalf("AsSubmitted returned %+v", s)
+	}
+	// Non-matching type
+	if _, ok := AsSubmitted(tea.Msg("not-submitted")); ok {
+		t.Fatal("AsSubmitted should return ok=false for other msg types")
+	}
+}
+
+func TestAsLaunchRequest(t *testing.T) {
+	var msg tea.Msg = LaunchRequest{Agent: "go-tests", WorkingDir: ".", Prompt: "Begin."}
+	r, ok := AsLaunchRequest(msg)
+	if !ok {
+		t.Fatal("AsLaunchRequest should return ok=true for LaunchRequest msg")
+	}
+	if r.Agent != "go-tests" || r.Prompt != "Begin." {
+		t.Fatalf("AsLaunchRequest returned %+v", r)
+	}
+	if _, ok := AsLaunchRequest(tea.Msg("other")); ok {
+		t.Fatal("AsLaunchRequest should return ok=false for other msg types")
+	}
+}
+
+func TestTrimHelpers(t *testing.T) {
+	cases := []struct {
+		in   string
+		left string
+		both string
+	}{
+		{"", "", ""},
+		{"  \t\n", "", ""},
+		{"  a ", "a ", "a"},
+		{"a\n\r\t ", "a\n\r\t ", "a"},
+		{"  abc  ", "abc  ", "abc"},
+	}
+	for _, c := range cases {
+		if got := trimLeftSpace(c.in); got != c.left {
+			t.Errorf("trimLeftSpace(%q) = %q, want %q", c.in, got, c.left)
+		}
+		if got := trimSpace(c.in); got != c.both {
+			t.Errorf("trimSpace(%q) = %q, want %q", c.in, got, c.both)
 		}
 	}
 }


### PR DESCRIPTION
**Key Changes:**

- Added a Responses API input-token watchdog to stop tool loops before server-side context growth causes unbounded billing
- Reduced tool result payload size to limit repeated context accumulation across iterations
- Improved iteration logging with cost and token visibility when metrics are available
- Expanded test coverage across browser launching, XDG paths, pipeline runners, templates, pane helpers, and Responses API budget handling

**Added:**

- Input-token cap handling - Introduced MaxResponsesInputTokens and ErrInputTokenCapReached in responses/responses.go so the tool loop exits with a clear error when reported input usage exceeds the configured limit
- Cost budget wiring for automated test generation - Added COST_BUDGET support to Taskfile.yaml and passed it through as max-cost to keep squad-driven coverage tasks bounded
- Broader unit coverage - Added tests for pipeline agent ordering, template listing/rendering, pane message unwrapping and trimming, browser path resolution, XDG config/cache creation, and Responses API input-token cap behavior
- Local development ignore rules - Added coverage artifact and local Claude configuration ignores while preserving tracked Claude agents in .gitignore

**Changed:**

- Tool output truncation limit - Lowered Responses API tool output truncation from 32KB to 16KB to reduce repeated context size and control token growth
- Responses API loop observability - Updated iteration logs to include max iteration count plus cost and token totals when metrics are present, improving debugging for budget-related exits