### PR TITLE
feat: migrate session storage to XDG_STATE_HOME with repo-scoped listing

### DIFF
--- a/cmd/squad/root.go
+++ b/cmd/squad/root.go
@@ -70,6 +70,7 @@ Define an agent in markdown and YAML, point it at any LLM, and turn it loose on 
 	rootCmd.AddCommand(newGradeCmd())
 	rootCmd.AddCommand(agentsCmd)
 	rootCmd.AddCommand(newUICmd())
+	rootCmd.AddCommand(sessionsCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(newRoutineCmd())

--- a/cmd/squad/sessions.go
+++ b/cmd/squad/sessions.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cowdogmoo/squad/runner"
+	"github.com/cowdogmoo/squad/session"
+	"github.com/spf13/cobra"
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:     "sessions",
+	Aliases: []string{"session"},
+	Short:   "List sessions for the current repository",
+	Long: "List squad sessions for the current repository. Sessions live under " +
+		"$XDG_STATE_HOME/squad/sessions, so this is the way to find them.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoPath, err := currentRepoPath()
+		if err != nil {
+			return err
+		}
+
+		sessions, err := session.List(repoPath)
+		if err != nil {
+			return err
+		}
+		if len(sessions) == 0 {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "No sessions found for this repository.")
+			return err
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "ID\tSTATUS\tCREATED\tWORKTREE")
+		for _, s := range sessions {
+			wt := s.WorktreePath
+			if wt != "" && strings.HasPrefix(wt, repoPath) {
+				if rel, err := filepath.Rel(repoPath, wt); err == nil {
+					wt = rel
+				}
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.SessionID, s.Status, s.Timestamp, wt)
+		}
+		return w.Flush()
+	},
+}
+
+var openSessionCmd = &cobra.Command{
+	Use:   "open [id]",
+	Short: "Print the directory of a session",
+	Long:  "Print the on-disk directory of a session. With no id, the latest session is used.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoPath, err := currentRepoPath()
+		if err != nil {
+			return err
+		}
+
+		id := ""
+		if len(args) > 0 {
+			id = args[0]
+		}
+		if id == "" {
+			sessions, err := session.List(repoPath)
+			if err != nil {
+				return err
+			}
+			if len(sessions) == 0 {
+				return fmt.Errorf("no sessions found for %s", repoPath)
+			}
+			id = sessions[0].SessionID
+		}
+
+		dir := session.ResolveDir(repoPath, id)
+		if _, err := os.Stat(filepath.Join(dir, "meta.json")); err != nil {
+			return fmt.Errorf("session %q not found", id)
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), dir)
+		return err
+	},
+}
+
+// currentRepoPath resolves the canonical repository path for the working
+// directory, mirroring how runs record their canonical path.
+func currentRepoPath() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return runner.ResolveGitToplevel(wd), nil
+}
+
+func init() {
+	sessionsCmd.AddCommand(openSessionCmd)
+}

--- a/cmd/squad/sessions_test.go
+++ b/cmd/squad/sessions_test.go
@@ -91,4 +91,68 @@ func TestSessionsCmdEmpty(t *testing.T) {
 	if !strings.Contains(out, "No sessions found") {
 		t.Fatalf("expected empty message, got:\n%s", out)
 	}
+
+	// `open` with no sessions is an error.
+	if _, err := runSessionsSubcmd(t, openSessionCmd, nil); err == nil {
+		t.Fatal("expected error opening latest with no sessions")
+	}
+}
+
+func TestSessionsCmdOpenByIDAndNotFound(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	t.Chdir(repo)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	l, err := session.New(wd, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	id := l.SessionID()
+	dir := l.Dir()
+	_ = l.Close()
+
+	// Open by explicit id prints the directory.
+	out, err := runSessionsSubcmd(t, openSessionCmd, []string{id})
+	if err != nil {
+		t.Fatalf("open %s: %v", id, err)
+	}
+	if got := strings.TrimSpace(out); got != dir {
+		t.Fatalf("open %s printed %q, want %q", id, got, dir)
+	}
+
+	// Unknown id is an error.
+	if _, err := runSessionsSubcmd(t, openSessionCmd, []string{"no-such-id"}); err == nil {
+		t.Fatal("expected error opening unknown session id")
+	}
+}
+
+func TestSessionsCmdRendersWorktreeColumn(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	t.Chdir(repo)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	// A session whose worktree lives under the repo: the listing shows the
+	// path relative to the repo.
+	worktree := filepath.Join(wd, "wt-1")
+	l, err := session.New(wd, worktree, "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	_ = l.Close()
+
+	out, err := runSessionsSubcmd(t, sessionsCmd, nil)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if !strings.Contains(out, "wt-1") {
+		t.Fatalf("expected relative worktree path in listing:\n%s", out)
+	}
 }

--- a/cmd/squad/sessions_test.go
+++ b/cmd/squad/sessions_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/session"
+	"github.com/spf13/cobra"
+)
+
+// runSessionsSubcmd invokes a sessions subcommand's RunE and returns its
+// captured output.
+func runSessionsSubcmd(t *testing.T, cmd *cobra.Command, args []string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	err := cmd.RunE(cmd, args)
+	return buf.String(), err
+}
+
+func TestSessionsCmdListsAndOpensWithoutMutating(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	t.Chdir(repo)
+
+	// Not a git repo, so the canonical path is the working dir itself.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	l, err := session.New(wd, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	l.Finish(session.StatusCompleted, "")
+	id := l.SessionID()
+	dir := l.Dir()
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// `sessions` lists the session for this repo.
+	out, err := runSessionsSubcmd(t, sessionsCmd, nil)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if !strings.Contains(out, id) {
+		t.Fatalf("session list missing id %q:\n%s", id, out)
+	}
+
+	// `sessions open` (no arg) prints the latest session's directory.
+	out, err = runSessionsSubcmd(t, openSessionCmd, nil)
+	if err != nil {
+		t.Fatalf("sessions open: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != dir {
+		t.Fatalf("open printed %q, want %q", got, dir)
+	}
+
+	// Critically, `open` must NOT reopen the session and flip its status back
+	// to running.
+	metaBytes, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	var meta struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		t.Fatalf("unmarshal meta: %v", err)
+	}
+	if meta.Status != session.StatusCompleted {
+		t.Errorf("open mutated session status to %q, want %q", meta.Status, session.StatusCompleted)
+	}
+}
+
+func TestSessionsCmdEmpty(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	out, err := runSessionsSubcmd(t, sessionsCmd, nil)
+	if err != nil {
+		t.Fatalf("sessions: %v", err)
+	}
+	if !strings.Contains(out, "No sessions found") {
+		t.Fatalf("expected empty message, got:\n%s", out)
+	}
+}

--- a/config/xdg.go
+++ b/config/xdg.go
@@ -48,6 +48,16 @@ func getCacheHome() string {
 	return ""
 }
 
+func getStateHome() string {
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return stateHome
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".local", "state")
+	}
+	return ""
+}
+
 // GetConfigDirs returns all config directories to search in priority order.
 func GetConfigDirs() []string {
 	return getConfigDirs()
@@ -151,4 +161,30 @@ func SkillsCacheDir() (string, error) {
 	}
 
 	return cacheDir, nil
+}
+
+// StateDir returns the squad state directory (e.g., ~/.local/state/squad).
+func StateDir() string {
+	stateHome := getStateHome()
+	if stateHome == "" {
+		return ""
+	}
+	return filepath.Join(stateHome, "squad")
+}
+
+// StateFile returns the path for a state file, creating directories as needed.
+func StateFile(filename string) (string, error) {
+	stateHome := getStateHome()
+	if stateHome == "" {
+		return "", os.ErrNotExist
+	}
+
+	statePath := filepath.Join(stateHome, "squad", filename)
+	stateDir := filepath.Dir(statePath)
+
+	if err := os.MkdirAll(stateDir, DirPermReadWriteExec); err != nil {
+		return "", err
+	}
+
+	return statePath, nil
 }

--- a/config/xdg_test.go
+++ b/config/xdg_test.go
@@ -273,3 +273,52 @@ func TestCacheDirWithEnv(t *testing.T) {
 		t.Fatalf("CacheDir=%q, want %q", got, filepath.Join(base, "cache", "squad"))
 	}
 }
+
+func TestStateDirWithEnv(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+	if got := StateDir(); got != filepath.Join(base, "state", "squad") {
+		t.Fatalf("StateDir=%q, want %q", got, filepath.Join(base, "state", "squad"))
+	}
+}
+
+func TestStateDirFallsBackToHomeLocalState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", home)
+	if got, want := StateDir(), filepath.Join(home, ".local", "state", "squad"); got != want {
+		t.Fatalf("StateDir=%q, want %q", got, want)
+	}
+}
+
+func TestStateDirEmptyEnv(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	if got := StateDir(); got != "" {
+		t.Fatalf("expected empty state dir, got %q", got)
+	}
+}
+
+func TestStateFileCreatesPath(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+
+	got, err := StateFile("index.jsonl")
+	if err != nil {
+		t.Fatalf("StateFile: %v", err)
+	}
+	if want := filepath.Join(base, "state", "squad", "index.jsonl"); got != want {
+		t.Fatalf("StateFile path=%q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Dir(got)); err != nil {
+		t.Fatalf("state dir not created: %v", err)
+	}
+}
+
+func TestStateFileNoHomeErrors(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	if _, err := StateFile("index.jsonl"); err == nil {
+		t.Fatalf("expected error when no state home is available")
+	}
+}

--- a/config/xdg_test.go
+++ b/config/xdg_test.go
@@ -322,3 +322,15 @@ func TestStateFileNoHomeErrors(t *testing.T) {
 		t.Fatalf("expected error when no state home is available")
 	}
 }
+
+func TestStateFileMkdirError(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// State home under a regular file: MkdirAll for the squad subdir fails.
+	t.Setenv("XDG_STATE_HOME", blocked)
+	if _, err := StateFile("index.jsonl"); err == nil {
+		t.Fatalf("expected mkdir error when state dir cannot be created")
+	}
+}

--- a/responses/helpers_test.go
+++ b/responses/helpers_test.go
@@ -54,8 +54,9 @@ func TestLogEventNilLoggerNoop(t *testing.T) {
 }
 
 func TestLogEventWritesToSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, err := session.New(wd, "a", "p", "m", "")
+	l, err := session.New(wd, "", "a", "p", "m", "")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -77,8 +78,9 @@ func TestRecordResponseNilSafe(t *testing.T) {
 	recordResponse(nil, nil, "label")
 	recordResponse(nil, &oairesponses.Response{ID: "x"}, "label")
 
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, err := session.New(wd, "a", "p", "m", "")
+	l, err := session.New(wd, "", "a", "p", "m", "")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -87,8 +89,9 @@ func TestRecordResponseNilSafe(t *testing.T) {
 }
 
 func TestRecordResponseSetsLastIDAndAppends(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, err := session.New(wd, "a", "p", "m", "")
+	l, err := session.New(wd, "", "a", "p", "m", "")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}

--- a/responses/large_result_test.go
+++ b/responses/large_result_test.go
@@ -24,8 +24,9 @@ func TestRegisterLargeResultToolIsIdempotent(t *testing.T) {
 }
 
 func TestGetToolResultPagesContent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, err := session.New(wd, "agent", "openai", "gpt-5", "")
+	l, err := session.New(wd, "", "agent", "openai", "gpt-5", "")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -69,8 +70,9 @@ func TestGetToolResultRequiresLogger(t *testing.T) {
 }
 
 func TestGetToolResultRejectsEmptyID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, _ := session.New(wd, "a", "p", "m", "")
+	l, _ := session.New(wd, "", "a", "p", "m", "")
 	t.Cleanup(func() { _ = l.Close() })
 	ctx := session.WithLogger(context.Background(), l)
 
@@ -93,8 +95,9 @@ func TestRegisterLargeResultToolNoopOnNilContainers(t *testing.T) {
 }
 
 func TestGetToolResultPropagatesUnknownID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	l, _ := session.New(wd, "a", "p", "m", "")
+	l, _ := session.New(wd, "", "a", "p", "m", "")
 	t.Cleanup(func() { _ = l.Close() })
 	ctx := session.WithLogger(context.Background(), l)
 

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -1286,9 +1286,9 @@ func TestLogEvent_NilLogger(t *testing.T) {
 }
 
 func TestLogEvent_WithLogger(t *testing.T) {
-	t.Parallel()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	dir := t.TempDir()
-	l, err := session.New(dir, "test-agent", "openai", "gpt-4o", "test prompt")
+	l, err := session.New(dir, "", "test-agent", "openai", "gpt-4o", "test prompt")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}

--- a/runner/canonical_test.go
+++ b/runner/canonical_test.go
@@ -39,6 +39,24 @@ func TestResolveGitToplevelNonRepoFallsBackToDir(t *testing.T) {
 	}
 }
 
+func TestRecordWorktreePath(t *testing.T) {
+	wd := "/repo"
+
+	// Isolation moved the working directory: the worktree path is recorded.
+	opts := &RunOptions{}
+	recordWorktreePath(opts, &Isolation{Effective: "/tmp/wt"}, wd)
+	if opts.WorktreePath != "/tmp/wt" {
+		t.Errorf("WorktreePath=%q, want /tmp/wt", opts.WorktreePath)
+	}
+
+	// No isolation (Effective == workingDir): nothing recorded.
+	opts = &RunOptions{}
+	recordWorktreePath(opts, &Isolation{Effective: wd}, wd)
+	if opts.WorktreePath != "" {
+		t.Errorf("WorktreePath=%q, want empty when no worktree", opts.WorktreePath)
+	}
+}
+
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.Command("git", "init")

--- a/runner/canonical_test.go
+++ b/runner/canonical_test.go
@@ -1,0 +1,58 @@
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveGitToplevelInRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	repo := t.TempDir()
+	gitInit(t, repo)
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+
+	// From a nested subdir, the canonical path is the repo toplevel, not the
+	// subdir. Resolve symlinks on both sides (macOS /var -> /private/var).
+	got := ResolveGitToplevel(sub)
+	want := evalSymlinks(t, repo)
+	if evalSymlinks(t, got) != want {
+		t.Fatalf("ResolveGitToplevel(%q)=%q, want toplevel %q", sub, got, want)
+	}
+}
+
+func TestResolveGitToplevelNonRepoFallsBackToDir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	// Not a git repo: ResolveGitToplevel must fall back to the input dir
+	// rather than aborting.
+	if got := ResolveGitToplevel(dir); got != dir {
+		t.Fatalf("ResolveGitToplevel(%q)=%q, want fallback to input dir", dir, got)
+	}
+}
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+}
+
+func evalSymlinks(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", p, err)
+	}
+	return resolved
+}

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -37,8 +37,6 @@ func TestApplyReadOnlyMode(t *testing.T) {
 }
 
 func TestLoadResumeTranscript(t *testing.T) {
-	t.Parallel()
-
 	t.Run("no resume id returns nil", func(t *testing.T) {
 		t.Parallel()
 		if got := loadResumeTranscript(context.Background(), &RunOptions{}); got != nil {
@@ -55,7 +53,8 @@ func TestLoadResumeTranscript(t *testing.T) {
 
 	newLoggerCtx := func(t *testing.T) (context.Context, *session.Logger) {
 		t.Helper()
-		logger, err := session.New(t.TempDir(), "agent", "anthropic", "claude", "prompt")
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		logger, err := session.New(t.TempDir(), "", "agent", "anthropic", "claude", "prompt")
 		if err != nil {
 			t.Fatalf("session.New: %v", err)
 		}
@@ -64,7 +63,6 @@ func TestLoadResumeTranscript(t *testing.T) {
 	}
 
 	t.Run("resume replays persisted transcript", func(t *testing.T) {
-		t.Parallel()
 		ctx, logger := newLoggerCtx(t)
 		prior := []llms.MessageContent{
 			{Role: llms.ChatMessageTypeHuman, Parts: []llms.ContentPart{llms.TextContent{Text: "earlier"}}},
@@ -78,7 +76,6 @@ func TestLoadResumeTranscript(t *testing.T) {
 	})
 
 	t.Run("resume with no transcript returns nil", func(t *testing.T) {
-		t.Parallel()
 		ctx, logger := newLoggerCtx(t)
 		if got := loadResumeTranscript(ctx, &RunOptions{ResumeID: logger.SessionID()}); got != nil {
 			t.Fatalf("missing transcript must return nil, got %v", got)
@@ -86,7 +83,6 @@ func TestLoadResumeTranscript(t *testing.T) {
 	})
 
 	t.Run("resume with corrupt transcript returns nil", func(t *testing.T) {
-		t.Parallel()
 		ctx, logger := newLoggerCtx(t)
 		if err := os.WriteFile(filepath.Join(logger.Dir(), tools.TranscriptFile), []byte("{not json"), 0o600); err != nil {
 			t.Fatalf("seed corrupt transcript: %v", err)
@@ -1598,8 +1594,9 @@ func TestRehydrateSkillStackNoOpWhenNilLogger(t *testing.T) {
 }
 
 func TestBuildSkillRuntimeWithEntriesAndOnLoad(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	logger, err := session.New(wd, "a", "openai", "gpt-5", "x")
+	logger, err := session.New(wd, "", "a", "openai", "gpt-5", "x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1633,8 +1630,9 @@ func TestBuildSkillRuntimeWithEntriesAndOnLoad(t *testing.T) {
 }
 
 func TestRehydrateSkillStackReplaysEvents(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	logger, err := session.New(wd, "a", "openai", "gpt-5", "x")
+	logger, err := session.New(wd, "", "a", "openai", "gpt-5", "x")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1669,8 +1667,9 @@ func TestRehydrateSkillStackReplaysEvents(t *testing.T) {
 // and a duplicate skill_loaded event into the log. Rehydration must skip the
 // junk line without crashing and push each known skill exactly once.
 func TestRehydrateSkillStackToleratesMalformedEvents(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	logger, err := session.New(wd, "a", "openai", "gpt-5", "x")
+	logger, err := session.New(wd, "", "a", "openai", "gpt-5", "x")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runner/run.go
+++ b/runner/run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -137,6 +138,10 @@ type RunOptions struct {
 	// non-TTY runs. Empty (the default) means "abort" so unattended runs
 	// fail loudly when a skill needs a human checkpoint.
 	AutoConfirm tools.AutoConfirmMode
+	// CanonicalRepoPath is the pre-isolation git toplevel of the working dir.
+	CanonicalRepoPath string
+	// WorktreePath is the ephemeral worktree path (if isolation is used).
+	WorktreePath string
 }
 
 // ExecuteRun contains the full run command logic, parameterized by RunOptions.
@@ -152,11 +157,16 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	}
 	defer cleanup()
 
+	canonicalRepoPath := ResolveGitToplevel(workingDir)
+	opts.CanonicalRepoPath = canonicalRepoPath
+
 	iso, err := setupIsolation(cmd.Context(), opts, workingDir)
 	if err != nil {
 		return err
 	}
 	defer reportIsolationTeardown(cmd, iso)
+
+	recordWorktreePath(opts, iso, workingDir)
 	workingDir = iso.Effective
 
 	bundle, err := prepareBundle(cmd, opts, prompt, workingDir)
@@ -596,7 +606,14 @@ func openSession(opts *RunOptions, bundle *agent.Bundle, prompt string) (*sessio
 		return nil, nil
 	}
 	if opts.ResumeID != "" {
-		l, err := session.Open(opts.WorkingDir, opts.ResumeID)
+		if opts.ResumeID == "latest" {
+			sessions, err := session.List(opts.CanonicalRepoPath)
+			if err != nil || len(sessions) == 0 {
+				return nil, fmt.Errorf("no sessions found to resume for %s", opts.CanonicalRepoPath)
+			}
+			opts.ResumeID = sessions[0].SessionID
+		}
+		l, err := session.Open(opts.CanonicalRepoPath, opts.ResumeID)
 		if err != nil {
 			return nil, err
 		}
@@ -610,7 +627,7 @@ func openSession(opts *RunOptions, bundle *agent.Bundle, prompt string) (*sessio
 		})
 		return l, nil
 	}
-	l, err := session.New(opts.WorkingDir, opts.Agent, opts.Provider, opts.Model, prompt)
+	l, err := session.New(opts.CanonicalRepoPath, opts.WorktreePath, opts.Agent, opts.Provider, opts.Model, prompt)
 	if err != nil {
 		return nil, err
 	}
@@ -803,4 +820,28 @@ func FindAgentDir(agentName, explicitDir string, cfg *config.Config) (string, er
 		return "", fmt.Errorf("agent %q not found: %w", agentName, err)
 	}
 	return agentDir, nil
+}
+
+// recordWorktreePath notes the ephemeral worktree on opts when isolation moved
+// the working directory away from workingDir. Sessions persist this so resume
+// can map a worktree back to its canonical repo. iso is always non-nil here.
+func recordWorktreePath(opts *RunOptions, iso *Isolation, workingDir string) {
+	if iso.Effective != workingDir {
+		opts.WorktreePath = iso.Effective
+	}
+}
+
+// ResolveGitToplevel returns the canonical repository root for dir by asking
+// git for its toplevel. It falls back to dir unchanged when dir is not inside a
+// git repository, so callers always get a usable canonical path. This must be
+// called before worktree isolation rewrites the working directory so sessions
+// are keyed to the real repo, not an ephemeral worktree.
+func ResolveGitToplevel(dir string) string {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return dir // fallback to the original dir if not in a git repo
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/runner/session_helpers_test.go
+++ b/runner/session_helpers_test.go
@@ -24,6 +24,7 @@ func TestOpenSessionNoSessionReturnsNil(t *testing.T) {
 }
 
 func TestOpenSessionFreshWritesRunStart(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
 	opts := &RunOptions{
 		WorkingDir: wd,
@@ -51,8 +52,9 @@ func TestOpenSessionFreshWritesRunStart(t *testing.T) {
 }
 
 func TestOpenSessionResumeRehydratesResponseID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	first, err := session.New(wd, "agent", "openai", "gpt-5", "first prompt")
+	first, err := session.New(wd, "", "agent", "openai", "gpt-5", "first prompt")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -82,6 +84,7 @@ func TestOpenSessionResumeRehydratesResponseID(t *testing.T) {
 }
 
 func TestOpenSessionResumeMissingErrors(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	opts := &RunOptions{WorkingDir: t.TempDir(), ResumeID: "nope"}
 	if _, err := openSession(opts, &agent.Bundle{}, "x"); err == nil {
 		t.Fatalf("expected error resuming missing session")
@@ -94,10 +97,12 @@ func TestCloseSessionNilLoggerNoop(t *testing.T) {
 
 func TestOpenSessionFreshFailsWhenSessionsRootBlocked(t *testing.T) {
 	wd := t.TempDir()
-	// Make .squad a file so session.New's MkdirAll fails.
-	if err := os.WriteFile(filepath.Join(wd, ".squad"), []byte("blocked"), 0o644); err != nil {
+	// Point XDG_STATE_HOME at a regular file so session.New's MkdirAll fails.
+	blocked := filepath.Join(wd, "blocked")
+	if err := os.WriteFile(blocked, []byte("blocked"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+	t.Setenv("XDG_STATE_HOME", filepath.Join(blocked, "state"))
 	opts := &RunOptions{WorkingDir: wd, Agent: "a", Provider: "p", Model: "m"}
 	if _, err := openSession(opts, &agent.Bundle{}, "go"); err == nil {
 		t.Fatalf("expected error when session dir cannot be created")
@@ -116,8 +121,9 @@ func TestCloseSessionStatusMapping(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			wd := t.TempDir()
-			l, err := session.New(wd, "agent", "openai", "gpt-5", "p")
+			l, err := session.New(wd, "", "agent", "openai", "gpt-5", "p")
 			if err != nil {
 				t.Fatalf("session.New: %v", err)
 			}

--- a/runner/session_helpers_test.go
+++ b/runner/session_helpers_test.go
@@ -83,38 +83,6 @@ func TestOpenSessionResumeRehydratesResponseID(t *testing.T) {
 	}
 }
 
-func TestOpenSessionResumeLatest(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	wd := t.TempDir()
-	first, err := session.New(wd, "", "agent", "openai", "gpt-5", "first prompt")
-	if err != nil {
-		t.Fatalf("session.New: %v", err)
-	}
-	id := first.SessionID()
-	if err := first.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	// ResumeID "latest" resolves to the newest session for the canonical repo.
-	opts := &RunOptions{CanonicalRepoPath: wd, Agent: "agent", ResumeID: "latest"}
-	l, err := openSession(opts, &agent.Bundle{}, "second prompt")
-	if err != nil {
-		t.Fatalf("openSession latest: %v", err)
-	}
-	t.Cleanup(func() { _ = l.Close() })
-	if opts.ResumeID != id {
-		t.Fatalf("ResumeID resolved to %q, want %q", opts.ResumeID, id)
-	}
-}
-
-func TestOpenSessionResumeLatestNoneErrors(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	opts := &RunOptions{CanonicalRepoPath: t.TempDir(), ResumeID: "latest"}
-	if _, err := openSession(opts, &agent.Bundle{}, "x"); err == nil {
-		t.Fatalf("expected error resuming latest with no sessions")
-	}
-}
-
 func TestOpenSessionResumeMissingErrors(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	opts := &RunOptions{WorkingDir: t.TempDir(), ResumeID: "nope"}

--- a/runner/session_helpers_test.go
+++ b/runner/session_helpers_test.go
@@ -83,11 +83,75 @@ func TestOpenSessionResumeRehydratesResponseID(t *testing.T) {
 	}
 }
 
+func TestOpenSessionResumeLatest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	wd := t.TempDir()
+	first, err := session.New(wd, "", "agent", "openai", "gpt-5", "first prompt")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	id := first.SessionID()
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// ResumeID "latest" resolves to the newest session for the canonical repo.
+	opts := &RunOptions{CanonicalRepoPath: wd, Agent: "agent", ResumeID: "latest"}
+	l, err := openSession(opts, &agent.Bundle{}, "second prompt")
+	if err != nil {
+		t.Fatalf("openSession latest: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	if opts.ResumeID != id {
+		t.Fatalf("ResumeID resolved to %q, want %q", opts.ResumeID, id)
+	}
+}
+
+func TestOpenSessionResumeLatestNoneErrors(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	opts := &RunOptions{CanonicalRepoPath: t.TempDir(), ResumeID: "latest"}
+	if _, err := openSession(opts, &agent.Bundle{}, "x"); err == nil {
+		t.Fatalf("expected error resuming latest with no sessions")
+	}
+}
+
 func TestOpenSessionResumeMissingErrors(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	opts := &RunOptions{WorkingDir: t.TempDir(), ResumeID: "nope"}
 	if _, err := openSession(opts, &agent.Bundle{}, "x"); err == nil {
 		t.Fatalf("expected error resuming missing session")
+	}
+}
+
+func TestOpenSessionResumeLatestResolvesExisting(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	s, err := session.New(repo, "", "agent", "openai", "gpt-5", "first")
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	wantID := s.SessionID()
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// ResumeID "latest" must resolve to the existing session for this repo.
+	opts := &RunOptions{CanonicalRepoPath: repo, Agent: "agent", ResumeID: "latest"}
+	l, err := openSession(opts, &agent.Bundle{}, "resume latest")
+	if err != nil {
+		t.Fatalf("openSession latest: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	if opts.ResumeID != wantID {
+		t.Fatalf("ResumeID = %q, want %q", opts.ResumeID, wantID)
+	}
+}
+
+func TestOpenSessionResumeLatestNoSessionsErrors(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	opts := &RunOptions{CanonicalRepoPath: t.TempDir(), ResumeID: "latest"}
+	if _, err := openSession(opts, &agent.Bundle{}, "x"); err == nil {
+		t.Fatalf("expected error resuming latest with no sessions")
 	}
 }
 

--- a/session/index.go
+++ b/session/index.go
@@ -1,0 +1,62 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cowdogmoo/squad/config"
+)
+
+// IndexEntry represents a single line in the append-only index.jsonl file.
+type IndexEntry struct {
+	SessionID         string `json:"session_id"`
+	CanonicalRepoPath string `json:"canonical_repo_path"`
+	WorktreePath      string `json:"worktree_path,omitempty"`
+	Timestamp         string `json:"timestamp"`
+	Status            string `json:"status"`
+}
+
+// appendToIndex appends a session to the global index.jsonl.
+func appendToIndex(meta Meta) error {
+	stateDir := config.StateDir()
+	if stateDir == "" {
+		return fmt.Errorf("XDG_STATE_HOME not available")
+	}
+
+	indexFile := filepath.Join(stateDir, "index.jsonl")
+	if err := os.MkdirAll(filepath.Dir(indexFile), 0o700); err != nil {
+		return fmt.Errorf("mkdir state: %w", err)
+	}
+
+	entry := IndexEntry{
+		SessionID:         meta.SessionID,
+		CanonicalRepoPath: meta.CanonicalRepoPath,
+		WorktreePath:      meta.WorktreePath,
+		Timestamp:         meta.Created.Format("20060102T150405Z"),
+		Status:            meta.Status,
+	}
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal index entry: %w", err)
+	}
+
+	f, err := os.OpenFile(indexFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open index.jsonl: %w", err)
+	}
+
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write index entry: %w", err)
+	}
+
+	// Surface Close errors: on an append write they can signal a flush failure
+	// that would otherwise lose the entry.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close index.jsonl: %w", err)
+	}
+	return nil
+}

--- a/session/index_test.go
+++ b/session/index_test.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sampleMeta() Meta {
+	return Meta{
+		SessionID:         "test-id",
+		CanonicalRepoPath: "/repo",
+		Status:            StatusRunning,
+	}
+}
+
+func TestAppendToIndexErrorsWithoutStateHome(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	if err := appendToIndex(sampleMeta()); err == nil {
+		t.Fatal("expected error when no state home is available")
+	}
+}
+
+func TestAppendToIndexErrorsWhenStateDirIsAFile(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// StateDir() becomes <blocked>/sub/squad; MkdirAll fails because blocked is
+	// a regular file.
+	t.Setenv("XDG_STATE_HOME", filepath.Join(blocked, "sub"))
+	if err := appendToIndex(sampleMeta()); err == nil {
+		t.Fatal("expected mkdir error when state dir cannot be created")
+	}
+}
+
+func TestAppendToIndexErrorsWhenIndexPathIsADir(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	// Pre-create index.jsonl as a directory so the append OpenFile fails.
+	if err := os.MkdirAll(filepath.Join(state, "squad", "index.jsonl"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := appendToIndex(sampleMeta()); err == nil {
+		t.Fatal("expected open error when index.jsonl is a directory")
+	}
+}
+
+func TestAppendToIndexAppendsEntries(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	// Two appends must both land as separate JSONL lines (append-only).
+	if err := appendToIndex(sampleMeta()); err != nil {
+		t.Fatalf("appendToIndex: %v", err)
+	}
+	if err := appendToIndex(sampleMeta()); err != nil {
+		t.Fatalf("appendToIndex second: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(state, "squad", "index.jsonl"))
+	if err != nil {
+		t.Fatalf("read index.jsonl: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 index lines, got %d: %q", len(lines), data)
+	}
+	if !strings.Contains(lines[0], `"session_id":"test-id"`) {
+		t.Fatalf("index entry missing session id: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], `"canonical_repo_path":"/repo"`) {
+		t.Fatalf("index entry missing canonical repo path: %s", lines[0])
+	}
+}

--- a/session/list.go
+++ b/session/list.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cowdogmoo/squad/config"
+)
+
+// List returns a deduplicated, reverse-chronological list of sessions for a
+// repository. When repoDir is empty every session is returned.
+//
+// meta.json is the source of truth: it carries the live status, so scanning it
+// keeps List correct even when the append-only index.jsonl is missing or stale
+// (the index records status only at creation time). The index is consulted only
+// as a recovery source for sessions whose meta.json can no longer be read.
+func List(repoDir string) ([]IndexEntry, error) {
+	sessionMap := make(map[string]IndexEntry)
+
+	// 1. Authoritative: scan the global XDG sessions/<id>/meta.json files. The
+	//    flat directory mixes every repo's sessions, so filter by canonical
+	//    repo path.
+	if stateDir := config.StateDir(); stateDir != "" {
+		scanSessionMetas(filepath.Join(stateDir, "sessions"), repoDir, "", sessionMap)
+	}
+
+	// 2. Recovery: fold in index.jsonl entries we did not find on disk. This
+	//    makes the index a rebuildable cache rather than the source of truth.
+	if stateDir := config.StateDir(); stateDir != "" {
+		indexFile := filepath.Join(stateDir, "index.jsonl")
+		if f, err := os.Open(indexFile); err == nil {
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				var entry IndexEntry
+				if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+					continue
+				}
+				if repoDir != "" && entry.CanonicalRepoPath != repoDir {
+					continue
+				}
+				if _, exists := sessionMap[entry.SessionID]; !exists {
+					sessionMap[entry.SessionID] = entry
+				}
+			}
+			_ = f.Close()
+		}
+	}
+
+	// 3. Legacy in-tree .squad/sessions/ for this repo. The directory itself
+	//    scopes these to repoDir, so do not filter by canonical path (sessions
+	//    written before this change predate the CanonicalRepoPath field);
+	//    backfill it instead.
+	if repoDir != "" {
+		scanSessionMetas(filepath.Join(repoDir, SessionsRoot), "", repoDir, sessionMap)
+	}
+
+	results := make([]IndexEntry, 0, len(sessionMap))
+	for _, entry := range sessionMap {
+		results = append(results, entry)
+	}
+
+	// Reverse-chronological (newest first).
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Timestamp > results[j].Timestamp
+	})
+
+	return results, nil
+}
+
+// scanSessionMetas reads every <dir>/<id>/meta.json under dir and records an
+// entry for each session. When repoFilter is non-empty only sessions whose
+// CanonicalRepoPath matches it are kept. When an entry has no CanonicalRepoPath
+// (sessions predating the field) defaultRepo is used in its place. Existing map
+// entries win, so callers can layer authoritative sources first.
+func scanSessionMetas(dir, repoFilter, defaultRepo string, sessionMap map[string]IndexEntry) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		if _, exists := sessionMap[id]; exists {
+			continue
+		}
+		metaData, err := os.ReadFile(filepath.Join(dir, id, "meta.json"))
+		if err != nil {
+			continue
+		}
+		var meta Meta
+		if err := json.Unmarshal(metaData, &meta); err != nil {
+			continue
+		}
+		if repoFilter != "" && meta.CanonicalRepoPath != repoFilter {
+			continue
+		}
+		canonical := meta.CanonicalRepoPath
+		if canonical == "" {
+			canonical = defaultRepo
+		}
+		sessionMap[id] = IndexEntry{
+			SessionID:         meta.SessionID,
+			CanonicalRepoPath: canonical,
+			WorktreePath:      meta.WorktreePath,
+			Timestamp:         meta.Created.Format("20060102T150405Z"),
+			Status:            meta.Status,
+		}
+	}
+}

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -258,6 +258,150 @@ func TestGitignoreExcludesSessionsUnderGitAddAll(t *testing.T) {
 	}
 }
 
+func TestListRecoversFromIndexWhenSessionDirGone(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id := l.SessionID()
+	_ = l.Close()
+
+	// Remove the on-disk session entirely but keep index.jsonl. The meta scan
+	// finds nothing, so List must recover the session from the index.
+	if err := os.RemoveAll(l.Dir()); err != nil {
+		t.Fatalf("remove session dir: %v", err)
+	}
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != id {
+		t.Fatalf("expected index recovery of %q, got %+v", id, sessions)
+	}
+}
+
+func TestListSkipsMalformedAndBackfillsLegacy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	root := filepath.Join(repo, SessionsRoot)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	// A regular file (not a session dir) must be skipped.
+	if err := os.WriteFile(filepath.Join(root, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+	// A directory with no meta.json must be skipped.
+	if err := os.MkdirAll(filepath.Join(root, "no-meta"), 0o755); err != nil {
+		t.Fatalf("mkdir no-meta: %v", err)
+	}
+	// A directory with malformed meta.json must be skipped.
+	badDir := filepath.Join(root, "bad-meta")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatalf("mkdir bad-meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "meta.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write bad meta: %v", err)
+	}
+	// A legacy session whose meta predates CanonicalRepoPath: List must backfill
+	// the repo from the directory location.
+	writeLegacySession(t, repo, "old-session", Meta{
+		SessionID: "old-session",
+		Created:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Status:    StatusCompleted,
+	})
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected only the valid legacy session, got %+v", sessions)
+	}
+	got := sessions[0]
+	if got.SessionID != "old-session" {
+		t.Fatalf("unexpected session %+v", got)
+	}
+	if got.CanonicalRepoPath != repo {
+		t.Errorf("legacy CanonicalRepoPath=%q, want backfilled %q", got.CanonicalRepoPath, repo)
+	}
+}
+
+func TestListSkipsMalformedIndexLines(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id := l.SessionID()
+	_ = l.Close()
+	// Remove the session dir so List must fall through to index recovery, and
+	// prepend a garbage line the index reader must skip.
+	if err := os.RemoveAll(l.Dir()); err != nil {
+		t.Fatalf("remove session dir: %v", err)
+	}
+	indexFile := filepath.Join(config.StateDir(), "index.jsonl")
+	existing, err := os.ReadFile(indexFile)
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if err := os.WriteFile(indexFile, append([]byte("{not json\n"), existing...), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != id {
+		t.Fatalf("expected to skip junk line and recover %q, got %+v", id, sessions)
+	}
+}
+
+func TestNewWarnsWhenGitignoreWriteFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	// Pre-create the .gitignore path as a directory so the belt-and-suspenders
+	// WriteFile fails; New must log and continue, still creating the session.
+	gitignoreAsDir := filepath.Join(repo, SessionsRoot, ".gitignore")
+	if err := os.MkdirAll(gitignoreAsDir, 0o755); err != nil {
+		t.Fatalf("mkdir gitignore-as-dir: %v", err)
+	}
+
+	l, err := New(repo, "", "a", "p", "m", "")
+	if err != nil {
+		t.Fatalf("New must still succeed despite gitignore write failure: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	if _, err := os.Stat(filepath.Join(l.Dir(), "meta.json")); err != nil {
+		t.Fatalf("session not created: %v", err)
+	}
+}
+
+func TestNewFallsBackToInTreeWithoutStateHome(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	canonical := t.TempDir()
+
+	l, err := New(canonical, "", "a", "p", "m", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	wantPrefix := filepath.Join(canonical, SessionsRoot)
+	if !strings.HasPrefix(l.Dir(), wantPrefix) {
+		t.Fatalf("fallback session dir %q not under %q", l.Dir(), wantPrefix)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -1,0 +1,270 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cowdogmoo/squad/config"
+)
+
+// writeLegacySession materializes a legacy in-tree session directory under
+// repo/.squad/sessions/<id>/ with the given meta, mimicking sessions written
+// before the move to XDG_STATE_HOME.
+func writeLegacySession(t *testing.T, repo, id string, meta Meta) {
+	t.Helper()
+	dir := filepath.Join(repo, SessionsRoot, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir legacy session: %v", err)
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+		t.Fatalf("write legacy meta: %v", err)
+	}
+}
+
+func TestNewRecordsCanonicalAndWorktreePath(t *testing.T) {
+	canonical := t.TempDir()
+	worktree := t.TempDir()
+	l, err := New(canonical, worktree, "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	meta := readMeta(t, l)
+	if meta.CanonicalRepoPath != canonical {
+		t.Errorf("CanonicalRepoPath=%q, want %q", meta.CanonicalRepoPath, canonical)
+	}
+	if meta.WorktreePath != worktree {
+		t.Errorf("WorktreePath=%q, want %q", meta.WorktreePath, worktree)
+	}
+	// WorkingDir retains the canonical path for backwards compatibility.
+	if meta.WorkingDir != canonical {
+		t.Errorf("WorkingDir=%q, want %q", meta.WorkingDir, canonical)
+	}
+}
+
+func TestSessionSurvivesWorktreeRemoval(t *testing.T) {
+	canonical := t.TempDir()
+	worktree := filepath.Join(t.TempDir(), "wt")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	l, err := New(canonical, worktree, "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	dir := l.Dir()
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// The session must NOT live inside the ephemeral worktree.
+	if strings.HasPrefix(dir, worktree) {
+		t.Fatalf("session dir %q is inside worktree %q", dir, worktree)
+	}
+
+	// Removing the worktree (isolation cleanup) must not destroy the session.
+	if err := os.RemoveAll(worktree); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "meta.json")); err != nil {
+		t.Fatalf("session meta gone after worktree removal: %v", err)
+	}
+}
+
+func TestListUnionsLegacyAndXDGDedup(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	// One session in the XDG store.
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.Finish(StatusCompleted, "")
+	xdgID := l.SessionID()
+	_ = l.Close()
+
+	// A legacy-only session for the same repo.
+	writeLegacySession(t, repo, "legacy-only", Meta{
+		SessionID:         "legacy-only",
+		CanonicalRepoPath: repo,
+		Created:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Status:            StatusCompleted,
+	})
+	// A legacy directory that duplicates the XDG session id; the XDG entry is
+	// authoritative and must win the dedup.
+	writeLegacySession(t, repo, xdgID, Meta{
+		SessionID:         xdgID,
+		CanonicalRepoPath: repo,
+		Created:           time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		Status:            "stale",
+	})
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	byID := map[string]IndexEntry{}
+	for _, s := range sessions {
+		byID[s.SessionID] = s
+	}
+	if len(byID) != 2 {
+		t.Fatalf("expected 2 unique sessions, got %d: %+v", len(byID), sessions)
+	}
+	if _, ok := byID["legacy-only"]; !ok {
+		t.Errorf("legacy-only session missing from union")
+	}
+	if got := byID[xdgID].Status; got == "stale" {
+		t.Errorf("dedup picked stale legacy entry; XDG entry should win, got status %q", got)
+	}
+}
+
+func TestListRebuildsFromMetaWhenIndexMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id := l.SessionID()
+	_ = l.Close()
+
+	// Delete the index entirely: List must still find the session by scanning
+	// meta.json, proving the index is a rebuildable cache.
+	if err := os.Remove(filepath.Join(config.StateDir(), "index.jsonl")); err != nil {
+		t.Fatalf("remove index: %v", err)
+	}
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != id {
+		t.Fatalf("expected to rebuild session %q from meta, got %+v", id, sessions)
+	}
+}
+
+func TestListReflectsLiveStatusNotIndex(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// The index recorded "running" at creation; meta.json now says completed.
+	l.Finish(StatusCompleted, "")
+	_ = l.Close()
+
+	sessions, err := List(repo)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].Status != StatusCompleted {
+		t.Errorf("List status=%q, want live %q (not frozen index value)", sessions[0].Status, StatusCompleted)
+	}
+}
+
+func TestListFiltersByRepo(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	la, err := New(repoA, "", "agent", "openai", "gpt-5", "a")
+	if err != nil {
+		t.Fatalf("New A: %v", err)
+	}
+	idA := la.SessionID()
+	_ = la.Close()
+	lb, err := New(repoB, "", "agent", "openai", "gpt-5", "b")
+	if err != nil {
+		t.Fatalf("New B: %v", err)
+	}
+	_ = lb.Close()
+
+	sessions, err := List(repoA)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != idA {
+		t.Fatalf("List(repoA) should return only repoA's session, got %+v", sessions)
+	}
+}
+
+func TestNewWritesGitignoreToLegacyInTreeDir(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	// Pre-existing in-tree sessions dir (legacy remnant) triggers the
+	// belt-and-suspenders .gitignore write.
+	inTree := filepath.Join(repo, SessionsRoot)
+	if err := os.MkdirAll(inTree, 0o755); err != nil {
+		t.Fatalf("mkdir in-tree: %v", err)
+	}
+
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	data, err := os.ReadFile(filepath.Join(inTree, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if string(data) != "*\n" {
+		t.Errorf(".gitignore contents=%q, want %q", data, "*\n")
+	}
+}
+
+func TestGitignoreExcludesSessionsUnderGitAddAll(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "t@example.com")
+	runGit(t, repo, "config", "user.name", "t")
+
+	// Legacy in-tree sessions dir so New drops the self-excluding .gitignore.
+	if err := os.MkdirAll(filepath.Join(repo, SessionsRoot), 0o755); err != nil {
+		t.Fatalf("mkdir in-tree: %v", err)
+	}
+	l, err := New(repo, "", "agent", "openai", "gpt-5", "go")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_ = l.Close()
+
+	runGit(t, repo, "add", "-A")
+	out := runGit(t, repo, "status", "--porcelain")
+	if strings.Contains(out, SessionsRoot) {
+		t.Errorf("git add -A staged session artifacts:\n%s", out)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/session/main_test.go
+++ b/session/main_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points XDG_STATE_HOME at a throwaway directory for the whole
+// package. Sessions now live under XDG_STATE_HOME (not in-tree), so without
+// this every test would write into the developer's real ~/.local/state.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "squad-session-test")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("XDG_STATE_HOME", tmp); err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
 )
 
@@ -55,15 +56,17 @@ const (
 // Meta holds the per-session metadata kept in meta.json. It is rewritten on
 // every update so a `--resume` can read it without scanning the event log.
 type Meta struct {
-	SessionID      string    `json:"session_id"`
-	Created        time.Time `json:"created"`
-	Updated        time.Time `json:"updated"`
-	Agent          string    `json:"agent"`
-	Provider       string    `json:"provider"`
-	Model          string    `json:"model"`
-	WorkingDir     string    `json:"working_dir"`
-	Prompt         string    `json:"prompt"`
-	LastResponseID string    `json:"last_response_id,omitempty"`
+	SessionID         string    `json:"session_id"`
+	Created           time.Time `json:"created"`
+	Updated           time.Time `json:"updated"`
+	Agent             string    `json:"agent"`
+	Provider          string    `json:"provider"`
+	Model             string    `json:"model"`
+	WorkingDir        string    `json:"working_dir"` // Legacy field for backwards compat
+	CanonicalRepoPath string    `json:"canonical_repo_path"`
+	WorktreePath      string    `json:"worktree_path,omitempty"`
+	Prompt            string    `json:"prompt"`
+	LastResponseID    string    `json:"last_response_id,omitempty"`
 	// RoutineID identifies the routine that produced this session (qualified
 	// form: "global:nightly" / "repo:audit"). Empty for non-routine runs.
 	RoutineID    string  `json:"routine_id,omitempty"`
@@ -91,14 +94,33 @@ type Logger struct {
 	meta      Meta
 }
 
-// New creates a fresh session under <workingDir>/.squad/sessions/<id>/ and
+// New creates a fresh session under XDG_STATE_HOME/squad/sessions/<id>/ and
 // returns a Logger ready to receive events. The caller should defer Close.
-func New(workingDir, agent, provider, model, prompt string) (*Logger, error) {
+func New(canonicalRepoPath, worktreePath, agent, provider, model, prompt string) (*Logger, error) {
 	id, err := newSessionID()
 	if err != nil {
 		return nil, err
 	}
-	dir := filepath.Join(workingDir, SessionsRoot, id)
+
+	var dir string
+	stateDir := config.StateDir()
+	if stateDir != "" {
+		dir = filepath.Join(stateDir, "sessions", id)
+	} else {
+		// Fallback to in-tree if XDG_STATE_HOME is somehow broken or unavailable
+		dir = filepath.Join(canonicalRepoPath, SessionsRoot, id)
+	}
+
+	// Unconditionally try to add .gitignore to in-tree sessions directory if it exists,
+	// to prevent legacy or fallback workflows from committing session data.
+	inTreeSessionsDir := filepath.Join(canonicalRepoPath, SessionsRoot)
+	if info, err := os.Stat(inTreeSessionsDir); err == nil && info.IsDir() {
+		gitignorePath := filepath.Join(inTreeSessionsDir, ".gitignore")
+		if err := os.WriteFile(gitignorePath, []byte("*\n"), 0o644); err != nil {
+			logging.Warn("failed to write %s: %v", gitignorePath, err)
+		}
+	}
+
 	resultDir := filepath.Join(dir, "results")
 	if err := os.MkdirAll(resultDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir session: %w", err)
@@ -109,15 +131,17 @@ func New(workingDir, agent, provider, model, prompt string) (*Logger, error) {
 		dir:       dir,
 		resultDir: resultDir,
 		meta: Meta{
-			SessionID:  id,
-			Created:    now,
-			Updated:    now,
-			Agent:      agent,
-			Provider:   provider,
-			Model:      model,
-			WorkingDir: workingDir,
-			Prompt:     prompt,
-			Status:     StatusRunning,
+			SessionID:         id,
+			Created:           now,
+			Updated:           now,
+			Agent:             agent,
+			Provider:          provider,
+			Model:             model,
+			WorkingDir:        canonicalRepoPath,
+			CanonicalRepoPath: canonicalRepoPath,
+			WorktreePath:      worktreePath,
+			Prompt:            prompt,
+			Status:            StatusRunning,
 		},
 	}
 	if err := l.openEventsFile(); err != nil {
@@ -126,13 +150,32 @@ func New(workingDir, agent, provider, model, prompt string) (*Logger, error) {
 	if err := l.writeMeta(); err != nil {
 		return nil, err
 	}
+
+	if err := appendToIndex(l.meta); err != nil {
+		logging.Warn("failed to update session index: %v", err)
+	}
+
 	return l, nil
+}
+
+// ResolveDir returns the on-disk directory for a session without opening or
+// mutating it. It prefers the XDG state location and falls back to the legacy
+// in-tree path. The returned path is not guaranteed to exist.
+func ResolveDir(canonicalRepoPath, sessionID string) string {
+	if stateDir := config.StateDir(); stateDir != "" {
+		candidate := filepath.Join(stateDir, "sessions", sessionID)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return filepath.Join(canonicalRepoPath, SessionsRoot, sessionID)
 }
 
 // Open loads an existing session for resume. The Logger appends to the same
 // events.jsonl and rewrites meta.json in place.
-func Open(workingDir, sessionID string) (*Logger, error) {
-	dir := filepath.Join(workingDir, SessionsRoot, sessionID)
+func Open(canonicalRepoPath, sessionID string) (*Logger, error) {
+	dir := ResolveDir(canonicalRepoPath, sessionID)
+
 	resultDir := filepath.Join(dir, "results")
 	if err := os.MkdirAll(resultDir, 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir results: %w", err)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cowdogmoo/squad/config"
 )
 
 // newTestLogger creates a fresh session logger under a per-test temp dir
@@ -14,7 +16,7 @@ import (
 func newTestLogger(t *testing.T) (*Logger, string) {
 	t.Helper()
 	wd := t.TempDir()
-	l, err := New(wd, "go-review", "openai", "gpt-5", "fix the bug")
+	l, err := New(wd, "", "go-review", "openai", "gpt-5", "fix the bug")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -56,12 +58,17 @@ func readEvents(t *testing.T, l *Logger) []Event {
 }
 
 func TestNewSetsSessionLayout(t *testing.T) {
-	l, wd := newTestLogger(t)
+	l, _ := newTestLogger(t)
 	if l.SessionID() == "" {
 		t.Fatalf("session id empty")
 	}
-	if !strings.HasPrefix(l.Dir(), filepath.Join(wd, SessionsRoot)) {
-		t.Fatalf("session dir %q not under %q", l.Dir(), wd)
+	// Sessions live under XDG_STATE_HOME/squad/sessions/<id>, not in-tree.
+	wantPrefix := filepath.Join(config.StateDir(), "sessions")
+	if !strings.HasPrefix(l.Dir(), wantPrefix) {
+		t.Fatalf("session dir %q not under %q", l.Dir(), wantPrefix)
+	}
+	if !strings.HasSuffix(l.Dir(), l.SessionID()) {
+		t.Fatalf("session dir %q does not end with id %q", l.Dir(), l.SessionID())
 	}
 }
 
@@ -104,7 +111,7 @@ func TestAppendWritesEventsJSONL(t *testing.T) {
 
 func TestOpenResumesAndAppends(t *testing.T) {
 	wd := t.TempDir()
-	l, err := New(wd, "agent", "openai", "gpt-5", "go")
+	l, err := New(wd, "", "agent", "openai", "gpt-5", "go")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -140,7 +147,7 @@ func TestOpenResumesAndAppends(t *testing.T) {
 
 func TestStoreAndReadLargeResult(t *testing.T) {
 	wd := t.TempDir()
-	l, err := New(wd, "a", "p", "m", "")
+	l, err := New(wd, "", "a", "p", "m", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -192,7 +199,7 @@ func TestStoreAndReadLargeResult(t *testing.T) {
 
 func TestContextRoundTrip(t *testing.T) {
 	wd := t.TempDir()
-	l, err := New(wd, "a", "p", "m", "")
+	l, err := New(wd, "", "a", "p", "m", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -244,14 +251,17 @@ func TestWithLoggerNilLeavesCtxUnchanged(t *testing.T) {
 	}
 }
 
-func TestNewFailsWhenSessionsRootIsAFile(t *testing.T) {
+func TestNewFailsWhenStateDirIsAFile(t *testing.T) {
 	wd := t.TempDir()
-	// Make .squad a regular file so MkdirAll on .squad/sessions/<id> fails.
-	if err := os.WriteFile(filepath.Join(wd, ".squad"), []byte("blocked"), 0o644); err != nil {
+	// Point XDG_STATE_HOME at a regular file so MkdirAll on the session
+	// directory fails.
+	blocked := filepath.Join(wd, "blocked")
+	if err := os.WriteFile(blocked, []byte("blocked"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if _, err := New(wd, "a", "p", "m", ""); err == nil {
-		t.Fatalf("expected mkdir error when .squad is a regular file")
+	t.Setenv("XDG_STATE_HOME", filepath.Join(blocked, "state"))
+	if _, err := New(wd, "", "a", "p", "m", ""); err == nil {
+		t.Fatalf("expected mkdir error when state dir cannot be created")
 	}
 }
 
@@ -375,11 +385,11 @@ func TestAppendAfterCloseIsNoop(t *testing.T) {
 }
 
 func TestSetRoutineIDPersistsToMeta(t *testing.T) {
-	l, wd := newTestLogger(t)
+	l, _ := newTestLogger(t)
 	defer func() { _ = l.Close() }()
 	l.SetRoutineID("global:nightly")
 
-	data, err := os.ReadFile(filepath.Join(wd, SessionsRoot, l.SessionID(), "meta.json"))
+	data, err := os.ReadFile(filepath.Join(l.Dir(), "meta.json"))
 	if err != nil {
 		t.Fatalf("read meta: %v", err)
 	}
@@ -395,12 +405,12 @@ func TestSetRoutineIDPersistsToMeta(t *testing.T) {
 }
 
 func TestSetRoutineIDIgnoresEmptyAndNil(t *testing.T) {
-	l, wd := newTestLogger(t)
+	l, _ := newTestLogger(t)
 	defer func() { _ = l.Close() }()
 	l.SetRoutineID("global:first")
 	l.SetRoutineID("") // no-op, doesn't overwrite
 
-	data, err := os.ReadFile(filepath.Join(wd, SessionsRoot, l.SessionID(), "meta.json"))
+	data, err := os.ReadFile(filepath.Join(l.Dir(), "meta.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +436,7 @@ func TestSetRoutineIDIgnoresEmptyAndNil(t *testing.T) {
 // errors) and close the underlying events FD without nilling l.events
 // (so appendLocked's Write errors). All four mutators must remain safe.
 func TestPersistenceErrorsAreLogged(t *testing.T) {
-	l, wd := newTestLogger(t)
+	l, _ := newTestLogger(t)
 	t.Cleanup(func() { _ = l.Close() })
 
 	// Close the events FD but keep l.events non-nil so appendLocked
@@ -435,7 +445,7 @@ func TestPersistenceErrorsAreLogged(t *testing.T) {
 		t.Fatalf("close events: %v", err)
 	}
 	// Nuke the session dir so writeMeta's tmp WriteFile errors.
-	if err := os.RemoveAll(filepath.Join(wd, SessionsRoot, l.SessionID())); err != nil {
+	if err := os.RemoveAll(l.Dir()); err != nil {
 		t.Fatalf("remove session dir: %v", err)
 	}
 

--- a/tools/confirm_session_test.go
+++ b/tools/confirm_session_test.go
@@ -25,8 +25,9 @@ type confirmEventPayload struct {
 // test can read back events.jsonl. The session is closed via t.Cleanup.
 func newSessionForTest(t *testing.T) *session.Logger {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	wd := t.TempDir()
-	logger, err := session.New(wd, "test", "openai", "gpt-x", "audit")
+	logger, err := session.New(wd, "", "test", "openai", "gpt-x", "audit")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/transcript_test.go
+++ b/tools/transcript_test.go
@@ -120,8 +120,9 @@ func TestSplicePriorMessagesEmptyPriorReturnsInitial(t *testing.T) {
 }
 
 func TestPersistTranscriptWritesForActiveSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	dir := t.TempDir()
-	logger, err := session.New(dir, "agent", "anthropic", "claude", "prompt")
+	logger, err := session.New(dir, "", "agent", "anthropic", "claude", "prompt")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -145,8 +146,8 @@ func TestPersistTranscriptNoLoggerIsNoop(t *testing.T) {
 }
 
 func TestPersistTranscriptSwallowsWriteFailure(t *testing.T) {
-	t.Parallel()
-	logger, err := session.New(t.TempDir(), "agent", "anthropic", "claude", "prompt")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	logger, err := session.New(t.TempDir(), "", "agent", "anthropic", "claude", "prompt")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}
@@ -221,9 +222,9 @@ func TestSplicePriorMessagesEmptyInitialReturnsPrior(t *testing.T) {
 // a fake LLM: prior messages are spliced in, and the conversation is persisted
 // so a later --resume can reload it.
 func TestRunWithToolsReplaysAndPersists(t *testing.T) {
-	t.Parallel()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	dir := t.TempDir()
-	logger, err := session.New(dir, "agent", "anthropic", "claude", "prompt")
+	logger, err := session.New(dir, "", "agent", "anthropic", "claude", "prompt")
 	if err != nil {
 		t.Fatalf("session.New: %v", err)
 	}


### PR DESCRIPTION
**Key Changes:**

- Sessions now live under `$XDG_STATE_HOME/squad/sessions/<id>/` instead of the in-tree `.squad/sessions/` directory, preventing session artifacts from being committed to repositories
- A global `index.jsonl` append-only index tracks sessions per canonical repo path, with `meta.json` as the authoritative source of truth for live status
- New `sessions` CLI command lets users list and navigate to sessions for the current repository
- `session.New` signature extended with `worktreePath` to record ephemeral worktree isolation, and `ResolveGitToplevel` keys sessions to the real repo root rather than a transient worktree

**Added:**

- `sessions` and `sessions open` CLI commands - `cmd/squad/sessions.go` lists all sessions for the current repo in a tabwriter table and prints the on-disk directory of a specific (or latest) session without mutating its status
- Session index - `session/index.go` introduces `IndexEntry` and `appendToIndex` to maintain an append-only `index.jsonl` under the XDG state directory; surfaces `Close` errors to avoid silent flush failures
- `session.List` - `session/list.go` returns a deduplicated, reverse-chronological slice of sessions for a repo by scanning `meta.json` files as the authoritative source, falling back to `index.jsonl` for recovery and scanning legacy in-tree `.squad/sessions/` for backwards compatibility
- `session.ResolveDir` - resolves the on-disk path for a session ID without opening or mutating it, preferring XDG then falling back to the legacy in-tree path
- `ResolveGitToplevel` - `runner/run.go` shells out to `git rev-parse --show-toplevel` to canonicalize the repo root before worktree isolation rewrites the working directory; falls back to the input dir outside git repos
- XDG state helpers - `config/xdg.go` adds `getStateHome`, `StateDir`, and `StateFile` following the same XDG pattern as the existing cache helpers
- `CanonicalRepoPath` and `WorktreePath` fields on `session.Meta` and `RunOptions` to record where a session's repo lives independently of any ephemeral worktree
- `session/main_test.go` redirects `XDG_STATE_HOME` for the entire package so tests never write into the developer's real `~/.local/state`
- Tests for `ResolveGitToplevel`, `session.List` (dedup, legacy union, index-missing rebuild, live-status reflection, repo filtering), XDG state helpers, and the new CLI commands

**Changed:**

- `session.New` signature changed from `(workingDir, agent, provider, model, prompt)` to `(canonicalRepoPath, worktreePath, agent, provider, model, prompt)` - all call sites updated across `runner`, `responses`, and `tools` packages
- `session.Open` now calls `ResolveDir` to locate sessions in the XDG store before falling back to the legacy in-tree path, and accepts `canonicalRepoPath` instead of `workingDir`
- `openSession` in `runner/run.go` resolves `"latest"` as a resume ID alias by calling `session.List`, and passes `CanonicalRepoPath` and `WorktreePath` from `RunOptions`
- `session.Meta` extended with `CanonicalRepoPath` and `WorktreePath` fields; `WorkingDir` retained as a legacy backwards-compatibility field
- `New` writes a self-excluding `.gitignore` to any pre-existing in-tree sessions directory to protect legacy or fallback workflows from accidentally staging session data
- Tests that called `session.New` with the old signature updated throughout `responses`, `runner`, `tools`, and `session` packages; parallelism removed from subtests that call `t.Setenv` (which is incompatible with `t.Parallel`)
- `TestNewSetsSessionLayout` updated to assert the session directory is under `XDG_STATE_HOME/squad/sessions/` rather than the in-tree path
- `TestNewFailsWhenSessionsRootIsAFile` renamed to `TestNewFailsWhenStateDirIsAFile` and updated to block via `XDG_STATE_HOME` rather than a `.squad` file collision