### PR TITLE
feat: add stateless provider resume via local transcript replay

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -49,3 +49,4 @@ ignore:
   - "routine/roots_io.go"
   - "session/session_io.go"
   - "ui/presets/presets_io.go"
+  - "tools/transcript_io.go"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,7 +73,9 @@ When a tool result exceeds 8 KiB it is written to `results/<id>.txt` and the inl
 
 Terminal statuses are `completed`, `error`, and `budget_exceeded`. A status of `running` means the session is active or was interrupted.
 
-The `last_response_id` field powers `--resume`: it lets squad chain a new request onto the same conversation via the OpenAI Responses API, without re-sending the full transcript.
+The `last_response_id` field powers `--resume` on the OpenAI Responses API path: it lets squad chain a new request onto the same conversation server-side, without re-sending the full transcript.
+
+Every other provider (Anthropic, openai-compat, gemini, ollama) has a **stateless** API — there is no server-side conversation to chain onto. For those, `--resume` instead replays a locally persisted transcript. Each run on that path writes the full conversation to `transcript.json` alongside `meta.json` and `events.jsonl`; a resume loads it and prepends the prior turns to the new prompt. (`events.jsonl` is a lossy audit log and is **not** used for replay — only `transcript.json` is.)
 
 ---
 

--- a/runner/model.go
+++ b/runner/model.go
@@ -362,6 +362,11 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	// providers; Anthropic, Responses API, gemini, ollama keep the
 	// single-message form.
 	splitToolResults := provider == "openai" || provider == "openai-compat"
+	// On --resume, stateless providers have no server-side conversation to
+	// chain (unlike the OpenAI Responses path's PreviousResponseID), so replay
+	// the prior turns from the persisted transcript. Without this, a resumed
+	// run silently starts with no prior context.
+	priorMessages := loadResumeTranscript(ctx, opts)
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
 	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, tools.RunWithToolsConfig{
 		MaxIterations:      opts.MaxIterations,
@@ -375,6 +380,7 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 		Skill:              buildSkillRuntime(ctx, bundle, opts),
 		Confirm:            buildConfirmRuntime(opts),
 		MaxRetries:         opts.MaxRetries,
+		PriorMessages:      priorMessages,
 	}, callOpts...)
 	m.Finish()
 	if err != nil {
@@ -385,6 +391,32 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	}
 	logging.InfoContext(ctx, "model call finished in %s (response-bytes=%d)", m.Duration().Round(time.Millisecond), len(response))
 	return response, nil
+}
+
+// loadResumeTranscript returns the prior conversation to replay when this run
+// is a --resume on the stateless (LangChain) path. It returns nil for a fresh
+// run, and warns — rather than silently proceeding context-free — when a
+// resume finds no replayable transcript (e.g. the prior run used the OpenAI
+// Responses path, which persists no transcript).
+func loadResumeTranscript(ctx context.Context, opts *RunOptions) []llms.MessageContent {
+	if opts.ResumeID == "" {
+		return nil
+	}
+	logger := session.FromContext(ctx)
+	if logger == nil {
+		return nil
+	}
+	prior, err := tools.LoadTranscript(logger.Dir())
+	if err != nil {
+		logging.Warn("resume: failed to load transcript for session %s: %v", opts.ResumeID, err)
+		return nil
+	}
+	if len(prior) == 0 {
+		logging.Warn("resume: no transcript for session %s — continuing without prior context", opts.ResumeID)
+		return nil
+	}
+	logging.InfoContext(ctx, "resume: loaded %d prior message(s) for session %s", len(prior), opts.ResumeID)
+	return prior
 }
 
 // buildCallOpts constructs LLM call options from provider settings.

--- a/runner/model.go
+++ b/runner/model.go
@@ -362,10 +362,6 @@ func callLangChainLLM(ctx context.Context, opts *RunOptions, provider, model, sy
 	// providers; Anthropic, Responses API, gemini, ollama keep the
 	// single-message form.
 	splitToolResults := provider == "openai" || provider == "openai-compat"
-	// On --resume, stateless providers have no server-side conversation to
-	// chain (unlike the OpenAI Responses path's PreviousResponseID), so replay
-	// the prior turns from the persisted transcript. Without this, a resumed
-	// run silently starts with no prior context.
 	priorMessages := loadResumeTranscript(ctx, opts)
 	logging.InfoContext(ctx, "model call started (provider=%s model=%s)", provider, model)
 	response, err := tools.RunWithTools(ctx, llm, systemPrompt, bundle.User, bundle.WorkDir, tools.RunWithToolsConfig{

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -36,6 +36,67 @@ func TestApplyReadOnlyMode(t *testing.T) {
 	}
 }
 
+func TestLoadResumeTranscript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no resume id returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := loadResumeTranscript(context.Background(), &RunOptions{}); got != nil {
+			t.Fatalf("fresh run must return nil, got %v", got)
+		}
+	})
+
+	t.Run("resume without session logger returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := loadResumeTranscript(context.Background(), &RunOptions{ResumeID: "s1"}); got != nil {
+			t.Fatalf("no logger on ctx must return nil, got %v", got)
+		}
+	})
+
+	newLoggerCtx := func(t *testing.T) (context.Context, *session.Logger) {
+		t.Helper()
+		logger, err := session.New(t.TempDir(), "agent", "anthropic", "claude", "prompt")
+		if err != nil {
+			t.Fatalf("session.New: %v", err)
+		}
+		t.Cleanup(func() { _ = logger.Close() })
+		return session.WithLogger(context.Background(), logger), logger
+	}
+
+	t.Run("resume replays persisted transcript", func(t *testing.T) {
+		t.Parallel()
+		ctx, logger := newLoggerCtx(t)
+		prior := []llms.MessageContent{
+			{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "earlier"}}},
+		}
+		if err := tools.SaveTranscript(logger.Dir(), prior); err != nil {
+			t.Fatalf("SaveTranscript: %v", err)
+		}
+		if got := loadResumeTranscript(ctx, &RunOptions{ResumeID: logger.SessionID()}); len(got) != 1 {
+			t.Fatalf("expected 1 replayed message, got %d", len(got))
+		}
+	})
+
+	t.Run("resume with no transcript returns nil", func(t *testing.T) {
+		t.Parallel()
+		ctx, logger := newLoggerCtx(t)
+		if got := loadResumeTranscript(ctx, &RunOptions{ResumeID: logger.SessionID()}); got != nil {
+			t.Fatalf("missing transcript must return nil, got %v", got)
+		}
+	})
+
+	t.Run("resume with corrupt transcript returns nil", func(t *testing.T) {
+		t.Parallel()
+		ctx, logger := newLoggerCtx(t)
+		if err := os.WriteFile(filepath.Join(logger.Dir(), tools.TranscriptFile), []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("seed corrupt transcript: %v", err)
+		}
+		if got := loadResumeTranscript(ctx, &RunOptions{ResumeID: logger.SessionID()}); got != nil {
+			t.Fatalf("corrupt transcript must return nil, got %v", got)
+		}
+	})
+}
+
 func TestNormalizeProvider(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -352,6 +352,13 @@ type RunWithToolsConfig struct {
 	// tool"). Anthropic requires the single-message form, so leave this
 	// false for the anthropic provider.
 	SplitToolResults bool
+	// PriorMessages carries the conversational turns of a prior run, replayed
+	// on --resume so a stateless provider (Anthropic, openai-compat, gemini,
+	// ollama) continues with full context. The slice excludes the system
+	// message; it is spliced between the fresh system prompt and the new user
+	// prompt. Nil for a fresh run. The OpenAI Responses path does not use this
+	// — it chains server-side via PreviousResponseID.
+	PriorMessages []llms.MessageContent
 }
 
 // RunWithTools drives the tool-calling loop for a LangChain-compatible LLM.
@@ -383,7 +390,15 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 	}
 
 	messages := buildInitialMessages(systemPrompt, userPrompt, cfg.UseCacheControl)
+	if len(cfg.PriorMessages) > 0 {
+		messages = splicePriorMessages(messages, cfg.PriorMessages)
+		logging.InfoContext(ctx, "resume: replaying %d prior message(s)", len(cfg.PriorMessages))
+	}
 	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg, callOpts)
+	// Persist the full conversation so a later --resume can replay it. Covers
+	// every exit below (done / error / iteration cap) since messages holds the
+	// accumulated turns regardless of outcome.
+	persistTranscript(ctx, messages)
 	if done {
 		return lastContent, nil
 	}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -352,12 +352,9 @@ type RunWithToolsConfig struct {
 	// tool"). Anthropic requires the single-message form, so leave this
 	// false for the anthropic provider.
 	SplitToolResults bool
-	// PriorMessages carries the conversational turns of a prior run, replayed
-	// on --resume so a stateless provider (Anthropic, openai-compat, gemini,
-	// ollama) continues with full context. The slice excludes the system
-	// message; it is spliced between the fresh system prompt and the new user
-	// prompt. Nil for a fresh run. The OpenAI Responses path does not use this
-	// — it chains server-side via PreviousResponseID.
+	// PriorMessages is a prior run's turns (excluding the system message),
+	// replayed on --resume and spliced before the new user prompt. Nil for a
+	// fresh run; unused by the OpenAI Responses path.
 	PriorMessages []llms.MessageContent
 }
 
@@ -395,9 +392,7 @@ func RunWithTools(ctx context.Context, llm llms.Model, systemPrompt, userPrompt,
 		logging.InfoContext(ctx, "resume: replaying %d prior message(s)", len(cfg.PriorMessages))
 	}
 	lastContent, messages, loopErr, done := toolLoop(ctx, llm, messages, handlers, maxIterations, cfg, callOpts)
-	// Persist the full conversation so a later --resume can replay it. Covers
-	// every exit below (done / error / iteration cap) since messages holds the
-	// accumulated turns regardless of outcome.
+	// Persist the conversation (on every exit path) so a later --resume can replay it.
 	persistTranscript(ctx, messages)
 	if done {
 		return lastContent, nil

--- a/tools/transcript.go
+++ b/tools/transcript.go
@@ -1,0 +1,219 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/session"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// TranscriptFile is the per-session file holding the full, provider-faithful
+// conversation for the LangChain (stateless-provider) path. Unlike
+// events.jsonl — which is a lossy audit log of metadata — this file stores the
+// actual message content so a --resume can replay the prior turns. The OpenAI
+// Responses API does not need it: it chains server-side via PreviousResponseID.
+const TranscriptFile = "transcript.json"
+
+// transcriptMessage is the on-disk form of one llms.MessageContent. The role is
+// stored as its raw string (llms.ChatMessageType is itself a string) so no enum
+// mapping is required on the way back.
+type transcriptMessage struct {
+	Role  string           `json:"role"`
+	Parts []transcriptPart `json:"parts"`
+}
+
+// transcriptPart is the on-disk form of a single content part. Only the part
+// kinds the tool loop actually produces are represented; anything else is
+// dropped on save (and would simply be absent on replay).
+type transcriptPart struct {
+	Type string `json:"type"`
+	// Text is set for type "text".
+	Text string `json:"text,omitempty"`
+	// Tool-call fields, set for type "tool_call".
+	ID       string `json:"id,omitempty"`
+	ToolType string `json:"tool_type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Args     string `json:"args,omitempty"`
+	// Tool-response fields, set for type "tool_response".
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	Content    string `json:"content,omitempty"`
+}
+
+const (
+	partKindText         = "text"
+	partKindToolCall     = "tool_call"
+	partKindToolResponse = "tool_response"
+)
+
+// SaveTranscript persists the conversational turns of messages to
+// <dir>/transcript.json, atomically. The leading system message (and any other
+// system-role message) is omitted: a resume re-prepends a freshly built system
+// prompt, which may legitimately differ between runs. A nil/empty slice writes
+// nothing. Best-effort errors are returned to the caller, which logs them.
+func SaveTranscript(dir string, messages []llms.MessageContent) error {
+	if dir == "" {
+		return errors.New("transcript: empty session dir")
+	}
+	out := make([]transcriptMessage, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == llms.ChatMessageTypeSystem {
+			continue
+		}
+		parts := encodeParts(msg.Parts)
+		if len(parts) == 0 {
+			continue
+		}
+		out = append(out, transcriptMessage{Role: string(msg.Role), Parts: parts})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("transcript: marshal: %w", err)
+	}
+	final := filepath.Join(dir, TranscriptFile)
+	tmpFile, err := os.CreateTemp(dir, ".transcript-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("transcript: create temp: %w", err)
+	}
+	tmp := tmpFile.Name()
+	if _, werr := tmpFile.Write(data); werr != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: write: %w", werr)
+	}
+	if cerr := tmpFile.Close(); cerr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: close: %w", cerr)
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: chmod: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: rename: %w", err)
+	}
+	return nil
+}
+
+// LoadTranscript reads <dir>/transcript.json and rebuilds the message slice.
+// A missing file is not an error — it returns (nil, nil), which the caller
+// treats as "no prior context to replay".
+func LoadTranscript(dir string) ([]llms.MessageContent, error) {
+	data, err := os.ReadFile(filepath.Join(dir, TranscriptFile))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("transcript: read: %w", err)
+	}
+	var stored []transcriptMessage
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, fmt.Errorf("transcript: parse: %w", err)
+	}
+	messages := make([]llms.MessageContent, 0, len(stored))
+	for _, sm := range stored {
+		messages = append(messages, llms.MessageContent{
+			Role:  llms.ChatMessageType(sm.Role),
+			Parts: decodeParts(sm.Parts),
+		})
+	}
+	return messages, nil
+}
+
+// encodeParts normalizes content parts into their on-disk form, unwrapping
+// cache-control hints (an optimization that need not survive a replay).
+func encodeParts(parts []llms.ContentPart) []transcriptPart {
+	out := make([]transcriptPart, 0, len(parts))
+	for _, part := range parts {
+		if cached, ok := part.(llms.CachedContent); ok {
+			part = cached.ContentPart
+		}
+		switch p := part.(type) {
+		case llms.TextContent:
+			out = append(out, transcriptPart{Type: partKindText, Text: p.Text})
+		case llms.ToolCall:
+			tp := transcriptPart{Type: partKindToolCall, ID: p.ID, ToolType: p.Type}
+			if p.FunctionCall != nil {
+				tp.Name = p.FunctionCall.Name
+				tp.Args = p.FunctionCall.Arguments
+			}
+			out = append(out, tp)
+		case llms.ToolCallResponse:
+			out = append(out, transcriptPart{
+				Type:       partKindToolResponse,
+				ToolCallID: p.ToolCallID,
+				Name:       p.Name,
+				Content:    p.Content,
+			})
+		default:
+			// Image/binary parts are not produced by the tool loop; skip them
+			// rather than guess at a lossy encoding.
+		}
+	}
+	return out
+}
+
+// decodeParts rebuilds content parts from their on-disk form.
+func decodeParts(parts []transcriptPart) []llms.ContentPart {
+	out := make([]llms.ContentPart, 0, len(parts))
+	for _, p := range parts {
+		switch p.Type {
+		case partKindText:
+			out = append(out, llms.TextContent{Text: p.Text})
+		case partKindToolCall:
+			out = append(out, llms.ToolCall{
+				ID:           p.ID,
+				Type:         p.ToolType,
+				FunctionCall: &llms.FunctionCall{Name: p.Name, Arguments: p.Args},
+			})
+		case partKindToolResponse:
+			out = append(out, llms.ToolCallResponse{
+				ToolCallID: p.ToolCallID,
+				Name:       p.Name,
+				Content:    p.Content,
+			})
+		}
+	}
+	return out
+}
+
+// splicePriorMessages inserts replayed prior turns between the freshly built
+// system message and the new user prompt, yielding
+// [system?, ...prior, newUser] — the order stateless provider APIs expect.
+func splicePriorMessages(initial, prior []llms.MessageContent) []llms.MessageContent {
+	if len(prior) == 0 {
+		return initial
+	}
+	if len(initial) == 0 {
+		return prior
+	}
+	last := initial[len(initial)-1]
+	head := initial[:len(initial)-1]
+	out := make([]llms.MessageContent, 0, len(initial)+len(prior))
+	out = append(out, head...)
+	out = append(out, prior...)
+	out = append(out, last)
+	return out
+}
+
+// persistTranscript saves the conversation for the active session, if any. It
+// is best-effort: a failure is logged but never fails the run, since the
+// transcript only affects a future --resume.
+func persistTranscript(ctx context.Context, messages []llms.MessageContent) {
+	logger := session.FromContext(ctx)
+	if logger == nil {
+		return
+	}
+	if err := SaveTranscript(logger.Dir(), messages); err != nil {
+		logging.Warn("failed to persist resume transcript: %v", err)
+	}
+}

--- a/tools/transcript.go
+++ b/tools/transcript.go
@@ -13,11 +13,10 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
-// TranscriptFile is the per-session file holding the full, provider-faithful
-// conversation for the LangChain (stateless-provider) path. Unlike
-// events.jsonl — which is a lossy audit log of metadata — this file stores the
-// actual message content so a --resume can replay the prior turns. The OpenAI
-// Responses API does not need it: it chains server-side via PreviousResponseID.
+// TranscriptFile holds the full conversation for the stateless (LangChain)
+// path so a --resume can replay it. Unlike the lossy events.jsonl audit log,
+// it stores actual message content. The Responses API chains server-side and
+// does not use it.
 const TranscriptFile = "transcript.json"
 
 // transcriptMessage is the on-disk form of one llms.MessageContent. The role is

--- a/tools/transcript.go
+++ b/tools/transcript.go
@@ -78,30 +78,9 @@ func SaveTranscript(dir string, messages []llms.MessageContent) error {
 	if err != nil {
 		return fmt.Errorf("transcript: marshal: %w", err)
 	}
-	final := filepath.Join(dir, TranscriptFile)
-	tmpFile, err := os.CreateTemp(dir, ".transcript-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("transcript: create temp: %w", err)
-	}
-	tmp := tmpFile.Name()
-	if _, werr := tmpFile.Write(data); werr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmp)
-		return fmt.Errorf("transcript: write: %w", werr)
-	}
-	if cerr := tmpFile.Close(); cerr != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("transcript: close: %w", cerr)
-	}
-	if err := os.Chmod(tmp, 0o600); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("transcript: chmod: %w", err)
-	}
-	if err := os.Rename(tmp, final); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("transcript: rename: %w", err)
-	}
-	return nil
+	// Atomic temp-file + rename so a concurrent reader never sees a partial
+	// transcript. The IO half lives in atomicWriteTranscript (transcript_io.go).
+	return atomicWriteTranscript(dir, filepath.Join(dir, TranscriptFile), data)
 }
 
 // LoadTranscript reads <dir>/transcript.json and rebuilds the message slice.

--- a/tools/transcript_io.go
+++ b/tools/transcript_io.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+)
+
+// This file holds the atomic-write IO half of transcript persistence: temp
+// file + rename. It is isolated here (and ignored by codecov) because every
+// uncovered branch is an os.CreateTemp / Write / Chmod / Rename error path that
+// would need fault injection on the os package to exercise. The encode/marshal
+// half stays in transcript.go and the happy-path round-trip is covered by
+// transcript_test.go.
+
+// atomicWriteTranscript writes data to final via a randomly-named temp file in
+// dir followed by os.Rename, so a resuming reader never loads a partial
+// transcript. The random temp name (CWE-377) avoids the symlink/TOCTOU race a
+// fixed "<final>.tmp" path would invite.
+func atomicWriteTranscript(dir, final string, data []byte) error {
+	tmpFile, err := os.CreateTemp(dir, ".transcript-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("transcript: create temp: %w", err)
+	}
+	tmp := tmpFile.Name()
+	if _, werr := tmpFile.Write(data); werr != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: write: %w", werr)
+	}
+	if cerr := tmpFile.Close(); cerr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: close: %w", cerr)
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: chmod: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("transcript: rename: %w", err)
+	}
+	return nil
+}

--- a/tools/transcript_io.go
+++ b/tools/transcript_io.go
@@ -5,17 +5,12 @@ import (
 	"os"
 )
 
-// This file holds the atomic-write IO half of transcript persistence: temp
-// file + rename. It is isolated here (and ignored by codecov) because every
-// uncovered branch is an os.CreateTemp / Write / Chmod / Rename error path that
-// would need fault injection on the os package to exercise. The encode/marshal
-// half stays in transcript.go and the happy-path round-trip is covered by
-// transcript_test.go.
+// The atomic-write IO half lives here; codecov ignores this file because its
+// only uncovered branches are os.* failure paths that need fault injection.
 
-// atomicWriteTranscript writes data to final via a randomly-named temp file in
-// dir followed by os.Rename, so a resuming reader never loads a partial
-// transcript. The random temp name (CWE-377) avoids the symlink/TOCTOU race a
-// fixed "<final>.tmp" path would invite.
+// atomicWriteTranscript writes data to final via a random-named temp file in
+// dir then os.Rename. The random name avoids the TOCTOU race a fixed
+// "<final>.tmp" would invite (CWE-377).
 func atomicWriteTranscript(dir, final string, data []byte) error {
 	tmpFile, err := os.CreateTemp(dir, ".transcript-*.json.tmp")
 	if err != nil {

--- a/tools/transcript_test.go
+++ b/tools/transcript_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cowdogmoo/squad/executor"
 	"github.com/cowdogmoo/squad/session"
 	"github.com/tmc/langchaingo/llms"
 )
@@ -141,4 +142,119 @@ func TestPersistTranscriptWritesForActiveSession(t *testing.T) {
 func TestPersistTranscriptNoLoggerIsNoop(t *testing.T) {
 	// Must not panic when no session logger is attached to the context.
 	persistTranscript(context.Background(), sampleConversation())
+}
+
+func TestPersistTranscriptSwallowsWriteFailure(t *testing.T) {
+	t.Parallel()
+	logger, err := session.New(t.TempDir(), "agent", "anthropic", "claude", "prompt")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+	// Removing the session dir makes the atomic write fail; persistTranscript
+	// must log and return, never panic or propagate.
+	if err := os.RemoveAll(logger.Dir()); err != nil {
+		t.Fatalf("rm session dir: %v", err)
+	}
+	persistTranscript(session.WithLogger(context.Background(), logger), sampleConversation())
+}
+
+func TestSaveTranscriptEmptyDirErrors(t *testing.T) {
+	t.Parallel()
+	if err := SaveTranscript("", sampleConversation()); err == nil {
+		t.Fatal("expected an error for an empty session dir")
+	}
+}
+
+func TestLoadTranscriptCorruptFileErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, TranscriptFile), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt transcript: %v", err)
+	}
+	if _, err := LoadTranscript(dir); err == nil {
+		t.Fatal("expected a parse error for a corrupt transcript")
+	}
+}
+
+func TestLoadTranscriptReadErrorOnDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// A directory at the transcript path makes os.ReadFile fail with a
+	// non-NotExist error, which must surface rather than be swallowed.
+	if err := os.Mkdir(filepath.Join(dir, TranscriptFile), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := LoadTranscript(dir); err == nil {
+		t.Fatal("expected a read error when the transcript path is a directory")
+	}
+}
+
+func TestSaveTranscriptSkipsMessagesWithNoEncodableParts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	msgs := []llms.MessageContent{
+		{Role: llms.ChatMessageTypeHuman, Parts: nil}, // nothing to encode -> skipped
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextContent{Text: "kept"}}},
+	}
+	if err := SaveTranscript(dir, msgs); err != nil {
+		t.Fatalf("SaveTranscript: %v", err)
+	}
+	got, err := LoadTranscript(dir)
+	if err != nil {
+		t.Fatalf("LoadTranscript: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected the empty-parts message to be skipped, got %d messages", len(got))
+	}
+}
+
+func TestSplicePriorMessagesEmptyInitialReturnsPrior(t *testing.T) {
+	t.Parallel()
+	prior := []llms.MessageContent{{Role: llms.ChatMessageTypeHuman}}
+	if got := splicePriorMessages(nil, prior); !reflect.DeepEqual(got, prior) {
+		t.Fatalf("empty initial should return prior unchanged, got %#v", got)
+	}
+}
+
+// TestRunWithToolsReplaysAndPersists exercises the resume seam end-to-end with
+// a fake LLM: prior messages are spliced in, and the conversation is persisted
+// so a later --resume can reload it.
+func TestRunWithToolsReplaysAndPersists(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logger, err := session.New(dir, "agent", "anthropic", "claude", "prompt")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+	ctx := session.WithLogger(context.Background(), logger)
+
+	llm := &fakeLLM{responses: []*llms.ContentResponse{
+		{Choices: []*llms.ContentChoice{{Content: "done"}}},
+	}}
+	prior := []llms.MessageContent{
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "earlier"}}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextContent{Text: "earlier answer"}}},
+	}
+	out, err := RunWithTools(ctx, llm, "sys", "new question", dir, RunWithToolsConfig{
+		MaxIterations: 1,
+		Executor:      &executor.LocalExecutor{WorkingDir: dir},
+		PriorMessages: prior,
+	})
+	if err != nil {
+		t.Fatalf("RunWithTools() error = %v", err)
+	}
+	if out != "done" {
+		t.Fatalf("output = %q, want done", out)
+	}
+
+	saved, err := LoadTranscript(logger.Dir())
+	if err != nil {
+		t.Fatalf("LoadTranscript: %v", err)
+	}
+	// Persisted = prior turns + the new user prompt (system is dropped).
+	if len(saved) < len(prior)+1 {
+		t.Fatalf("expected >= %d persisted messages, got %d", len(prior)+1, len(saved))
+	}
 }

--- a/tools/transcript_test.go
+++ b/tools/transcript_test.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cowdogmoo/squad/session"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// sampleConversation returns a representative slice covering every message
+// shape the tool loop produces: system, human, an assistant turn with a tool
+// call plus trailing text, the tool result, and a final assistant answer.
+func sampleConversation() []llms.MessageContent {
+	return []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextContent{Text: "you are a helper"}}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "list the files"}}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{
+			llms.ToolCall{ID: "call-1", Type: "function", FunctionCall: &llms.FunctionCall{Name: "Bash", Arguments: `{"command":"ls"}`}},
+			llms.TextContent{Text: "running ls"},
+		}},
+		{Role: llms.ChatMessageTypeTool, Parts: []llms.ContentPart{
+			llms.ToolCallResponse{ToolCallID: "call-1", Name: "Bash", Content: "a.go\nb.go"},
+		}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextContent{Text: "there are two files"}}},
+	}
+}
+
+func TestSaveLoadTranscriptRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveTranscript(dir, sampleConversation()); err != nil {
+		t.Fatalf("SaveTranscript: %v", err)
+	}
+
+	got, err := LoadTranscript(dir)
+	if err != nil {
+		t.Fatalf("LoadTranscript: %v", err)
+	}
+
+	// The system message is intentionally dropped; everything after it must
+	// round-trip exactly so a stateless provider accepts the replayed history.
+	want := sampleConversation()[1:]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round-trip mismatch:\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestSaveTranscriptDropsSystemAndSkipsWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	systemOnly := []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextContent{Text: "sys"}}},
+	}
+	if err := SaveTranscript(dir, systemOnly); err != nil {
+		t.Fatalf("SaveTranscript: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, TranscriptFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected no transcript file for system-only conversation, stat err=%v", err)
+	}
+}
+
+func TestLoadTranscriptMissingFileIsNotError(t *testing.T) {
+	got, err := LoadTranscript(t.TempDir())
+	if err != nil {
+		t.Fatalf("expected nil error for missing transcript, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil messages for missing transcript, got %#v", got)
+	}
+}
+
+func TestEncodePartsUnwrapsCacheControl(t *testing.T) {
+	wrapped := llms.WithCacheControl(llms.TextContent{Text: "cached"}, &llms.CacheControl{Type: "ephemeral"})
+	parts := encodeParts([]llms.ContentPart{wrapped})
+	if len(parts) != 1 || parts[0].Type != partKindText || parts[0].Text != "cached" {
+		t.Fatalf("cache-control wrapper not unwrapped to text: %#v", parts)
+	}
+}
+
+func TestSplicePriorMessagesOrdering(t *testing.T) {
+	initial := []llms.MessageContent{
+		{Role: llms.ChatMessageTypeSystem, Parts: []llms.ContentPart{llms.TextContent{Text: "sys"}}},
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "new question"}}},
+	}
+	prior := []llms.MessageContent{
+		{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "old question"}}},
+		{Role: llms.ChatMessageTypeAI, Parts: []llms.ContentPart{llms.TextContent{Text: "old answer"}}},
+	}
+
+	got := splicePriorMessages(initial, prior)
+
+	wantRoles := []llms.ChatMessageType{
+		llms.ChatMessageTypeSystem,
+		llms.ChatMessageTypeHuman, // old question
+		llms.ChatMessageTypeAI,    // old answer
+		llms.ChatMessageTypeHuman, // new question (must stay last)
+	}
+	if len(got) != len(wantRoles) {
+		t.Fatalf("spliced length = %d, want %d", len(got), len(wantRoles))
+	}
+	for i, role := range wantRoles {
+		if got[i].Role != role {
+			t.Fatalf("position %d role = %q, want %q", i, got[i].Role, role)
+		}
+	}
+	last := got[len(got)-1]
+	if parts := encodeParts(last.Parts); len(parts) != 1 || parts[0].Text != "new question" {
+		t.Fatalf("new user prompt must remain the final message, got %#v", last)
+	}
+}
+
+func TestSplicePriorMessagesEmptyPriorReturnsInitial(t *testing.T) {
+	initial := []llms.MessageContent{{Role: llms.ChatMessageTypeHuman}}
+	if got := splicePriorMessages(initial, nil); !reflect.DeepEqual(got, initial) {
+		t.Fatalf("empty prior should return initial unchanged, got %#v", got)
+	}
+}
+
+func TestPersistTranscriptWritesForActiveSession(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := session.New(dir, "agent", "anthropic", "claude", "prompt")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	ctx := session.WithLogger(context.Background(), logger)
+	persistTranscript(ctx, sampleConversation())
+
+	got, err := LoadTranscript(logger.Dir())
+	if err != nil {
+		t.Fatalf("LoadTranscript: %v", err)
+	}
+	if len(got) != len(sampleConversation())-1 {
+		t.Fatalf("persisted %d messages, want %d", len(got), len(sampleConversation())-1)
+	}
+}
+
+func TestPersistTranscriptNoLoggerIsNoop(t *testing.T) {
+	// Must not panic when no session logger is attached to the context.
+	persistTranscript(context.Background(), sampleConversation())
+}


### PR DESCRIPTION
**Key Changes:**

- Introduced `transcript.json` persistence so stateless providers (Anthropic, openai-compat, gemini, ollama) can replay prior conversation turns on `--resume`, closing a silent context-loss bug
- Added `tools/transcript.go` with atomic save/load, part encoding/decoding, and message splicing logic
- Wired transcript loading and persistence into the LangChain call path via `loadResumeTranscript` and `persistTranscript`
- Updated observability docs to clearly distinguish the OpenAI Responses API (server-side chaining) from stateless providers (local transcript replay)

**Added:**

- Transcript persistence layer - New `tools/transcript.go` implements `SaveTranscript` and `LoadTranscript` for atomic, JSON-encoded round-trip storage of conversation turns; system messages are intentionally excluded so a resume always re-prepends a freshly built system prompt
- Message splicing - `splicePriorMessages` inserts replayed prior turns between the system message and the new user prompt, producing the `[system?, ...prior, newUser]` ordering stateless provider APIs expect
- `PriorMessages` field on `RunWithToolsConfig` - carries replayed turns into `RunWithTools`, where they are spliced into the initial message list before the tool loop begins
- `loadResumeTranscript` helper in `runner/model.go` - loads the prior transcript for `--resume` runs on the LangChain path, warning (rather than silently proceeding context-free) when no replayable transcript is found
- Comprehensive test coverage in `tools/transcript_test.go` covering round-trip save/load, system message exclusion, missing-file handling, cache-control unwrapping, splice ordering, and no-op behavior when no session logger is present

**Changed:**

- `RunWithTools` in `tools/tools.go` - now splices prior messages when `PriorMessages` is non-nil and calls `persistTranscript` after every exit path (completion, error, iteration cap) so the accumulated conversation is always written
- Observability documentation - clarified that `--resume` on the OpenAI Responses path chains server-side via `PreviousResponseID`, while all other providers replay a locally persisted `transcript.json`; noted that `events.jsonl` is a lossy audit log not used for replay