### PR TITLE
chore: update markdownlint-cli pre-commit hook to v0.49.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: shfmt
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         args: ["--fix", "--config", ".hooks/linters/markdownlint.json"]


### PR DESCRIPTION
**Key Changes:**

- Bumped markdownlint-cli dependency to the latest version in pre-commit configuration

**Changed:**

- markdownlint-cli version - Updated `markdownlint-cli` pre-commit hook from `v0.48.0` to `v0.49.0` in `.pre-commit-config.yaml`