### PR TITLE
docs: tighten and consolidate inline code comments

### DIFF
--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -38,12 +38,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// buildRunAgentFunc creates the callback used by the pipeline runner to execute
-// individual agents. It handles agent resolution, bundle building, budget
-// propagation, and model invocation.
-// effectiveStageMode resolves the mode a composed sub-agent runs in. A
-// top-level `--mode readonly` overrides any per-stage mode so no stage can opt
-// back into edit mode; otherwise the stage's declared mode wins.
+// effectiveStageMode resolves a composed sub-agent's mode: a top-level
+// `--mode readonly` overrides any per-stage mode.
 func effectiveStageMode(topMode, stageMode string) string {
 	if topMode == "readonly" {
 		return "readonly"
@@ -51,6 +47,9 @@ func effectiveStageMode(topMode, stageMode string) string {
 	return stageMode
 }
 
+// buildRunAgentFunc creates the callback used by the pipeline runner to execute
+// individual agents. It handles agent resolution, bundle building, budget
+// propagation, and model invocation.
 func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentDir string, cfg *config.Config, vars map[string]string, pipelineRunner *pl.Runner) func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 	return func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 		mergedVars := mergeVars(vars, stageVars)
@@ -239,9 +238,6 @@ func buildComposedRunOpts(cmd *cobra.Command, cfg *config.Config) *runner.RunOpt
 		maxCost = 0
 	}
 
-	// The top-level --mode must reach sub-agents; buildRunAgentFunc forces
-	// each stage readonly when this is "readonly", overriding the per-stage
-	// mode declared in the manifest.
 	mode, _ := cmd.Flags().GetString("mode")
 
 	return &runner.RunOptions{

--- a/runner/composed.go
+++ b/runner/composed.go
@@ -8,12 +8,8 @@ import (
 )
 
 // ComposedFlags lists flags that are incompatible with composed agents.
-// Used by the run command to validate flag usage.
-//
-// `require-actionable` is intentionally absent: it is a leaf-only flag with no
-// effect on the pipeline path, so the composed runner tolerates (and ignores)
-// it rather than rejecting the run. This lets a single task definition pass
-// `--require-actionable` to both leaf and composed agents.
+// `require-actionable` is deliberately omitted: it is leaf-only and a no-op on
+// the pipeline path, so it is tolerated rather than rejected.
 var ComposedFlags = []string{
 	"system",
 	"print-bundle",

--- a/runner/model.go
+++ b/runner/model.go
@@ -129,8 +129,7 @@ func rehydrateSkillStack(rt *tools.SkillRuntime, workingDir string, logger *sess
 }
 
 // applyReadOnlyMode enables the readonly tool gate on ctx when mode is
-// "readonly", so the mutating file tools (Write/Edit/MultiEdit) are rejected
-// for the rest of the run. Any other mode returns ctx unchanged.
+// "readonly", and returns ctx unchanged otherwise.
 func applyReadOnlyMode(ctx context.Context, mode string) context.Context {
 	if mode != "readonly" {
 		return ctx
@@ -160,10 +159,8 @@ func InvokeModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (s
 	temperature := opts.Temperature
 	maxTokens := opts.MaxTokens
 
-	// Readonly mode hard-gates the mutating file tools. InvokeModel is the
-	// single chokepoint for both leaf runs and composed sub-agents (the
-	// pipeline runner dispatches each sub-agent through here), so this is
-	// honored even when a sub-agent's prompt does not branch on mode.
+	// InvokeModel is the single chokepoint for both leaf and composed
+	// sub-agent runs, so readonly enforcement applies uniformly here.
 	ctx = applyReadOnlyMode(ctx, opts.Mode)
 
 	// Create metrics early so partial cost is always available, even if

--- a/tools/readonlyguard.go
+++ b/tools/readonlyguard.go
@@ -4,12 +4,10 @@ import "context"
 
 type readOnlyKeyType struct{}
 
-// InitReadOnlyMode marks ctx as read-only. While set, the mutating file tools
-// (Write, Edit, MultiEdit) are denied before their handlers run, so an agent
-// invoked with `--mode readonly` cannot modify the working tree regardless of
-// what its prompt instructs. This is the hard backstop behind readonly mode:
-// prompt wording alone is not enough, since a prompt that omits the
-// edit-mode conditional would otherwise let the model apply changes.
+// InitReadOnlyMode marks ctx as read-only, denying the mutating file tools
+// (Write, Edit, MultiEdit) before their handlers run. This is the hard backstop
+// behind `--mode readonly`: it holds even when an agent's prompt omits the
+// edit-mode conditional and asks the model to apply changes.
 func InitReadOnlyMode(ctx context.Context) context.Context {
 	return context.WithValue(ctx, readOnlyKeyType{}, true)
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1097,9 +1097,6 @@ func executeToolCall(ctx context.Context, toolCall llms.ToolCall, handlers map[s
 		return toolResponse
 	}
 
-	// Readonly mode is a hard gate: deny the mutating file tools before the
-	// handler runs so an analysis-only run cannot modify the working tree,
-	// regardless of whether the agent's prompt honors the mode.
 	if IsReadOnlyMode(ctx) && IsMutatingTool(toolName) {
 		toolResponse.Name = toolName
 		toolResponse.Content = fmt.Sprintf("error: %s is not permitted in readonly mode (this run is analysis-only and must not modify files)", toolName)


### PR DESCRIPTION
**Key Changes:**

- Relocated misplaced comment block so `buildRunAgentFunc` doc sits directly above its function declaration
- Condensed verbose inline explanations across multiple files into shorter, precise summaries
- Removed redundant inline comments where the code itself is self-explanatory

**Changed:**

- Comment placement and wording for `effectiveStageMode` and `buildRunAgentFunc` - separated the two doc comments that were merged together and moved `buildRunAgentFunc`'s comment to sit immediately above its definition in `cmd/squad/pipeline.go`
- `ComposedFlags` doc comment - condensed the explanation of why `require-actionable` is omitted into a single concise sentence in `runner/composed.go`
- `applyReadOnlyMode` and `InvokeModel` comments - shortened multi-line explanations to tighter single-line summaries in `runner/model.go`
- `InitReadOnlyMode` doc comment - reworded to be more direct while preserving the key detail that the hard backstop holds even when an agent's prompt omits the edit-mode conditional in `tools/readonlyguard.go`

**Removed:**

- Redundant inline comment above the readonly gate check in `executeToolCall` - the surrounding code and `InitReadOnlyMode` doc already convey the same intent in `tools/tools.go`
- Inline comment explaining `--mode` flag propagation in `buildComposedRunOpts` - removed as the behavior is sufficiently documented elsewhere in `cmd/squad/pipeline.go`