### PR TITLE
feat: add per-agent iteration_factor override in agent manifest

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -92,7 +92,11 @@ type Manifest struct {
 	MCPServers    []mcp.ServerConfig `yaml:"mcp_servers,omitempty"`
 	DisableTask   bool               `yaml:"disable_task,omitempty"`
 	MaxIterations int                `yaml:"max_iterations,omitempty"` // iteration cap for this agent (0 = use CLI default)
-	EditDeadline  int                `yaml:"edit_deadline,omitempty"`  // stop after N iterations with no Edit calls (0 = disabled)
+	// IterationFactor overrides the config-level model.iteration_factor for
+	// this agent, keyed by model name (a "default" key applies to any model).
+	// Lets an agent tune its per-model budget independently of global config.
+	IterationFactor map[string]float64 `yaml:"iteration_factor,omitempty"`
+	EditDeadline    int                `yaml:"edit_deadline,omitempty"` // stop after N iterations with no Edit calls (0 = disabled)
 	// CommentsOnly, when true, restricts Edit and MultiEdit calls to
 	// changes that only add or remove comment lines or blank lines.
 	// Edits that modify, add, or remove non-comment code are rejected.
@@ -254,7 +258,10 @@ type Bundle struct {
 	MCPServers    []mcp.ServerConfig // MCP server dependencies declared in agent.yaml
 	DisableTask   bool               // when true, the Task tool is not registered for this agent
 	MaxIterations int                // iteration cap from manifest (0 = use CLI default)
-	EditDeadline  int                // stop after N iterations with no Edit calls (0 = disabled)
+	// IterationFactor is the manifest's per-model iteration multiplier; when
+	// set it overrides the config-level model.iteration_factor for this agent.
+	IterationFactor map[string]float64
+	EditDeadline    int // stop after N iterations with no Edit calls (0 = disabled)
 	// RemoteOnly mirrors Manifest.IsRemoteOnly. When true, local
 	// filesystem tools are not registered and the runner skips
 	// working-dir resolution / repo-summary injection.
@@ -928,24 +935,25 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 	primary := manifest.PrimaryModel()
 
 	return &Bundle{
-		System:        sys.String(),
-		User:          userMessage,
-		Combined:      combined.Bytes(),
-		WorkDir:       workingDir,
-		Model:         primary.Model,
-		Provider:      primary.Provider,
-		BaseURL:       primary.BaseURL,
-		Models:        manifest.Models,
-		Budget:        manifest.Budget,
-		Environment:   manifest.Environment,
-		MCPServers:    resolvedMCP,
-		DisableTask:   manifest.DisableTask,
-		MaxIterations: manifest.MaxIterations,
-		EditDeadline:  manifest.EditDeadline,
-		RemoteOnly:    manifest.IsRemoteOnly(),
-		CommentsOnly:  manifest.CommentsOnly,
-		SkillEntries:  skillEntries,
-		Requires:      manifest.Requires,
+		System:          sys.String(),
+		User:            userMessage,
+		Combined:        combined.Bytes(),
+		WorkDir:         workingDir,
+		Model:           primary.Model,
+		Provider:        primary.Provider,
+		BaseURL:         primary.BaseURL,
+		Models:          manifest.Models,
+		Budget:          manifest.Budget,
+		Environment:     manifest.Environment,
+		MCPServers:      resolvedMCP,
+		DisableTask:     manifest.DisableTask,
+		MaxIterations:   manifest.MaxIterations,
+		IterationFactor: manifest.IterationFactor,
+		EditDeadline:    manifest.EditDeadline,
+		RemoteOnly:      manifest.IsRemoteOnly(),
+		CommentsOnly:    manifest.CommentsOnly,
+		SkillEntries:    skillEntries,
+		Requires:        manifest.Requires,
 	}, nil
 }
 

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1508,3 +1508,17 @@ func TestBuildBundleInline_ReferenceMissingEverywhere(t *testing.T) {
 		t.Fatal("expected error when reference missing in both stage and baseDir")
 	}
 }
+
+func TestManifestIterationFactorParses(t *testing.T) {
+	var m Manifest
+	src := "name: x\niteration_factor:\n  gpt-oss-120b: 3.0\n  default: 1.5\n"
+	if err := yamlPkg.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := m.IterationFactor["gpt-oss-120b"]; got != 3.0 {
+		t.Fatalf("iteration_factor[gpt-oss-120b] = %v, want 3.0", got)
+	}
+	if got := m.IterationFactor["default"]; got != 1.5 {
+		t.Fatalf("iteration_factor[default] = %v, want 1.5", got)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ effective = clamp( base × factor[model] , 10 , 1000 )
 ```
 
 - **base** — the agent manifest's `max_iterations`, or `run.max_iterations` (default `100`) when the manifest leaves it unset.
-- **factor[model]** — `model.iteration_factor[<model>]`, then a `default` entry, then `1.0`. Non-positive values are ignored.
+- **factor[model]** — resolved with this precedence: the **agent manifest's** `iteration_factor[<model>]` (then its `default` key), then the global `model.iteration_factor[<model>]` (then its `default` key), then `1.0`. Non-positive values are ignored.
 - An explicit `--max-iterations` flag overrides all of the above and is used verbatim.
 
 ```yaml
@@ -127,6 +127,18 @@ model:
     gpt-oss-120b: 3.0      # slow to converge — give it room
     claude-sonnet-4-6: 1.0
     default: 1.0
+```
+
+An individual agent can override the global factor for specific models in its
+`agent.yaml` manifest — useful when one agent converges faster or slower than
+the global default on a given model:
+
+```yaml
+# agent.yaml
+name: go-review
+max_iterations: 40        # this agent's base budget
+iteration_factor:
+  gpt-oss-120b: 1.5       # overrides the global 3.0 for this agent only
 ```
 
 ### agents

--- a/runner/model.go
+++ b/runner/model.go
@@ -608,7 +608,7 @@ func resolveIterationBudget(opts *RunOptions, bundle *agent.Bundle, model string
 	if bundle != nil && bundle.MaxIterations > 0 {
 		base = bundle.MaxIterations
 	}
-	scaled := int(float64(base)*modelIterationFactor(opts.Config, model) + 0.5)
+	scaled := int(float64(base)*resolveModelFactor(bundle, opts.Config, model) + 0.5)
 	if scaled < minIterationBudget {
 		return minIterationBudget
 	}
@@ -618,20 +618,39 @@ func resolveIterationBudget(opts *RunOptions, bundle *agent.Bundle, model string
 	return scaled
 }
 
-// modelIterationFactor returns the per-model iteration multiplier from config,
-// preferring an exact model entry, then a "default" entry, then 1.0.
-// Non-positive factors are ignored so a stray 0 can't zero out the budget.
-func modelIterationFactor(cfg *config.Config, model string) float64 {
-	if cfg == nil || len(cfg.Model.IterationFactor) == 0 {
-		return 1.0
+// resolveModelFactor returns the per-model iteration multiplier for a run,
+// preferring the agent manifest's iteration_factor over the config-level
+// model.iteration_factor, and falling back to 1.0. This lets an agent override
+// the global per-model budget while still inheriting it when the agent is
+// silent.
+func resolveModelFactor(bundle *agent.Bundle, cfg *config.Config, model string) float64 {
+	if bundle != nil {
+		if f, ok := lookupIterationFactor(bundle.IterationFactor, model); ok {
+			return f
+		}
 	}
-	if f, ok := cfg.Model.IterationFactor[model]; ok && f > 0 {
-		return f
-	}
-	if f, ok := cfg.Model.IterationFactor["default"]; ok && f > 0 {
-		return f
+	if cfg != nil {
+		if f, ok := lookupIterationFactor(cfg.Model.IterationFactor, model); ok {
+			return f
+		}
 	}
 	return 1.0
+}
+
+// lookupIterationFactor returns a positive multiplier for the model from the
+// map, preferring an exact model entry, then a "default" entry. Non-positive
+// values are ignored (treated as unset) so a stray 0 can't zero out the budget.
+func lookupIterationFactor(m map[string]float64, model string) (float64, bool) {
+	if len(m) == 0 {
+		return 0, false
+	}
+	if f, ok := m[model]; ok && f > 0 {
+		return f, true
+	}
+	if f, ok := m["default"]; ok && f > 0 {
+		return f, true
+	}
+	return 0, false
 }
 
 // applyChildIterationCap sets the child agent's iteration cap based on

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -1834,6 +1834,41 @@ func TestResolveIterationBudget(t *testing.T) {
 			model:    "m",
 			expected: 23, // 22.5 -> 23
 		},
+		{
+			name:     "manifest factor overrides config factor for the model",
+			opts:     &RunOptions{MaxIterations: 100, Config: factorConfig(map[string]float64{"m": 3})},
+			bundle:   &agent.Bundle{IterationFactor: map[string]float64{"m": 0.5}},
+			model:    "m",
+			expected: 50, // manifest 0.5 wins over config 3.0
+		},
+		{
+			name:     "manifest default overrides config exact entry",
+			opts:     &RunOptions{MaxIterations: 100, Config: factorConfig(map[string]float64{"m": 3})},
+			bundle:   &agent.Bundle{IterationFactor: map[string]float64{"default": 2}},
+			model:    "m",
+			expected: 200, // manifest default 2.0 wins over config exact 3.0
+		},
+		{
+			name:     "manifest factor applies with no config",
+			opts:     &RunOptions{MaxIterations: 20},
+			bundle:   &agent.Bundle{IterationFactor: map[string]float64{"m": 2}},
+			model:    "m",
+			expected: 40,
+		},
+		{
+			name:     "manifest non-positive factor falls through to config",
+			opts:     &RunOptions{MaxIterations: 100, Config: factorConfig(map[string]float64{"m": 3})},
+			bundle:   &agent.Bundle{IterationFactor: map[string]float64{"m": 0}},
+			model:    "m",
+			expected: 300, // manifest 0 ignored, config 3.0 applies
+		},
+		{
+			name:     "manifest factor with manifest base, both from bundle",
+			opts:     &RunOptions{MaxIterations: 100},
+			bundle:   &agent.Bundle{MaxIterations: 12, IterationFactor: map[string]float64{"m": 4}},
+			model:    "m",
+			expected: 48, // base 12 (manifest) × 4 (manifest)
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Key Changes:**

- Agents can now declare `iteration_factor` in their `agent.yaml` manifest to override the global `model.iteration_factor` on a per-model basis
- Introduced `resolveModelFactor` and `lookupIterationFactor` helpers that apply manifest-level factors with higher precedence than config-level factors
- Added `IterationFactor` field to both `Manifest` and `Bundle` structs, wired through `BuildBundleWithOptions`
- Updated documentation and tests to cover the new precedence rules and YAML parsing

**Added:**

- `IterationFactor map[string]float64` field on `Manifest` and `Bundle` structs, supporting per-model keys and a `default` fallback - `agent/bundle.go`
- `lookupIterationFactor` helper that performs exact-model then `default` key lookup while ignoring non-positive values - `runner/model.go`
- `resolveModelFactor` function that checks the bundle's `IterationFactor` before falling back to the config-level `model.iteration_factor` - `runner/model.go`
- Documentation example showing how to set `iteration_factor` in an agent manifest to override the global factor for a specific model - `docs/configuration.md`
- Tests covering manifest factor precedence over config, `default` key fallback, non-positive value passthrough, and YAML parsing - `runner/model_test.go`, `agent/bundle_test.go`

**Changed:**

- `resolveIterationBudget` now calls `resolveModelFactor(bundle, opts.Config, model)` instead of the old `modelIterationFactor(opts.Config, model)`, enabling the bundle to influence factor resolution - `runner/model.go`
- `modelIterationFactor` replaced by the two new helpers (`resolveModelFactor` + `lookupIterationFactor`) which separate lookup logic from precedence logic - `runner/model.go`
- Documentation updated to describe the full resolution precedence: agent manifest factor → global config factor → `1.0` - `docs/configuration.md`