### PR TITLE
fix: handle container removal error on start failure

### DIFF
--- a/executor/docker.go
+++ b/executor/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/telemetry"
 	"github.com/moby/moby/api/types/container"
 	dockerclient "github.com/moby/moby/client"
@@ -140,7 +141,9 @@ func newDockerExecutor(cfg *Config, workingDir string, client dockerAPI) (*Docke
 	}
 
 	if err := client.ContainerStart(ctx, resp.ID); err != nil {
-		_ = client.ContainerRemove(ctx, resp.ID, dockerclient.ContainerRemoveOptions{Force: true})
+		if rmErr := client.ContainerRemove(ctx, resp.ID, dockerclient.ContainerRemoveOptions{Force: true}); rmErr != nil {
+			logging.Warn("docker executor cleanup failed: %v", rmErr)
+		}
 		return nil, fmt.Errorf("failed to start docker container: %w", err)
 	}
 

--- a/executor/docker_test.go
+++ b/executor/docker_test.go
@@ -211,6 +211,35 @@ func TestNewDockerExecutor_StartFailure(t *testing.T) {
 	}
 }
 
+// TestNewDockerExecutor_StartFailureCleanupError covers the path where the
+// post-start-failure cleanup ContainerRemove itself fails: the original start
+// error must still be returned (the cleanup failure is only logged).
+func TestNewDockerExecutor_StartFailureCleanupError(t *testing.T) {
+	t.Parallel()
+	client := &fakeDockerClient{
+		startFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("cannot start")
+		},
+		removeFn: func(_ context.Context, _ string, _ dockerclient.ContainerRemoveOptions) error {
+			return fmt.Errorf("cannot remove")
+		},
+	}
+
+	_, err := newDockerExecutor(&Config{
+		Options: map[string]string{"image": "ubuntu:22.04"},
+	}, "/tmp", client)
+	if err == nil || !strings.Contains(err.Error(), "failed to start docker container") {
+		t.Fatalf("expected start error to be returned, got: %v", err)
+	}
+	// The original start error must surface, not the cleanup error.
+	if strings.Contains(err.Error(), "cannot remove") {
+		t.Fatalf("cleanup error must not mask the start error, got: %v", err)
+	}
+	if len(client.removeCalls) != 1 {
+		t.Fatalf("expected one cleanup remove call, got %d", len(client.removeCalls))
+	}
+}
+
 func TestDockerExecutor_Execute(t *testing.T) {
 	t.Parallel()
 	client := &fakeDockerClient{


### PR DESCRIPTION
**Key Changes:**

- Replaced silent discard of container removal errors with a logged warning when cleanup fails after a container start failure
- Ensured the original start error is always returned to the caller, even when the subsequent cleanup also fails
- Added a dedicated test case to verify cleanup error does not mask the start error

**Added:**

- `TestNewDockerExecutor_StartFailureCleanupError` test - Covers the code path where both `ContainerStart` and the subsequent `ContainerRemove` fail, asserting that the original start error surfaces to the caller and the cleanup error is only logged, not propagated

**Changed:**

- Container cleanup error handling - In `newDockerExecutor`, the `ContainerRemove` call on start failure now captures its return value and logs a warning via `logging.Warn` if removal fails, rather than silently discarding it with `_ =`