### PR TITLE
feat: add agent CLI dependency preflight checks

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -109,6 +109,12 @@ type Manifest struct {
 	// (catalog enabled, both scopes, no allow/deny). See skill package
 	// and PLAN.md for the progressive-disclosure model.
 	Skills *SkillsConfig `yaml:"skills,omitempty"`
+
+	// Requires declares external CLI dependencies the agent needs at
+	// runtime (e.g. gosec, bandit). The runner verifies each is on PATH
+	// before invoking the model and aborts with install hints on missing
+	// tools so failures surface in milliseconds rather than mid-run.
+	Requires *RequiresConfig `yaml:"requires,omitempty"`
 }
 
 // SkillsConfig controls which Agent Skills are surfaced to this agent via
@@ -261,6 +267,10 @@ type Bundle struct {
 	// the Skill tool's runtime so the names the agent sees are exactly
 	// the names it can load via Skill(name).
 	SkillEntries []skill.Entry
+	// Requires mirrors Manifest.Requires so the runner can invoke
+	// Preflight() without re-reading the manifest. nil means "no
+	// declared external dependencies".
+	Requires *RequiresConfig
 }
 
 // TemplateData holds the data passed to prompt templates.
@@ -935,6 +945,7 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 		RemoteOnly:    manifest.IsRemoteOnly(),
 		CommentsOnly:  manifest.CommentsOnly,
 		SkillEntries:  skillEntries,
+		Requires:      manifest.Requires,
 	}, nil
 }
 

--- a/agent/composed.go
+++ b/agent/composed.go
@@ -106,6 +106,10 @@ func (m *Manifest) Validate() error {
 		return fmt.Errorf("manifest name is required")
 	}
 
+	if err := m.Requires.Validate(m.Name); err != nil {
+		return err
+	}
+
 	if m.IsComposed() {
 		return m.validateComposed()
 	}

--- a/agent/requires.go
+++ b/agent/requires.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// RequiresConfig declares external dependencies an agent needs at runtime.
+// The runner verifies these before invoking the model so a missing tool
+// fails fast with an actionable install hint instead of mid-run.
+type RequiresConfig struct {
+	// Commands lists CLI binaries that must be on PATH for the agent
+	// to function. The runner uses exec.LookPath to verify each.
+	Commands []RequiredCommand `yaml:"commands,omitempty"`
+}
+
+// RequiredCommand names a single CLI binary and how to install it.
+type RequiredCommand struct {
+	// Name is the binary name as it would be invoked (e.g. "gosec").
+	Name string `yaml:"name"`
+
+	// Install maps a package manager (or "url") to the install identifier.
+	// Common keys: brew, pipx, pip, npm, cargo, go, apt, dnf, pacman, url.
+	// Values are passed verbatim to the user as install hints; the runner
+	// does not execute them. An empty map is allowed but unhelpful.
+	Install map[string]string `yaml:"install,omitempty"`
+}
+
+// Validate checks that the Requires block is structurally well-formed.
+func (r *RequiresConfig) Validate(manifestName string) error {
+	if r == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(r.Commands))
+	for i, c := range r.Commands {
+		if c.Name == "" {
+			return fmt.Errorf("agent %q: requires.commands[%d]: name is required", manifestName, i)
+		}
+		if strings.ContainsAny(c.Name, " \t/") {
+			return fmt.Errorf("agent %q: requires.commands[%d]: name %q must be a bare binary name, not a path", manifestName, i, c.Name)
+		}
+		if seen[c.Name] {
+			return fmt.Errorf("agent %q: requires.commands: duplicate command %q", manifestName, c.Name)
+		}
+		seen[c.Name] = true
+	}
+	return nil
+}
+
+// Preflight verifies every required command is on PATH. Returns nil when
+// all are present (or when r is nil/empty). When commands are missing it
+// returns a single error listing each missing tool with its install hints.
+func (r *RequiresConfig) Preflight() error {
+	if r == nil || len(r.Commands) == 0 {
+		return nil
+	}
+	var missing []RequiredCommand
+	for _, c := range r.Commands {
+		if _, err := exec.LookPath(c.Name); err != nil {
+			missing = append(missing, c)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", formatMissing(missing))
+}
+
+func formatMissing(missing []RequiredCommand) string {
+	var b strings.Builder
+	plural := "tool"
+	if len(missing) > 1 {
+		plural = "tools"
+	}
+	fmt.Fprintf(&b, "preflight: %d required %s missing:\n", len(missing), plural)
+	for _, c := range missing {
+		fmt.Fprintf(&b, "\n  %s\n", c.Name)
+		for _, line := range formatInstall(c.Install) {
+			fmt.Fprintf(&b, "    %s\n", line)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatInstall renders an Install map as a stable, ordered list of hint
+// lines. The first hint is prefixed "Install:"; subsequent hints align as
+// "     or:" so the output reads like the example in docs/creating-agents.md.
+func formatInstall(install map[string]string) []string {
+	if len(install) == 0 {
+		return []string{"Install: (no hint provided)"}
+	}
+	keys := make([]string, 0, len(install))
+	for k := range install {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return installPriority(keys[i]) < installPriority(keys[j])
+	})
+
+	lines := make([]string, 0, len(keys))
+	for i, k := range keys {
+		hint := renderInstallHint(k, install[k])
+		if i == 0 {
+			lines = append(lines, "Install: "+hint)
+		} else {
+			lines = append(lines, "     or: "+hint)
+		}
+	}
+	return lines
+}
+
+// installPriority orders well-known package managers ahead of less common
+// ones so the most actionable hint appears first. Unknown keys sort
+// alphabetically after the known set.
+func installPriority(key string) int {
+	switch key {
+	case "brew":
+		return 0
+	case "pipx":
+		return 1
+	case "pip":
+		return 2
+	case "npm":
+		return 3
+	case "cargo":
+		return 4
+	case "go":
+		return 5
+	case "apt":
+		return 6
+	case "dnf":
+		return 7
+	case "pacman":
+		return 8
+	case "url":
+		return 100
+	default:
+		return 50
+	}
+}
+
+func renderInstallHint(manager, value string) string {
+	if manager == "url" {
+		return value
+	}
+	if value == "" {
+		return manager + " (no package name provided)"
+	}
+	switch manager {
+	case "brew":
+		return "brew install " + value
+	case "pipx":
+		return "pipx install " + value
+	case "pip":
+		return "pip install " + value
+	case "npm":
+		return "npm install -g " + value
+	case "cargo":
+		return "cargo install " + value
+	case "go":
+		return "go install " + value
+	case "apt":
+		return "sudo apt install " + value
+	case "dnf":
+		return "sudo dnf install " + value
+	case "pacman":
+		return "sudo pacman -S " + value
+	default:
+		return manager + ": " + value
+	}
+}

--- a/agent/requires_test.go
+++ b/agent/requires_test.go
@@ -181,6 +181,93 @@ func TestRequiresPreflight_UnknownManagerKeyPassedThrough(t *testing.T) {
 	}
 }
 
+// TestRequiresPreflight_AllManagerHints exercises every well-known package
+// manager so installPriority and renderInstallHint stay fully covered as
+// the list grows. Each manager is tested in isolation (one missing tool
+// per case) so the rendered hint appears as the "Install:" line verbatim.
+func TestRequiresPreflight_AllManagerHints(t *testing.T) {
+	cases := []struct {
+		manager  string
+		value    string
+		wantHint string
+	}{
+		{"brew", "gosec", "brew install gosec"},
+		{"pipx", "bandit", "pipx install bandit"},
+		{"pip", "bandit", "pip install bandit"},
+		{"npm", "prettier", "npm install -g prettier"},
+		{"cargo", "ripgrep", "cargo install ripgrep"},
+		{"go", "github.com/securego/gosec/v2/cmd/gosec@latest", "go install github.com/securego/gosec/v2/cmd/gosec@latest"},
+		{"apt", "shellcheck", "sudo apt install shellcheck"},
+		{"dnf", "shellcheck", "sudo dnf install shellcheck"},
+		{"pacman", "shellcheck", "sudo pacman -S shellcheck"},
+		{"url", "https://example.test/install", "https://example.test/install"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.manager, func(t *testing.T) {
+			r := &RequiresConfig{Commands: []RequiredCommand{
+				{
+					Name:    "definitely-not-a-real-binary-xyz123",
+					Install: map[string]string{tc.manager: tc.value},
+				},
+			}}
+			err := r.Preflight()
+			if err == nil {
+				t.Fatalf("expected preflight to fail for missing tool")
+			}
+			if !strings.Contains(err.Error(), "Install: "+tc.wantHint) {
+				t.Fatalf("expected hint %q, got:\n%s", "Install: "+tc.wantHint, err.Error())
+			}
+		})
+	}
+}
+
+// TestInstallPriority covers every branch of installPriority directly.
+// Going through Preflight only exercises priorities for the managers
+// that happen to share a single Install map, so test the function head-on.
+func TestInstallPriority(t *testing.T) {
+	cases := []struct {
+		key      string
+		wantRank int
+	}{
+		{"brew", 0},
+		{"pipx", 1},
+		{"pip", 2},
+		{"npm", 3},
+		{"cargo", 4},
+		{"go", 5},
+		{"apt", 6},
+		{"dnf", 7},
+		{"pacman", 8},
+		{"url", 100},
+		{"snap", 50}, // unknown → default
+		{"", 50},     // empty → default
+		{"something-else", 50},
+	}
+	for _, tc := range cases {
+		if got := installPriority(tc.key); got != tc.wantRank {
+			t.Errorf("installPriority(%q) = %d, want %d", tc.key, got, tc.wantRank)
+		}
+	}
+}
+
+// TestRequiresPreflight_KnownManagerEmptyValue covers the
+// "known manager, no package name" branch of renderInstallHint.
+func TestRequiresPreflight_KnownManagerEmptyValue(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{
+			Name:    "definitely-not-a-real-binary-xyz123",
+			Install: map[string]string{"brew": ""},
+		},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	if !strings.Contains(err.Error(), "brew (no package name provided)") {
+		t.Fatalf("expected placeholder for empty value, got:\n%s", err.Error())
+	}
+}
+
 // TestManifestValidate_InvokesRequires ensures the top-level Validate()
 // surfaces RequiresConfig errors so bad manifests fail at LoadManifest time.
 func TestManifestValidate_InvokesRequires(t *testing.T) {

--- a/agent/requires_test.go
+++ b/agent/requires_test.go
@@ -1,0 +1,235 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRequiresValidate_NilOK(t *testing.T) {
+	var r *RequiresConfig
+	if err := r.Validate("any"); err != nil {
+		t.Fatalf("nil RequiresConfig should validate, got: %v", err)
+	}
+}
+
+func TestRequiresValidate_EmptyOK(t *testing.T) {
+	r := &RequiresConfig{}
+	if err := r.Validate("any"); err != nil {
+		t.Fatalf("empty RequiresConfig should validate, got: %v", err)
+	}
+}
+
+func TestRequiresValidate_RejectsMissingName(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{{Name: ""}}}
+	err := r.Validate("go-security-audit")
+	if err == nil || !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("expected missing-name error, got: %v", err)
+	}
+}
+
+func TestRequiresValidate_RejectsPathInName(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{{Name: "/usr/bin/gosec"}}}
+	err := r.Validate("a")
+	if err == nil || !strings.Contains(err.Error(), "bare binary name") {
+		t.Fatalf("expected bare-name error, got: %v", err)
+	}
+}
+
+func TestRequiresValidate_RejectsDuplicates(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{Name: "gosec"},
+		{Name: "gosec"},
+	}}
+	err := r.Validate("a")
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestRequiresPreflight_NilOK(t *testing.T) {
+	var r *RequiresConfig
+	if err := r.Preflight(); err != nil {
+		t.Fatalf("nil RequiresConfig should preflight clean, got: %v", err)
+	}
+}
+
+func TestRequiresPreflight_EmptyOK(t *testing.T) {
+	r := &RequiresConfig{}
+	if err := r.Preflight(); err != nil {
+		t.Fatalf("empty RequiresConfig should preflight clean, got: %v", err)
+	}
+}
+
+// TestRequiresPreflight_PresentOK uses a tool that exists on every platform
+// (go itself, since the test runs under `go test`).
+func TestRequiresPreflight_PresentOK(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{{Name: "go"}}}
+	if err := r.Preflight(); err != nil {
+		t.Fatalf("preflight for 'go' should pass under `go test`, got: %v", err)
+	}
+}
+
+func TestRequiresPreflight_MissingFails(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{
+			Name:    "definitely-not-a-real-binary-xyz123",
+			Install: map[string]string{"brew": "fake-tool", "pipx": "fake-tool"},
+		},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail for missing tool")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"preflight",
+		"1 required tool missing",
+		"definitely-not-a-real-binary-xyz123",
+		"brew install fake-tool",
+		"pipx install fake-tool",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("preflight error missing %q\nfull error:\n%s", want, msg)
+		}
+	}
+}
+
+func TestRequiresPreflight_MultipleMissingPluralizes(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{Name: "definitely-not-a-real-binary-xyz123"},
+		{Name: "also-not-a-real-binary-xyz123"},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	if !strings.Contains(err.Error(), "2 required tools missing") {
+		t.Fatalf("expected plural 'tools', got: %s", err.Error())
+	}
+}
+
+func TestRequiresPreflight_PartialMissingOnlyReportsMissing(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{Name: "go"},
+		{Name: "definitely-not-a-real-binary-xyz123"},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	if strings.Contains(err.Error(), "\n  go\n") {
+		t.Errorf("present tool 'go' should not appear in missing report:\n%s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "definitely-not-a-real-binary-xyz123") {
+		t.Errorf("missing tool not reported:\n%s", err.Error())
+	}
+}
+
+func TestRequiresPreflight_NoInstallHint(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{Name: "definitely-not-a-real-binary-xyz123"},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	if !strings.Contains(err.Error(), "(no hint provided)") {
+		t.Fatalf("expected placeholder hint, got: %s", err.Error())
+	}
+}
+
+func TestRequiresPreflight_InstallHintOrdering(t *testing.T) {
+	// brew should appear before pipx (priority 0 vs 1), pipx before url.
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{
+			Name: "definitely-not-a-real-binary-xyz123",
+			Install: map[string]string{
+				"url":  "https://example.test",
+				"pipx": "foo",
+				"brew": "foo",
+			},
+		},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	msg := err.Error()
+	brewIdx := strings.Index(msg, "brew install foo")
+	pipxIdx := strings.Index(msg, "pipx install foo")
+	urlIdx := strings.Index(msg, "https://example.test")
+	if brewIdx < 0 || pipxIdx <= brewIdx || urlIdx <= pipxIdx {
+		t.Fatalf("expected install hint order brew < pipx < url, got:\n%s", msg)
+	}
+}
+
+func TestRequiresPreflight_UnknownManagerKeyPassedThrough(t *testing.T) {
+	r := &RequiresConfig{Commands: []RequiredCommand{
+		{
+			Name:    "definitely-not-a-real-binary-xyz123",
+			Install: map[string]string{"snap": "fake-tool"},
+		},
+	}}
+	err := r.Preflight()
+	if err == nil {
+		t.Fatal("expected preflight to fail")
+	}
+	if !strings.Contains(err.Error(), "snap: fake-tool") {
+		t.Fatalf("expected unknown manager 'snap' to pass through verbatim, got:\n%s", err.Error())
+	}
+}
+
+// TestManifestValidate_InvokesRequires ensures the top-level Validate()
+// surfaces RequiresConfig errors so bad manifests fail at LoadManifest time.
+func TestManifestValidate_InvokesRequires(t *testing.T) {
+	m := &Manifest{
+		Name:       "leaf",
+		EntryPoint: "system.md",
+		Wrapper:    "agent.md",
+		Requires: &RequiresConfig{Commands: []RequiredCommand{
+			{Name: ""},
+		}},
+	}
+	err := m.Validate()
+	if err == nil || !strings.Contains(err.Error(), "requires.commands") {
+		t.Fatalf("expected Validate to surface requires error, got: %v", err)
+	}
+}
+
+// TestLoadManifest_ParsesRequires writes a minimal agent.yaml with a
+// requires block and confirms LoadManifest round-trips it.
+func TestLoadManifest_ParsesRequires(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `name: test-agent
+version: 0.1.0
+entrypoint: system.md
+wrapper: agent.md
+requires:
+  commands:
+    - name: gosec
+      install:
+        brew: gosec
+        go: github.com/securego/gosec/v2/cmd/gosec@latest
+    - name: govulncheck
+      install:
+        go: golang.org/x/vuln/cmd/govulncheck@latest
+`
+	if err := os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Requires == nil || len(m.Requires.Commands) != 2 {
+		t.Fatalf("expected 2 commands, got: %+v", m.Requires)
+	}
+	if m.Requires.Commands[0].Name != "gosec" {
+		t.Errorf("expected first command 'gosec', got %q", m.Requires.Commands[0].Name)
+	}
+	if got := m.Requires.Commands[0].Install["brew"]; got != "gosec" {
+		t.Errorf("expected brew install hint 'gosec', got %q", got)
+	}
+}

--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -102,6 +102,19 @@ skills:
   scopes: [repo, catalog]      # which scopes to surface
   allow: []                    # exclusive allowlist of skill names
   deny: []                     # remove skills by name (only when allow is empty)
+
+# Optional: external CLI dependencies the agent invokes via Bash.
+# The runner verifies each on PATH before invoking the model and aborts
+# with install hints on missing tools. See "Declaring Tool Dependencies".
+requires:
+  commands:
+    - name: gosec
+      install:
+        brew: gosec
+        go: github.com/securego/gosec/v2/cmd/gosec@latest
+    - name: govulncheck
+      install:
+        go: golang.org/x/vuln/cmd/govulncheck@latest
 ```
 
 Only `name`, `entrypoint`, `wrapper`, and `task` are required. Everything else is optional.
@@ -168,6 +181,44 @@ Do NOT modify any files. Report only.
 Agents run commands locally by default. To run in a different environment,
 set the `environment` field in `agent.yaml`. See
 [Execution Backends](./execution-backends.md) for all options and examples.
+
+### Declaring Tool Dependencies
+
+Agents that shell out to external CLIs (linters, scanners, formatters)
+declare them in `requires.commands`. The runner verifies each is on PATH
+before invoking the model — so a missing tool fails in milliseconds with
+an install hint instead of mid-run after burning tokens.
+
+```yaml
+requires:
+  commands:
+    - name: bandit
+      install:
+        brew: bandit
+        pipx: bandit
+        url: https://bandit.readthedocs.io
+    - name: pip-audit
+      install:
+        pipx: pip-audit
+```
+
+**Fields:**
+
+- `name` (required): the bare binary name as it would be invoked. Must not
+  contain slashes or whitespace.
+- `install` (optional): a map from package-manager key to install
+  identifier. The runner does not execute these — they're rendered into
+  the failure message as human-readable hints.
+
+**Recognized install keys** (rendered with the right command prefix and
+ordered by likely availability): `brew`, `pipx`, `pip`, `npm`, `cargo`,
+`go`, `apt`, `dnf`, `pacman`. The special key `url` renders verbatim.
+Unknown keys (e.g. `snap`, `nix`) are passed through as `key: value`.
+
+**Composed agents** should declare the union of all stages' tool
+dependencies at the top level. Sub-agent manifests may also declare
+their own `requires:` block, which is checked when that sub-agent runs
+directly. Dry-runs (`--dry-run`) skip the preflight.
 
 ### MCP Server Integration
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -550,6 +550,10 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 		return nil, fmt.Errorf("config not available in context")
 	}
 
+	if err := bundle.Requires.Preflight(); err != nil {
+		return nil, err
+	}
+
 	return bundle, nil
 }
 

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -412,6 +412,61 @@ func TestPrepareBundle(t *testing.T) {
 	}
 }
 
+// TestPrepareBundle_RequiresPreflightFails wires an agent with a requires
+// block that points at a tool guaranteed to be absent from PATH and
+// confirms prepareBundle surfaces the preflight error rather than building
+// a runnable bundle.
+func TestPrepareBundle_RequiresPreflightFails(t *testing.T) {
+	t.Parallel()
+	agentsDir := t.TempDir()
+	agentName := "needs-missing-tool"
+	agentDir := filepath.Join(agentsDir, agentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manifest := fmt.Sprintf(`name: %s
+version: 0.0.0
+entrypoint: system.md
+wrapper: wrapper.md
+requires:
+  commands:
+    - name: definitely-not-a-real-binary-xyz123
+      install:
+        brew: fake-tool
+`, agentName)
+	for _, f := range []struct{ name, body string }{
+		{"agent.yaml", manifest},
+		{"system.md", "System prompt."},
+		{"wrapper.md", "Wrapper prompt."},
+	} {
+		if err := os.WriteFile(filepath.Join(agentDir, f.name), []byte(f.body), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f.name, err)
+		}
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	opts := &RunOptions{
+		Agent:           agentName,
+		AgentsDir:       agentsDir,
+		ConfigAvailable: true,
+	}
+	bundle, err := prepareBundle(cmd, opts, "prompt", t.TempDir())
+	if err == nil {
+		t.Fatal("expected prepareBundle to fail when a required tool is missing")
+	}
+	if bundle != nil {
+		t.Fatal("expected nil bundle on preflight failure")
+	}
+	if !strings.Contains(err.Error(), "preflight") {
+		t.Fatalf("expected preflight error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "definitely-not-a-real-binary-xyz123") {
+		t.Fatalf("expected missing-tool name in error, got: %v", err)
+	}
+}
+
 func TestResolveModelPrecedenceNilGuard(t *testing.T) {
 	t.Parallel()
 	// Calling with either argument nil must be a silent no-op rather than a


### PR DESCRIPTION
**Key Changes:**

- Introduced `requires.commands` manifest support for declaring external CLI tools agents need at runtime
- Added fast preflight checks that fail before model execution when required tools are missing
- Rendered actionable install hints for missing dependencies across common package managers
- Documented dependency declarations and covered validation, parsing, and preflight behavior with tests

**Added:**

- Runtime dependency model and preflight logic - Added `RequiresConfig` and `RequiredCommand` support with command validation, PATH checks, stable install-hint ordering, and readable missing-tool errors in `agent/requires.go`
- Test coverage for dependency declarations - Added validation, manifest parsing, preflight success/failure, install hint formatting, pluralization, and unknown package manager coverage in `agent/requires_test.go`
- Agent authoring documentation - Added `requires.commands` examples, field descriptions, supported install keys, composed-agent guidance, and dry-run behavior notes in `docs/creating-agents.md`

**Changed:**

- Manifest and runner flow now enforce dependencies early - Manifest validation invokes `requires` validation, bundle construction carries the parsed dependency config, and run preparation executes preflight before invoking the model in `agent/bundle.go`, `agent/composed.go`, and `runner/run.go`