### PR TITLE
test: add cli and repomap detector coverage

### DIFF
--- a/cmd/squad/agents_list_remove_test.go
+++ b/cmd/squad/agents_list_remove_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/config"
+	"github.com/spf13/cobra"
+)
+
+func TestAgentsList_emptyMessage(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	out, err := runAgentsSubcmd(t, cfg, agentsListCmd)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "No agents found") {
+		t.Fatalf("expected empty message, got:\n%s", out)
+	}
+}
+
+func TestAgentsList_rendersLocalPathAgent(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+
+	// Set up a local path containing one scaffolded-looking agent.
+	agentsRoot := t.TempDir()
+	agentDir := filepath.Join(agentsRoot, "demo-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: demo-agent\nversion: 1.2.3\ndescription: a demo agent\n"
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Agents.LocalPaths = []string{agentsRoot}
+
+	out, err := runAgentsSubcmd(t, cfg, agentsListCmd)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, want := range []string{"NAME", "demo-agent", "1.2.3", "a demo agent"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestAgentsList_nilCfgErrors(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runAgentsList(cmd, nil); err == nil {
+		t.Fatal("expected error when context lacks a config")
+	}
+}
+
+func TestAgentsRemove_repositoryByName(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	cfg.Agents.Repositories["team"] = config.RepoSpec{URL: "https://example.com/agents.git"}
+
+	if _, err := runAgentsSubcmd(t, cfg, agentsRemoveCmd, "team"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, ok := cfg.Agents.Repositories["team"]; ok {
+		t.Fatal("expected repository to be deleted from cfg")
+	}
+}
+
+func TestAgentsRemove_unknownErrors(t *testing.T) {
+	cfg := newAgentsTestCfg(t)
+	_, err := runAgentsSubcmd(t, cfg, agentsRemoveCmd, "ghost")
+	if err == nil {
+		t.Fatal("expected error when removing an unknown source")
+	}
+}
+
+func TestAgentsRemove_nilCfgErrors(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runAgentsRemove(cmd, []string{"x"}); err == nil {
+		t.Fatal("expected error when context lacks a config")
+	}
+}

--- a/cmd/squad/grade_test.go
+++ b/cmd/squad/grade_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/grading"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// withIsolatedCache redirects os.UserCacheDir() to a temp directory so the
+// grade store doesn't pollute the developer's real ~/.cache.
+func withIsolatedCache(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, ".cache"))
+}
+
+// runGradeCmd parses flags + args against a fresh `grade` cobra command and
+// returns the combined stdout/stderr.
+func runGradeCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newGradeCmd()
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { _ = cmd.Flags().Set(f.Name, f.DefValue) })
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.ParseFlags(args); err != nil {
+		return buf.String(), err
+	}
+	if err := cmd.RunE(cmd, cmd.Flags().Args()); err != nil {
+		return buf.String(), err
+	}
+	return buf.String(), nil
+}
+
+// gradableReport is a minimal markdown report containing every section the
+// grader looks for, so report-quality scoring is deterministic.
+const gradableReport = `# Changes Summary
+
+Fixed three bugs.
+
+# Analysis Summary
+
+Reviewed the code.
+
+# Files Touched
+
+- foo.go
+- bar.go
+
+# Validation
+
+All tests pass.
+
+# Issues Fixed
+
+- bug: something
+- bug: something else
+
+# Issues Skipped
+
+- nit: ignored
+
+# Findings
+
+- finding: x
+`
+
+func writeReport(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "report.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunGrade_fromFile_savesAndPrints(t *testing.T) {
+	withIsolatedCache(t)
+	report := writeReport(t, gradableReport)
+
+	out, err := runGradeCmd(t,
+		report,
+		"--agent", "demo-review",
+		"--iterations", "10",
+		"--files", "15",
+	)
+	if err != nil {
+		t.Fatalf("grade: %v", err)
+	}
+	if !strings.Contains(out, "Grade:") {
+		t.Fatalf("expected grade header in output:\n%s", out)
+	}
+
+	// Verify persistence — a follow-up --history should see the entry.
+	histOut, err := runGradeCmd(t, "--history", "--agent", "demo-review")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if !strings.Contains(histOut, "demo-review") {
+		t.Fatalf("expected saved grade in history:\n%s", histOut)
+	}
+}
+
+func TestRunGrade_noSaveSkipsPersistence(t *testing.T) {
+	withIsolatedCache(t)
+	report := writeReport(t, gradableReport)
+
+	if _, err := runGradeCmd(t,
+		report,
+		"--agent", "ephemeral",
+		"--iterations", "5",
+		"--files", "10",
+		"--save=false",
+	); err != nil {
+		t.Fatalf("grade: %v", err)
+	}
+
+	out, err := runGradeCmd(t, "--history", "--agent", "ephemeral")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if !strings.Contains(out, "No grades found") {
+		t.Fatalf("expected no-history message when --save=false, got:\n%s", out)
+	}
+}
+
+func TestRunGrade_jsonOutput(t *testing.T) {
+	withIsolatedCache(t)
+	report := writeReport(t, gradableReport)
+	out, err := runGradeCmd(t,
+		report,
+		"--agent", "json-agent",
+		"--iterations", "8",
+		"--files", "12",
+		"--json",
+	)
+	if err != nil {
+		t.Fatalf("grade: %v", err)
+	}
+	var got grading.GradeResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected JSON output, parse error %v, output:\n%s", err, out)
+	}
+	if got.Agent != "json-agent" {
+		t.Errorf("Agent = %q, want json-agent", got.Agent)
+	}
+}
+
+func TestRunGrade_stdinInput(t *testing.T) {
+	withIsolatedCache(t)
+
+	// Swap os.Stdin for a pipe whose read side carries gradableReport.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString(gradableReport); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		if err := r.Close(); err != nil {
+			t.Logf("close pipe: %v", err)
+		}
+	})
+
+	out, err := runGradeCmd(t, "-",
+		"--agent", "stdin-agent",
+		"--iterations", "6",
+		"--files", "10",
+		"--save=false",
+	)
+	if err != nil {
+		t.Fatalf("grade stdin: %v", err)
+	}
+	if !strings.Contains(out, "Grade:") {
+		t.Fatalf("expected grade output from stdin path:\n%s", out)
+	}
+}
+
+func TestRunGrade_missingArgsErrors(t *testing.T) {
+	withIsolatedCache(t)
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no args, no flags", []string{}},
+		{"file but no agent", []string{writeReport(t, gradableReport)}},
+		{"stats without agent", []string{"--stats"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := runGradeCmd(t, tc.args...); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestRunGrade_unreadableFileSurfacesError(t *testing.T) {
+	withIsolatedCache(t)
+	_, err := runGradeCmd(t,
+		filepath.Join(t.TempDir(), "does-not-exist.md"),
+		"--agent", "demo",
+		"--iterations", "5",
+		"--files", "8",
+	)
+	if err == nil {
+		t.Fatal("expected read error to surface")
+	}
+}
+
+func TestDisplayHistory_emptyMessage(t *testing.T) {
+	withIsolatedCache(t)
+	out, err := runGradeCmd(t, "--history", "--agent", "nobody")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if !strings.Contains(out, "No grades found") {
+		t.Fatalf("expected empty message, got:\n%s", out)
+	}
+}
+
+func TestDisplayHistory_jsonOutput(t *testing.T) {
+	withIsolatedCache(t)
+	store, err := grading.NewStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	parsed := grading.NewParser().Parse(gradableReport)
+	res := grading.ComputeGrade(parsed, grading.GradeOptions{
+		Agent: "hist-json", Iterations: 9, FileCount: 12,
+	})
+	if err := store.Save(res); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	out, err := runGradeCmd(t, "--history", "--agent", "hist-json", "--json")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	var arr []grading.GradeResult
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		t.Fatalf("expected JSON array, got error %v, output:\n%s", err, out)
+	}
+	if len(arr) != 1 || arr[0].Agent != "hist-json" {
+		t.Fatalf("unexpected history payload: %+v", arr)
+	}
+}
+
+func TestDisplayStats_textAndJSON(t *testing.T) {
+	withIsolatedCache(t)
+	store, err := grading.NewStore()
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	parser := grading.NewParser()
+	for i := 0; i < 3; i++ {
+		parsed := parser.Parse(gradableReport)
+		if err := store.Save(grading.ComputeGrade(parsed, grading.GradeOptions{
+			Agent: "stats-agent", Iterations: 8 + i, FileCount: 12,
+		})); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+	}
+
+	textOut, err := runGradeCmd(t, "--stats", "--agent", "stats-agent")
+	if err != nil {
+		t.Fatalf("stats text: %v", err)
+	}
+	for _, want := range []string{"Statistics for stats-agent", "Total Runs:", "Avg Score:"} {
+		if !strings.Contains(textOut, want) {
+			t.Errorf("missing %q in stats output:\n%s", want, textOut)
+		}
+	}
+
+	jsonOut, err := runGradeCmd(t, "--stats", "--agent", "stats-agent", "--json")
+	if err != nil {
+		t.Fatalf("stats json: %v", err)
+	}
+	var stats grading.AgentStats
+	if err := json.Unmarshal([]byte(jsonOut), &stats); err != nil {
+		t.Fatalf("stats json parse: %v, output:\n%s", err, jsonOut)
+	}
+	if stats.TotalRuns != 3 {
+		t.Errorf("TotalRuns = %d, want 3", stats.TotalRuns)
+	}
+}
+
+func TestDisplayStats_unknownAgentErrors(t *testing.T) {
+	withIsolatedCache(t)
+	if _, err := runGradeCmd(t, "--stats", "--agent", "ghost"); err == nil {
+		t.Fatal("expected stats for unknown agent to error")
+	}
+}
+
+func TestWriteJSON_marshalErrorSurfaces(t *testing.T) {
+	// channel values are unsupported by encoding/json so MarshalIndent errors.
+	if err := writeJSON(&bytes.Buffer{}, make(chan int)); err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
+func TestOutputJSON_writesIndented(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := outputJSON(cmd, map[string]int{"a": 1}); err != nil {
+		t.Fatalf("outputJSON: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"a": 1`) {
+		t.Fatalf("expected indented JSON, got:\n%s", buf.String())
+	}
+}

--- a/cmd/squad/init_agent_test.go
+++ b/cmd/squad/init_agent_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// runInitAgentCmd executes a freshly constructed `init agent` cobra command
+// with the given flags + args so each test invocation starts from default
+// flag state.
+func runInitAgentCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newInitAgentCmd()
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { _ = cmd.Flags().Set(f.Name, f.DefValue) })
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.ParseFlags(args); err != nil {
+		return buf.String(), err
+	}
+	if err := cmd.RunE(cmd, cmd.Flags().Args()); err != nil {
+		return buf.String(), err
+	}
+	return buf.String(), nil
+}
+
+func TestRunInitAgent_createsScaffoldFromTemplates(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if _, err := runInitAgentCmd(t,
+		"my-review",
+		"--lang", "go",
+		"--agents-dir", agentsDir,
+	); err != nil {
+		t.Fatalf("init agent: %v", err)
+	}
+
+	for _, rel := range []string{
+		"my-review/agent.yaml",
+		"my-review/system.md",
+		"my-review/agent.md",
+		"my-review/task.md",
+		"my-review/README.md",
+		"my-review/references/my-review-guide.md",
+	} {
+		if _, err := os.Stat(filepath.Join(agentsDir, rel)); err != nil {
+			t.Errorf("expected %s to be created: %v", rel, err)
+		}
+	}
+}
+
+func TestRunInitAgent_invalidLangErrors(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := runInitAgentCmd(t,
+		"any-name",
+		"--lang", "cobol",
+		"--agents-dir", filepath.Join(tmp, "agents"),
+	)
+	if err == nil {
+		t.Fatal("expected unknown language to error")
+	}
+}
+
+func TestRunInitAgent_copyFromExisting(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+
+	// Seed an existing agent via the same template path.
+	if _, err := runInitAgentCmd(t,
+		"seed-agent",
+		"--lang", "python",
+		"--agents-dir", agentsDir,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Copy it.
+	if _, err := runInitAgentCmd(t,
+		"derived-agent",
+		"--from", "seed-agent",
+		"--agents-dir", agentsDir,
+	); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	manifestPath := filepath.Join(agentsDir, "derived-agent", "agent.yaml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read copied manifest: %v", err)
+	}
+	if !strings.Contains(string(data), "name: derived-agent") {
+		t.Fatalf("expected manifest name rewritten to derived-agent, got:\n%s", data)
+	}
+}
+
+func TestRunInitAgent_existingWithoutForceErrors(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+
+	if _, err := runInitAgentCmd(t, "dup", "--lang", "generic", "--agents-dir", agentsDir); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	_, err := runInitAgentCmd(t, "dup", "--lang", "generic", "--agents-dir", agentsDir)
+	if err == nil {
+		t.Fatal("expected re-creation without --force to error")
+	}
+}

--- a/tools/repomap_detectors_test.go
+++ b/tools/repomap_detectors_test.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPythonPackage_pyprojectName(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "pyproject.toml")
+	if err := os.WriteFile(marker, []byte("[project]\nname = \"awesome-pkg\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mods, err := detectPythonPackage(dir, marker)
+	if err != nil {
+		t.Fatalf("detectPythonPackage: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Type != "python-package" || mods[0].Name != "awesome-pkg" {
+		t.Fatalf("unexpected modules: %+v", mods)
+	}
+}
+
+func TestDetectPythonPackage_fallsBackToDirName(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "fallback-pkg")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// setup.py is also a valid marker; no pyproject.toml so name should
+	// come from filepath.Base(dir).
+	marker := filepath.Join(dir, "setup.py")
+	if err := os.WriteFile(marker, []byte("from setuptools import setup\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mods, err := detectPythonPackage(dir, marker)
+	if err != nil {
+		t.Fatalf("detectPythonPackage: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Name != "fallback-pkg" {
+		t.Fatalf("expected name from directory, got %+v", mods)
+	}
+}
+
+func TestDetectPythonPackage_unreadablePyprojectFallsBackToDir(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "missing-toml")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Marker points at pyproject.toml that does not exist — exercises the
+	// os.ReadFile error branch where name stays as the directory base.
+	mods, err := detectPythonPackage(dir, filepath.Join(dir, "pyproject.toml"))
+	if err != nil {
+		t.Fatalf("detectPythonPackage: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Name != "missing-toml" {
+		t.Fatalf("expected directory fallback, got %+v", mods)
+	}
+}
+
+func TestDetectMavenModule(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "svc-api")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mods, err := detectMavenModule(dir, filepath.Join(dir, "pom.xml"))
+	if err != nil {
+		t.Fatalf("detectMavenModule: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Type != "maven-module" || mods[0].Name != "svc-api" {
+		t.Fatalf("unexpected modules: %+v", mods)
+	}
+}
+
+func TestDetectGradleModule(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "app")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mods, err := detectGradleModule(dir, filepath.Join(dir, "build.gradle"))
+	if err != nil {
+		t.Fatalf("detectGradleModule: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Type != "gradle-module" || mods[0].Name != "app" {
+		t.Fatalf("unexpected modules: %+v", mods)
+	}
+}
+
+func TestDetectCMakeProject(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "engine")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mods, err := detectCMakeProject(dir, filepath.Join(dir, "CMakeLists.txt"))
+	if err != nil {
+		t.Fatalf("detectCMakeProject: %v", err)
+	}
+	if len(mods) != 1 || mods[0].Type != "cmake-project" || mods[0].Name != "engine" {
+		t.Fatalf("unexpected modules: %+v", mods)
+	}
+}


### PR DESCRIPTION

**Key Changes:**

- Added end-to-end command tests for agent listing, removal, initialization, and grading workflows
- Covered grade persistence, JSON output, stdin input, history, stats, and validation/error scenarios
- Verified agent scaffolding behavior for template creation, copying, invalid languages, and duplicate handling
- Added repository map detector tests for Python, Maven, Gradle, and CMake module discovery

**Added:**

- Agent source command coverage - Added tests for empty list output, local path agent rendering, repository removal by name, unknown source errors, and missing config handling in cmd/squad/agents_list_remove_test.go
- Grade command coverage - Added tests for report grading from files and stdin, save and no-save behavior, JSON formatting, history and stats output, missing arguments, unreadable files, and JSON helper errors in cmd/squad/grade_test.go
- Agent initialization coverage - Added tests for scaffold generation from language templates, copying from an existing agent with manifest rewriting, invalid language validation, and duplicate creation protection in cmd/squad/init_agent_test.go
- Repository map detector coverage - Added tests for Python package name detection and fallbacks, plus Maven, Gradle, and CMake module detection in tools/repomap_detectors_test.go