### PR TITLE
ci: migrate renovate config to .github/renovate.json5 and add gomodTidy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,27 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+    ':automergeDigest',
+    ':automergeMinor',
+  ],
+  postUpdateOptions: [
+    'gomodTidy',
+  ],
+  packageRules: [
+    {
+      matchManagers: [
+        'github-actions',
+      ],
+      automerge: true,
+    },
+    {
+      matchUpdateTypes: [
+        'digest',
+        'pin',
+        'patch',
+      ],
+      automerge: true,
+    },
+  ],
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":automergeDigest", ":automergeMinor"],
-  "packageRules": [
-    { "matchManagers": ["github-actions"], "automerge": true },
-    { "matchUpdateTypes": ["digest", "pin", "patch"], "automerge": true }
-  ]
-}


### PR DESCRIPTION
**Key Changes:**

- Migrated the Renovate config from root `renovate.json` to `.github/renovate.json5`, the idiomatic location that the existing Renovate workflow trigger already watches
- Added the `gomodTidy` post-update option so Renovate runs `go mod tidy` on its branches, keeping `go.mod`/`go.sum` tidy after dependency bumps

**Why:**

Renovate Go-module PRs were failing the `go-mod-tidy` pre-commit check in CI. Renovate edited `go.mod`/`go.sum` but never tidied them, so stale entries survived into the PR; CI then tidied the files, saw a diff, and failed (see PR #98). `gomodTidy` makes Renovate tidy the branch itself.

Separately, the workflow `paths` trigger watched `.github/renovate.json5`, a file that did not exist (config lived at root `renovate.json`), so config edits never triggered the workflow. Moving the config to `.github/renovate.json5` fixes that mismatch.

**Changed:**

- Added `.github/renovate.json5` with the same rules as before plus `postUpdateOptions: ["gomodTidy"]`
- Removed root-level `renovate.json` (root config takes precedence over `.github/`, so both could not coexist)

**Note:** existing open Renovate PRs (e.g. #98) need a rebase after this merges to pick up a tidy `go.sum`.