### PR TITLE
fix: detect and reject fabricated "files touched" reports from agents

### DIFF
--- a/runner/apply.go
+++ b/runner/apply.go
@@ -58,6 +58,39 @@ func responseIndicatesNoChanges(response string) bool {
 	return strings.Contains(strings.ToLower(response), "no changes")
 }
 
+// validateActionableChanges guards against fabricated "changes made" reports.
+// validateActionableResponse accepts a report that merely contains the text
+// "files touched", which a local model can emit without ever calling an edit
+// tool. When such a report claims files were touched but nothing actually
+// changed — no tool edit, no unified diff, and a clean git working tree — the
+// run is treated as a fabrication and fails. It is only meaningful for
+// edit-mode runs inside a git repo; every other case passes through.
+func validateActionableChanges(ctx context.Context, response, workingDir string) error {
+	// A real tool edit or a unified diff is authoritative actionable output.
+	if tools.EditsApplied(ctx) {
+		return nil
+	}
+	if _, err := extractUnifiedDiff(response); err == nil {
+		return nil
+	}
+	// A genuine "no changes" report is fine. Only a "files touched" claim
+	// needs cross-checking against the working tree.
+	if responseIndicatesNoChanges(response) ||
+		!strings.Contains(strings.ToLower(response), "files touched") {
+		return nil
+	}
+	// Changes can only be verified inside a git repo; don't penalize others.
+	if !isGitRepo(ctx, workingDir) {
+		return nil
+	}
+	// If git can't report (error) or the tree actually changed, the report is
+	// trustworthy; only a confirmed-clean tree is a fabrication.
+	if dirty, err := workingTreeDirty(ctx, workingDir); err != nil || dirty {
+		return nil
+	}
+	return fmt.Errorf("report claims \"files touched\" but the working tree is unchanged: the agent reported edits it never applied (disable with --require-actionable=false)")
+}
+
 func extractUnifiedDiff(response string) (string, error) {
 	const fence = "```diff"
 	const altFence = "```patch"

--- a/runner/apply_test.go
+++ b/runner/apply_test.go
@@ -167,6 +167,58 @@ func TestValidateActionableResponse_EditDeadlineReached(t *testing.T) {
 	}
 }
 
+func TestValidateActionableChanges(t *testing.T) {
+	t.Parallel()
+
+	const touched = "## Files Touched\n- a.yml — changed"
+	const noChanges = "No changes detected; codebase is clean."
+	const diff = "```diff\ndiff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-x\n+y\n```"
+
+	tests := []struct {
+		name    string
+		input   string
+		edits   bool // a real tool edit was recorded in ctx
+		dirty   bool // make the git tree dirty before checking
+		wantErr bool
+	}{
+		{"files touched but clean tree is fabrication", touched, false, false, true},
+		{"files touched with dirty tree passes", touched, false, true, false},
+		{"no changes report passes on clean tree", noChanges, false, false, false},
+		{"unified diff passes on clean tree", diff, false, false, false},
+		{"edits applied bypasses git check", touched, true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := initGitRepo(t)
+			if tt.dirty {
+				if err := os.WriteFile(filepath.Join(dir, "changed.txt"), []byte("x"), 0o644); err != nil {
+					t.Fatalf("dirty file: %v", err)
+				}
+			}
+			ctx := tools.InitEdits(context.Background())
+			if tt.edits {
+				tools.MarkEditsApplied(ctx)
+			}
+			err := validateActionableChanges(ctx, tt.input, dir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateActionableChanges() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateActionableChanges_NonGitDirSkips(t *testing.T) {
+	t.Parallel()
+	scrubGitEnv(t)
+	ctx := tools.InitEdits(context.Background())
+	// A non-git working dir cannot be verified, so the guard must pass through
+	// rather than fail a legitimate run.
+	if err := validateActionableChanges(ctx, "## Files Touched\n- a.yml", t.TempDir()); err != nil {
+		t.Fatalf("expected nil for non-git dir, got: %v", err)
+	}
+}
+
 func TestApplyResponseDiffNoChanges(t *testing.T) {
 	t.Parallel()
 	ctx := tools.InitEdits(context.Background())

--- a/runner/run.go
+++ b/runner/run.go
@@ -578,6 +578,13 @@ func handleResponse(cmd *cobra.Command, opts *RunOptions, response, workingDir s
 		if err := validateActionableResponse(cmd.Context(), response); err != nil {
 			return err
 		}
+		// Edit-mode runs must actually change the tree; a clean tree behind a
+		// "files touched" report means the model fabricated its result.
+		if opts.Mode == "" || opts.Mode == "edit" {
+			if err := validateActionableChanges(cmd.Context(), response, workingDir); err != nil {
+				return err
+			}
+		}
 	}
 
 	if opts.Apply {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -279,6 +279,7 @@ func TestHandleResponse(t *testing.T) {
 		wantErrContains string
 		wantStdout      bool
 		wantFile        bool
+		gitRepo         bool
 	}{
 		{
 			name:            "requires actionable error",
@@ -286,6 +287,14 @@ func TestHandleResponse(t *testing.T) {
 			response:        "plain text",
 			wantErr:         true,
 			wantErrContains: "not actionable",
+		},
+		{
+			name:            "fabricated files touched fails on clean git tree",
+			opts:            &RunOptions{RequireActionable: true, Mode: "edit"},
+			response:        "## Files Touched\n- a.yml — changed",
+			gitRepo:         true,
+			wantErr:         true,
+			wantErrContains: "working tree is unchanged",
 		},
 		{
 			name:       "apply no changes writes file",
@@ -314,7 +323,11 @@ func TestHandleResponse(t *testing.T) {
 			}
 			ctx := context.Background()
 			cmd.SetContext(ctx)
-			err := handleResponse(cmd, tt.opts, tt.response, t.TempDir())
+			workingDir := t.TempDir()
+			if tt.gitRepo {
+				workingDir = initGitRepo(t)
+			}
+			err := handleResponse(cmd, tt.opts, tt.response, workingDir)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("handleResponse() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
**Key Changes:**

- Introduces `validateActionableChanges` to catch agents that claim edits were made without actually modifying the working tree
- Guards are scoped to edit-mode runs inside git repositories, leaving all other cases unaffected
- A "files touched" claim is only rejected when no real tool edit, no unified diff, and a clean git working tree are all simultaneously true

**Added:**

- Fabrication detection guard - Implemented `validateActionableChanges` in `runner/apply.go` that cross-checks "files touched" claims against the git working tree, tool edit records, and unified diff presence before accepting a response as legitimate
- Edit-mode enforcement - Wired `validateActionableChanges` into `handleResponse` in `runner/run.go` so the check runs automatically for edit-mode runs, with an opt-out hint (`--require-actionable=false`) surfaced in the error message

- Test coverage - Added `TestValidateActionableChanges` with five table-driven cases covering clean-tree fabrication, dirty-tree pass-through, no-changes reports, unified diff bypass, and tool-edit bypass; added `TestValidateActionableChanges_NonGitDirSkips` to confirm non-git directories are never penalized - `runner/apply_test.go`

**Changed:**

- Response validation flow - Extended `handleResponse` in `runner/run.go` to call the new guard after the existing `validateActionableResponse` check, but only when `opts.Mode` is `""` or `"edit"` to avoid penalizing non-edit modes