### PR TITLE
refactor: improve error handling in event payload decoding

### DIFF
--- a/watch/summary.go
+++ b/watch/summary.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/session"
 )
 
@@ -38,7 +39,10 @@ func decodePayload(raw []byte) map[string]any {
 		return nil
 	}
 	var p map[string]any
-	_ = json.Unmarshal(raw, &p)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		logging.Warn("failed to decode event payload: %v", err)
+		return nil
+	}
 	return p
 }
 


### PR DESCRIPTION
**Changed:**

- Added proper error handling for `json.Unmarshal` in `decodePayload`, logging a warning and returning `nil` on failure instead of silently discarding the error - `watch/summary.go`
- Imported `github.com/cowdogmoo/squad/logging` to support warning output on decode failures