### PR TITLE
ci: disable persisted checkout credentials

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Semgrep analysis
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6


### PR DESCRIPTION
**Key Changes:**

- Disabled persisted GitHub credentials for checkout steps across CI workflows
- Reduced credential exposure by preventing checkout tokens from remaining in git config after repository checkout
- Preserved existing workflow behavior and pinned action versions while tightening CI security defaults

**Changed:**

- CI checkout security - Set persist-credentials to false for repository checkout in the pre-commit, Semgrep, and test workflows so jobs do not retain unnecessary GitHub token credentials after checkout