### PR TITLE
docs: update terminology and improve resume flag help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 `squad` is a framework for building, sharing, and running unattended AI agents from the command line. Define an agent as plain markdown prompts and a YAML manifest, point it at any LLM provider, and let it work through a codebase using a fixed tool surface (Read, Write, Edit, Glob, Grep, Bash, plus any MCP server).
 
-Agents run in a deterministic tool loop with per-run cost caps, structured event logs, and session resume. Multi-agent **pipelines** compose stages with dependency ordering and regression gates. **Routines** schedule unattended runs through OS-native daemons. Provider support includes OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, vLLM, LM Studio, Together AI). Execution can target the local machine, a Docker container, a Kubernetes pod, or an EC2 instance over AWS SSM.
+Agents run in a bounded tool loop with per-run cost caps, structured event logs, and session resume. Multi-agent **pipelines** compose stages with dependency ordering and regression gates. **Routines** schedule unattended runs through OS-native daemons. Provider support includes OpenAI, Anthropic, Google AI, Ollama, and any OpenAI-compatible endpoint (NVIDIA NIM, Databricks, vLLM, LM Studio, Together AI). Execution can target the local machine, a Docker container, a Kubernetes pod, or an EC2 instance over AWS SSM.
 
 ## Table of Contents
 
@@ -44,7 +44,7 @@ Agents run in a deterministic tool loop with per-run cost caps, structured event
 
 ## Architecture
 
-`squad` is a single Go binary built around a deterministic tool-calling loop. The CLI assembles an **agent bundle** (system prompt + tool definitions + budget config) from on-disk markdown and YAML, then drives the model through tool calls until it returns a final response or a budget/iteration cap fires.
+`squad` is a single Go binary built around a bounded tool-calling loop. The CLI assembles an **agent bundle** (system prompt + tool definitions + budget config) from on-disk markdown and YAML, then drives the model through tool calls until it returns a final response or a budget/iteration cap fires.
 
 ```text
                         ┌──────────────────────────────────────────────┐

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -347,7 +347,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	cmd.Flags().Bool("stream", false, "Stream model output tokens to stderr as they arrive")
 	cmd.Flags().Int("max-concurrent-tasks", 0, "Max concurrent background child tasks (default: 4)")
 	cmd.Flags().Bool("json", false, "Force JSON output format (composed agents only)")
-	cmd.Flags().String("resume", "", "Resume a prior session by id (see ./.squad/sessions/)")
+	cmd.Flags().String("resume", "", "Resume a prior session by id, or 'latest' (find ids with 'squad sessions')")
 	cmd.Flags().String("isolate", "", "Isolation mode: 'worktree' (separate dir + branch), 'branch' (new branch in-place), 'commit' (snapshot dirty tree), 'staged' (commit index, stash rest), 'unstaged' (work as-is), or 'none' (default: from manifest/config)")
 	cmd.Flags().Bool("skills-enabled", false, "Force-enable the Agent Skills catalog for this run (overrides agent.yaml)")
 	cmd.Flags().Bool("skills-disabled", false, "Force-disable the Agent Skills catalog for this run (overrides agent.yaml)")


### PR DESCRIPTION
**Key Changes:**

- Replaced "deterministic" with "bounded" to more accurately describe the tool-calling loop behavior
- Improved the `--resume` flag description to mention the `latest` keyword and how to find session IDs

**Changed:**

- Tool loop terminology - Updated references in `README.md` from "deterministic tool loop" and "deterministic tool-calling loop" to "bounded tool loop" and "bounded tool-calling loop" to better reflect actual behavior
- Resume flag help text - Clarified `--resume` flag description in `cmd/squad/run.go` to inform users they can pass `'latest'` as a value and that session IDs can be found using `squad sessions`