### PR TITLE
chore: enable renovate pre-commit hook management and simplify workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,14 @@
     'config:recommended',
     ':automergeDigest',
     ':automergeMinor',
+    ':enablePreCommit',
   ],
   postUpdateOptions: [
     'gomodTidy',
   ],
+  'pre-commit': {
+    enabled: true,
+  },
   packageRules: [
     {
       matchManagers: [

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   pre-commit:
-    name: Update pre-commit hooks and run pre-commit
+    name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git repository
@@ -102,4 +102,4 @@ jobs:
 
       - name: Run pre-commit
         run: |
-          task -y pre-commit:run-pre-commit
+          task -y pre-commit:run-hooks


### PR DESCRIPTION
**Key Changes:**

- Enabled Renovate to automatically manage and update pre-commit hook versions
- Simplified the pre-commit workflow job name and task command to better reflect its purpose

**Changed:**

- Renovate configuration - Added `:enablePreCommit` preset and `pre-commit.enabled: true` to allow Renovate to manage pre-commit hook dependencies automatically in `.github/renovate.json5`
- Pre-commit workflow - Renamed job from "Update pre-commit hooks and run pre-commit" to "Run pre-commit" and updated task invocation from `pre-commit:run-pre-commit` to `pre-commit:run-hooks` for clarity in `.github/workflows/pre-commit.yaml`