### PR TITLE
fix: skip binary files and overlong lines in grep search

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,7 @@ package tools
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,10 @@ import (
 // when no explicit --max-iterations flag is provided.
 const MaxToolIterations = 100
 const maxToolOutput = 64 * 1024
+
+// grepBinarySniffBytes is how many leading bytes the grep walker inspects for
+// a NUL byte to detect (and skip) binary files.
+const grepBinarySniffBytes = 8000
 const maxSameToolRepeat = 10
 const maxMutatingToolRepeat = 50
 
@@ -1842,12 +1847,21 @@ func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) file
 				retErr = cerr
 			}
 		}()
+		// Peek the first chunk without consuming it so the same reader can
+		// still be scanned from the top. A NUL byte marks a binary file (the
+		// heuristic git and ripgrep use); skipping it avoids the scanner
+		// choking on the long no-newline runs in binaries — e.g. a compiled
+		// binary or coverage profile sitting in the repo root.
+		reader := bufio.NewReaderSize(file, maxToolOutput)
+		if sniff, _ := reader.Peek(grepBinarySniffBytes); bytes.IndexByte(sniff, 0) >= 0 {
+			return nil
+		}
 		rel, err := filepath.Rel(workingDir, path)
 		if err != nil {
 			rel = path
 		}
-		scanner := bufio.NewScanner(file)
-		scanner.Buffer(make([]byte, 64*1024), maxToolOutput)
+		scanner := bufio.NewScanner(reader)
+		scanner.Buffer(make([]byte, maxToolOutput), maxToolOutput)
 		lineNum := 1
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -1856,8 +1870,11 @@ func grepVisitFile(workingDir string, re *regexp.Regexp, matches *[]string) file
 			}
 			lineNum++
 		}
-		if err := scanner.Err(); err != nil {
-			return err
+		if scanner.Err() != nil {
+			// An overlong line (e.g. a minified asset) or a mid-read error
+			// skips just this file rather than aborting the whole search —
+			// the walker is best-effort and already skips files it can't open.
+			return nil
 		}
 		return nil
 	}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -427,6 +427,38 @@ func TestGrepSearchPathSingleFile(t *testing.T) {
 	}
 }
 
+// TestGrepSearchPathSkipsBinaryAndOverlongLines guards the regression where a
+// binary file (e.g. a compiled binary in the repo root) or a single overlong
+// line aborted the entire search with "bufio.Scanner: token too long".
+func TestGrepSearchPathSkipsBinaryAndOverlongLines(t *testing.T) {
+	dir := t.TempDir()
+
+	// Normal text file containing the needle — this is the only expected match.
+	if err := os.WriteFile(filepath.Join(dir, "code.go"), []byte("package x\n// NEEDLE here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Binary file: a NUL byte marks it binary. Its "NEEDLE" text must NOT match
+	// because the file is skipped wholesale.
+	if err := os.WriteFile(filepath.Join(dir, "blob.bin"), append([]byte("NEEDLE\x00"), bytes.Repeat([]byte{0}, 16)...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Text file with a single line far longer than the scanner buffer. It must
+	// be skipped without aborting the walk.
+	overlong := append(bytes.Repeat([]byte("a"), maxToolOutput+1024), []byte("NEEDLE")...)
+	if err := os.WriteFile(filepath.Join(dir, "huge.txt"), overlong, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	re := regexp.MustCompile("NEEDLE")
+	matches, err := grepSearchPath(dir, dir, re)
+	if err != nil {
+		t.Fatalf("grepSearchPath returned error (binary/overlong files must be skipped, not fatal): %v", err)
+	}
+	if len(matches) != 1 || !strings.Contains(matches[0], "code.go") {
+		t.Fatalf("expected exactly one match in code.go, got: %v", matches)
+	}
+}
+
 func TestBashTool(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
**Key Changes:**

- Binary files containing NUL bytes are now silently skipped during grep searches instead of causing scanner errors
- Files with overlong lines (e.g. minified assets) no longer abort the entire directory walk
- Regression test added to guard both failure modes

**Added:**

- Regression test `TestGrepSearchPathSkipsBinaryAndOverlongLines` - covers three cases in a temp directory: a normal text file that must match, a binary file whose NEEDLE text must not appear in results, and a file with a single line exceeding the scanner buffer that must be skipped without error

**Changed:**

- Binary file detection - Added NUL-byte sniff of the first 8000 bytes at the start of `grepVisitFile`, matching the same heuristic used by git and ripgrep; files detected as binary are skipped entirely and the walk continues
- Overlong line handling - `bufio.ErrTooLong` is now caught after scanner completion and treated as a non-fatal skip rather than propagating the error and aborting the search; requires new `bytes` and `io` imports