### PR TITLE
feat: expand transient network error patterns for langchaingo sanitization

### DIFF
--- a/tools/retry.go
+++ b/tools/retry.go
@@ -51,13 +51,25 @@ var errorMappings = []errorMapping{
 }
 
 // transientNetworkPatterns are substrings of raw error messages that indicate
-// transient network-level failures worth retrying.
+// transient network-level failures worth retrying. The first group covers raw
+// net errors; the second covers the generic strings langchaingo's OpenAI client
+// substitutes for them in sanitizeHTTPError (which discards the underlying
+// "connection refused" etc. before we ever see it).
 var transientNetworkPatterns = []string{
 	"connection reset",
 	"connection refused",
+	"connection timed out",
 	"broken pipe",
 	"eof",
 	"temporary failure",
+	"no such host",
+	"i/o timeout",
+	"network is unreachable",
+	"tls handshake",
+	// langchaingo sanitizeHTTPError replacements:
+	"network error",   // "network error: failed to reach API server"
+	"failed to reach", // belt-and-suspenders for the same message
+	"request timeout", // "request timeout: ..." (deadline or net timeout)
 }
 
 // classifyError extracts or infers an llms.Error from any error.

--- a/tools/retry_test.go
+++ b/tools/retry_test.go
@@ -71,6 +71,15 @@ func TestIsRetryable(t *testing.T) {
 		{"connection reset", errors.New("connection reset by peer"), true},
 		{"broken pipe", errors.New("broken pipe"), true},
 		{"eof", errors.New("unexpected eof"), true},
+		// langchaingo sanitizeHTTPError strips the underlying net error, so we
+		// must recognize its generic substitutes as transient.
+		{"sanitized network error", errors.New("network error: failed to reach API server"), true},
+		{"sanitized net timeout", errors.New("request timeout: network operation exceeded timeout"), true},
+		{"sanitized deadline", errors.New("request timeout: API call exceeded deadline"), true},
+		{"dial no such host", errors.New("dial tcp: lookup api.host: no such host"), true},
+		{"i/o timeout", errors.New("read tcp: i/o timeout"), true},
+		// "request cancelled" is the sanitized ctx-cancel message and must stay fatal.
+		{"sanitized cancelled", errors.New("request cancelled"), false},
 		{"unknown random", errors.New("some unknown error"), false},
 	}
 


### PR DESCRIPTION
**Key Changes:**

- Added recognition of langchaingo's sanitized error strings that replace underlying net errors before they reach retry logic
- Expanded transient network pattern list with additional low-level error types that were previously unhandled
- Added test coverage for sanitized error messages, ensuring cancellation errors remain non-retryable

**Added:**

- New transient network patterns - Added `"connection timed out"`, `"no such host"`, `"i/o timeout"`, `"network is unreachable"`, and `"tls handshake"` to cover low-level net failures not previously matched in `retry.go`
- langchaingo sanitized error patterns - Added `"network error"`, `"failed to reach"`, and `"request timeout"` to handle the generic strings langchaingo's `sanitizeHTTPError` substitutes for underlying connection errors before they reach the retry classifier
- Test cases for sanitized errors - Added coverage in `retry_test.go` for `"network error: failed to reach API server"`, `"request timeout: ..."` variants, `"dial tcp: lookup ... no such host"`, and `"read tcp: i/o timeout"`, plus an explicit assertion that `"request cancelled"` remains fatal

**Changed:**

- Comment on `transientNetworkPatterns` - Expanded inline documentation to explain that the pattern list covers both raw net errors and the sanitized substitutes langchaingo produces via `sanitizeHTTPError`, clarifying why certain generic strings must be matched