### PR TITLE
feat: add sharded (map/reduce) execution mode and ascii-only edit guard

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/cowdogmoo/squad/browser"
 	"github.com/cowdogmoo/squad/executor"
 	"github.com/cowdogmoo/squad/logging"
@@ -89,6 +90,7 @@ type Manifest struct {
 	DependsOn     []string           `yaml:"depends_on,omitempty"`
 	Output        *OutputConfig      `yaml:"output,omitempty"`
 	Budget        *BudgetConfig      `yaml:"budget,omitempty"`
+	Execution     *ExecutionConfig   `yaml:"execution,omitempty"`
 	MCPServers    []mcp.ServerConfig `yaml:"mcp_servers,omitempty"`
 	DisableTask   bool               `yaml:"disable_task,omitempty"`
 	MaxIterations int                `yaml:"max_iterations,omitempty"` // iteration cap for this agent (0 = use CLI default)
@@ -103,6 +105,11 @@ type Manifest struct {
 	// Use for comment-cleanup agents (e.g. go-scrub-comments) so an LLM
 	// hallucinating new code cannot silently break the codebase.
 	CommentsOnly bool `yaml:"comments_only,omitempty"`
+	// ASCIIOnly, when true, rejects Edit/MultiEdit calls whose replacement
+	// text introduces non-ASCII characters not already in the original. Use
+	// for de-slop agents (e.g. degpt) so a model cannot sneak in smart quotes,
+	// em dashes, or other typographic tells — the very things it should strip.
+	ASCIIOnly bool `yaml:"ascii_only,omitempty"`
 	// Isolation declares the recommended isolation mode: "" (none) or
 	// "worktree" to run inside a fresh git worktree on a new branch.
 	// CLI --isolate and config run.isolation override this.
@@ -167,6 +174,112 @@ type ChildBudget struct {
 	Name          string  `yaml:"name"`
 	MaxCost       float64 `yaml:"max_cost,omitempty"`       // dedicated cost cap in USD (0 = use remaining budget)
 	MaxIterations int     `yaml:"max_iterations,omitempty"` // iteration cap for child (0 = inherit parent's cap)
+}
+
+// ExecutionConfig opts an agent into sharded (map/reduce) execution: squad
+// partitions the agent's input and runs the single-agent loop once per shard
+// with isolated context, then merges the per-shard outputs. It is intended for
+// agents whose unit of work is independent per file (degpt, go-scrub-comments,
+// rust-scrub-comments). Absent this block, the agent runs as a single loop —
+// the legacy behavior, unchanged.
+type ExecutionConfig struct {
+	// ShardBy selects the partitioning unit. "" (default) = no sharding;
+	// "file" = one shard per file (or per ShardBatch files).
+	ShardBy string `yaml:"shard_by,omitempty"`
+	// Glob lists the patterns squad globs (relative to the working dir) to
+	// build the work-list. Required when ShardBy is "file".
+	Glob []string `yaml:"glob,omitempty"`
+	// Exclude lists glob patterns to drop from the work-list (vendored,
+	// generated, VCS dirs).
+	Exclude []string `yaml:"exclude,omitempty"`
+	// ShardBatch is how many files go in one shard. Default 1 (strict per-file).
+	ShardBatch int `yaml:"shard_batch,omitempty"`
+	// Merge controls how per-shard outputs are combined: "json" (default,
+	// structured aggregate + per-shard sections) or "none" (verbatim concat).
+	Merge string `yaml:"merge,omitempty"`
+	// MaxParallel bounds concurrent shards. Default 1 (sequential, v1).
+	MaxParallel int `yaml:"max_parallel,omitempty"`
+	// OnShardError is "continue" (default; aggregate failures, other shards
+	// proceed) or "stop" (first failure aborts the rest).
+	OnShardError string `yaml:"on_shard_error,omitempty"`
+}
+
+// Sharded reports whether this manifest opts into sharded execution.
+func (m *Manifest) Sharded() bool {
+	return m.Execution != nil && m.Execution.ShardBy != ""
+}
+
+// Validate checks the execution block and fills defaults. It returns an error
+// for misconfiguration so failures surface at bundle load, not mid-run.
+func (e *ExecutionConfig) Validate() error {
+	if e == nil || e.ShardBy == "" {
+		return nil
+	}
+	if e.ShardBy != "file" {
+		return fmt.Errorf("execution.shard_by: unsupported value %q (only \"file\" is supported)", e.ShardBy)
+	}
+	if len(e.Glob) == 0 {
+		return fmt.Errorf("execution.shard_by: \"file\" requires a non-empty execution.glob")
+	}
+	if err := e.validatePatterns(); err != nil {
+		return err
+	}
+	e.fillDefaults()
+	return e.validateEnums()
+}
+
+// validatePatterns rejects malformed glob/exclude patterns at load so a typo
+// fails the bundle instead of silently matching nothing at runtime.
+func (e *ExecutionConfig) validatePatterns() error {
+	for _, p := range e.Glob {
+		if !doublestar.ValidatePattern(p) {
+			return fmt.Errorf("execution.glob: invalid pattern %q", p)
+		}
+	}
+	for _, p := range e.Exclude {
+		if !doublestar.ValidatePattern(p) {
+			return fmt.Errorf("execution.exclude: invalid pattern %q", p)
+		}
+	}
+	return nil
+}
+
+// fillDefaults applies the documented defaults to unset fields.
+func (e *ExecutionConfig) fillDefaults() {
+	if e.ShardBatch == 0 {
+		e.ShardBatch = 1
+	}
+	if e.Merge == "" {
+		e.Merge = "json"
+	}
+	if e.MaxParallel == 0 {
+		e.MaxParallel = 1
+	}
+	if e.OnShardError == "" {
+		e.OnShardError = "continue"
+	}
+}
+
+// validateEnums checks ranges and enum membership after defaults are applied.
+func (e *ExecutionConfig) validateEnums() error {
+	if e.ShardBatch < 1 {
+		return fmt.Errorf("execution.shard_batch must be >= 1, got %d", e.ShardBatch)
+	}
+	if e.Merge != "json" && e.Merge != "none" {
+		return fmt.Errorf("execution.merge: unsupported value %q (want \"json\" or \"none\")", e.Merge)
+	}
+	if e.MaxParallel < 1 {
+		return fmt.Errorf("execution.max_parallel must be >= 1, got %d", e.MaxParallel)
+	}
+	if e.OnShardError != "continue" && e.OnShardError != "stop" {
+		return fmt.Errorf("execution.on_shard_error: unsupported value %q (want \"continue\" or \"stop\")", e.OnShardError)
+	}
+	return nil
+}
+
+// Sharded reports whether this bundle opts into sharded (per-file) execution.
+func (b *Bundle) Sharded() bool {
+	return b.Execution != nil && b.Execution.ShardBy != ""
 }
 
 // PrimaryModel returns the first ranked ModelPreference, or the zero value
@@ -254,6 +367,7 @@ type Bundle struct {
 	BaseURL       string             // primary model's base URL override (for openai-compat)
 	Models        []ModelPreference  // ranked model preferences from manifest
 	Budget        *BudgetConfig      // budget configuration from manifest
+	Execution     *ExecutionConfig   // sharded-execution config from manifest (nil = single-loop)
 	Environment   *executor.Config   // execution environment from agent manifest
 	MCPServers    []mcp.ServerConfig // MCP server dependencies declared in agent.yaml
 	DisableTask   bool               // when true, the Task tool is not registered for this agent
@@ -269,6 +383,9 @@ type Bundle struct {
 	// CommentsOnly mirrors Manifest.CommentsOnly. Restricts Edit/MultiEdit
 	// to comment-only changes when true.
 	CommentsOnly bool
+	// ASCIIOnly mirrors Manifest.ASCIIOnly. Rejects edits that introduce
+	// non-ASCII characters not already present in the replaced text.
+	ASCIIOnly bool
 	// SkillEntries is the filtered set of skills surfaced in the system
 	// prompt's "Available skills" block. The runner uses these to build
 	// the Skill tool's runtime so the names the agent sees are exactly
@@ -944,6 +1061,7 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 		BaseURL:         primary.BaseURL,
 		Models:          manifest.Models,
 		Budget:          manifest.Budget,
+		Execution:       manifest.Execution,
 		Environment:     manifest.Environment,
 		MCPServers:      resolvedMCP,
 		DisableTask:     manifest.DisableTask,
@@ -952,6 +1070,7 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 		EditDeadline:    manifest.EditDeadline,
 		RemoteOnly:      manifest.IsRemoteOnly(),
 		CommentsOnly:    manifest.CommentsOnly,
+		ASCIIOnly:       manifest.ASCIIOnly,
 		SkillEntries:    skillEntries,
 		Requires:        manifest.Requires,
 	}, nil

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1560,3 +1560,27 @@ func TestExecutionConfigValidate(t *testing.T) {
 		t.Errorf("defaults not filled: %+v", cfg)
 	}
 }
+
+func TestSharded(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		exec *ExecutionConfig
+		want bool
+	}{
+		{"nil execution", nil, false},
+		{"empty shard_by", &ExecutionConfig{}, false},
+		{"file shard_by", &ExecutionConfig{ShardBy: "file"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := (&Manifest{Execution: tt.exec}).Sharded(); got != tt.want {
+				t.Errorf("Manifest.Sharded() = %v, want %v", got, tt.want)
+			}
+			if got := (&Bundle{Execution: tt.exec}).Sharded(); got != tt.want {
+				t.Errorf("Bundle.Sharded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1522,3 +1522,41 @@ func TestManifestIterationFactorParses(t *testing.T) {
 		t.Fatalf("iteration_factor[default] = %v, want 1.5", got)
 	}
 }
+
+func TestExecutionConfigValidate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cfg     *ExecutionConfig
+		wantErr bool
+	}{
+		{"nil is no-op", nil, false},
+		{"empty shard_by is no-op", &ExecutionConfig{}, false},
+		{"unsupported shard_by", &ExecutionConfig{ShardBy: "dir", Glob: []string{"*.go"}}, true},
+		{"file requires glob", &ExecutionConfig{ShardBy: "file"}, true},
+		{"valid file shard", &ExecutionConfig{ShardBy: "file", Glob: []string{"**/*.go"}}, false},
+		{"invalid glob pattern", &ExecutionConfig{ShardBy: "file", Glob: []string{"[bad"}}, true},
+		{"invalid exclude pattern", &ExecutionConfig{ShardBy: "file", Glob: []string{"**/*.go"}, Exclude: []string{"[bad"}}, true},
+		{"negative shard_batch", &ExecutionConfig{ShardBy: "file", Glob: []string{"*.go"}, ShardBatch: -1}, true},
+		{"unsupported merge", &ExecutionConfig{ShardBy: "file", Glob: []string{"*.go"}, Merge: "xml"}, true},
+		{"negative max_parallel", &ExecutionConfig{ShardBy: "file", Glob: []string{"*.go"}, MaxParallel: -1}, true},
+		{"unsupported on_shard_error", &ExecutionConfig{ShardBy: "file", Glob: []string{"*.go"}, OnShardError: "panic"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tt.cfg.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	// Defaults are filled on a valid config.
+	cfg := &ExecutionConfig{ShardBy: "file", Glob: []string{"**/*.go"}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected err: %v", err)
+	}
+	if cfg.ShardBatch != 1 || cfg.Merge != "json" || cfg.MaxParallel != 1 || cfg.OnShardError != "continue" {
+		t.Errorf("defaults not filled: %+v", cfg)
+	}
+}

--- a/agent/composed.go
+++ b/agent/composed.go
@@ -110,6 +110,10 @@ func (m *Manifest) Validate() error {
 		return err
 	}
 
+	if err := m.Execution.Validate(); err != nil {
+		return err
+	}
+
 	if m.IsComposed() {
 		return m.validateComposed()
 	}

--- a/agent/composed_test.go
+++ b/agent/composed_test.go
@@ -55,6 +55,18 @@ func TestValidate_LeafInlinePromptRejectsEntrypoint(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsBadExecutionBlock(t *testing.T) {
+	m := &Manifest{
+		Name:      "bad",
+		Prompt:    "hi",
+		Execution: &ExecutionConfig{ShardBy: "dir", Glob: []string{"*.go"}},
+	}
+	err := m.Validate()
+	if err == nil || !strings.Contains(err.Error(), "shard_by") {
+		t.Fatalf("expected execution validation error, got: %v", err)
+	}
+}
+
 func TestValidate_LeafInlinePromptRejectsWrapper(t *testing.T) {
 	m := &Manifest{
 		Name:    "bad",

--- a/docs/design/sharded-execution.md
+++ b/docs/design/sharded-execution.md
@@ -1,0 +1,216 @@
+# Design: Sharded (map/reduce) agent execution
+
+Status: **DRAFT for review** — no code yet.
+Author: (pairing session)
+Date: 2026-06-25
+
+## 1. Problem
+
+squad runs each leaf agent as a **single linear tool loop with one ever-growing
+context window**. Every file the agent reads accumulates in the same context.
+For agents whose unit of work is **independent per file** — `degpt`,
+`go-scrub-comments`, `rust-scrub-comments` — this is the wrong shape:
+
+- Context bloats as the agent reads all N files → weak/local models loop,
+  slow down, or overflow the window (observed: gpt-oss-120b looped to 23
+  iterations / 6 min and covered 5/32 files; glm-4.7-flash overflowed a 32K
+  slot outright).
+- The agent prompt is forced to babysit the harness's job
+  ("read 4-6 files per iteration", "do NOT re-Glob", "STOP after report") —
+  brittle instructions that the model ignores under load.
+
+The work is embarrassingly parallel: scanning `a.md` has nothing to do with
+scanning `b.md`. squad should **partition the input and run the agent per
+shard with isolated context**, then merge. The model should never have to
+reason about context budget.
+
+## 2. Goal & non-goals
+
+**Goal:** an opt-in, manifest-declared execution mode that shards an agent's
+input (by file, batched), runs the existing single-agent loop once per shard
+with fresh context, and merges the per-shard outputs into one result —
+preserving edit mode, readonly mode, the fabrication guard, and metrics.
+
+**Non-goals:**
+
+- Not the default. Whole-repo-context agents (cross-file refactors, dependency
+  tracing, `go-review`) must be unaffected. Sharding is opt-in per agent.
+- Not a replacement for pipelines (which compose *different* agents). This
+  shards *one* agent over *data*.
+- v1 does not shard by non-file units (function, package). File/glob only;
+  the schema leaves room to extend.
+
+## 3. Manifest schema
+
+New optional `execution:` block on the leaf-agent manifest
+(`agent.Manifest`, `agent/bundle.go`):
+
+```yaml
+execution:
+  shard_by: file          # "" (default, no sharding) | "file"
+  glob:                   # patterns squad globs to build the work-list.
+    - "**/*.md"           #   Required when shard_by: file.
+    - "**/*.txt"
+  exclude:                # optional ignore globs (node_modules, vendor, .git…)
+    - "**/node_modules/**"
+  shard_batch: 4          # files per shard (default 1 = strict per-file)
+  merge: reports          # "reports" (concat per-shard text) | "none"
+  max_parallel: 1         # v1 default 1 (sequential); >1 enables concurrency (v2)
+  on_shard_error: continue # "continue" (aggregate failures) | "stop"
+```
+
+```go
+// agent/bundle.go
+type ExecutionConfig struct {
+    ShardBy      string   `yaml:"shard_by,omitempty"`      // "" | "file"
+    Glob         []string `yaml:"glob,omitempty"`
+    Exclude      []string `yaml:"exclude,omitempty"`
+    ShardBatch   int      `yaml:"shard_batch,omitempty"`   // default 1
+    Merge        string   `yaml:"merge,omitempty"`         // default "reports"
+    MaxParallel  int      `yaml:"max_parallel,omitempty"`  // default 1
+    OnShardError string   `yaml:"on_shard_error,omitempty"`// default "continue"
+}
+// Manifest gains:  Execution *ExecutionConfig `yaml:"execution,omitempty"`
+```
+
+Validation at bundle-load: `shard_by: file` requires non-empty `glob`;
+`merge` ∈ {reports,none}; `shard_batch` ≥ 1; `max_parallel` ≥ 1.
+
+## 4. Execution model
+
+In `ExecuteRun` (`runner/run.go`), after `prepareBundle` and before the single
+`InvokeModel` call, branch on `bundle.Manifest.Execution.ShardBy`:
+
+```
+if shardBy == "file":
+    files   := globWorkList(workingDir, exec.Glob, exec.Exclude)   // squad owns discovery
+    shards  := batch(files, exec.ShardBatch)
+    results := runShards(ctx, opts, bundle, shards)                // each → InvokeModel, isolated ctx
+    response, m := merge(results, exec.Merge)
+    handleResponse(merged response)                                // one validate/apply/write
+else:
+    (today's single InvokeModel path, unchanged)
+```
+
+Per-shard run (`runShard`):
+
+- Clones `opts` with the shard's file list injected. The shard files are
+  surfaced to the agent via the prompt (a `{{.ShardFiles}}` template var and/or
+  an injected "Files assigned to you:" block), so the prompt no longer globs.
+- **Fresh context per shard**: a new `InvokeModel` call gets its own message
+  history and `tools.ResetEditsApplied(ctx)`. This is the core win — each run
+  sees only its 1–N files.
+- Returns `(response string, *metrics.Metrics, error)` — `InvokeModel`'s
+  existing signature; no new primitive needed.
+
+`InvokeModel` is reused as-is. Sharding is orchestration *around* it.
+
+## 5. Merge semantics
+
+- `merge: reports` — concatenate per-shard response text under a synthesized
+  header per shard (`## <file(s)>`), then a roll-up summary line
+  (`N files scanned, M edited, K clean`). Re-emit the required literal markers
+  once at the top (`Files touched: …` aggregated across shards, or
+  `Files touched: none` + `No changes` when all clean).
+- `merge: none` — emit shards verbatim, separated.
+
+Edits are applied **by each shard's own loop** against its own files (edit mode
+uses the Edit tool directly; no unified-diff reassembly needed). Merge is about
+the *report*, not the edits.
+
+## 6. Guard & budget interactions
+
+- **Fabrication guard** (`validateActionableChanges`): runs **per shard**
+  (inside each shard's handleResponse-equivalent), where the claim↔tree check is
+  cleanest (a shard claims edits to its own file). The merged report is not
+  re-checked for fabrication (it's an aggregate). `tools.EditsApplied` is
+  per-shard ctx. This actually *strengthens* the guard — fabrication is caught
+  at file granularity instead of being masked by other files' real edits.
+- **Iteration budget** (`scale_factor: files`, `MaxIterations`,
+  `IterationFactor`): becomes **per-shard** — each shard gets the budget for
+  *its* file count (batch size), so a 1-file shard gets a small cap and can't
+  loop for 23 iterations. This makes the existing `files_per_iteration` budget
+  finally meaningful. Total run budget = sum of shard budgets, logged.
+- **EditDeadline / CommentsOnly**: apply per shard unchanged.
+- **Metrics**: aggregate tokens/cost/iterations across shards into one
+  `*metrics.Metrics` (sum), so `printMetrics` and history reporting are
+  unchanged downstream.
+
+## 7. Agent (degpt) changes once sharding lands
+
+The prompt sheds all context-management scaffolding:
+
+- Delete the Phase-1 "Glob all four patterns / FROZEN set / do NOT re-Glob"
+  machinery and the "read 4-6 files per iteration / READ-ONCE / phase boundary"
+  rules — squad now hands the agent its files.
+- System prompt becomes: "Score the prose paragraphs in the file(s) provided.
+  Flag/rewrite per the rules. Report." No discovery, no budget babysitting.
+- `budget.scale_factor: files` stays (now drives per-shard caps).
+- Same `detect-llm-tells` skill, same edit/readonly gating.
+
+`go-scrub-comments` / `rust-scrub-comments` adopt the same `execution:` block
+(glob `**/*.go` / `**/*.rs`).
+
+## 8. Parallelism
+
+- **v1: `max_parallel: 1` (sequential).** Lands the context-isolation win with
+  zero concurrency risk. Each shard is small → fast even serially.
+- **v2: `max_parallel: N`.** Bounded worker pool over shards, mirroring the
+  tier-parallel pattern already in `pipeline/pipeline.go`. Edit-mode shards
+  touch disjoint files (no write conflicts by construction, since shards
+  partition the file set). Metrics/merge collected after the barrier.
+
+## 9. Failure handling
+
+- `on_shard_error: continue` (default): a shard that errors (model error,
+  budget exceeded, guard rejection) is recorded as a failed shard in the merged
+  report; other shards proceed. Exit non-zero iff ≥1 shard failed *and* none
+  succeeded, OR a stricter policy is chosen.
+- `on_shard_error: stop`: first failure aborts remaining shards.
+- A shard whose fabrication guard fires fails *that shard only* — the offending
+  file's report is dropped, not the whole run.
+
+## 10. Edge cases
+
+- **0 files matched**: emit a clean no-findings report (`Files touched: none` /
+  `No changes`), exit 0. Do not error.
+- **1 file / 1 shard**: behaves like a normal single run (no overhead beyond a
+  glob).
+- **Working tree dirty before run**: per-shard guard only attributes a shard's
+  own claimed files; pre-existing dirt elsewhere is ignored (same as today).
+- **`working_dir: none` agents**: incompatible with `shard_by: file`; reject at
+  load.
+
+## 11. Testing
+
+- Unit: `globWorkList` (include/exclude), `batch` (batching + remainder),
+  `merge` (marker re-emission, roll-up counts), schema validation.
+- Integration (table-driven, fake `InvokeModel`): N shards → merged report;
+  one shard fabricates → that shard fails, others pass; 0-file → clean report;
+  edit-mode shards apply to disjoint files.
+- End-to-end smoke: degpt over a 3-file fixture (1 slop, 2 clean) on local
+  gpt-oss → exactly the slop file edited, fast, exit 0, report lists all 3.
+
+## 12. Backward compatibility
+
+- No `execution:` block → today's exact behavior. Zero risk to existing agents.
+- New manifest field is optional and omit-empty.
+- The CLI gains no required flags; an optional `--no-shard` escape hatch can
+  force the single-loop path for debugging.
+
+## 13. Open questions
+
+1. **Discovery ownership**: squad globs (proposed). Confirm no agent needs to
+   influence the work-list dynamically (e.g., skip files by content) — if so,
+   add an optional pre-filter hook later.
+2. **Merge for edit mode**: is a concatenated report enough, or do we want a
+   structured roll-up (JSON summary + per-file sections)? Proposed: text concat
+   + roll-up header for v1.
+3. **Budget accounting**: sum per-shard, or impose a global ceiling that halts
+   remaining shards when hit? Proposed: per-shard caps + logged total; optional
+   global ceiling later.
+4. **Where the shard loop lives**: `ExecuteRun` (proposed) vs a new
+   `runner/shard.go` orchestrator called by `ExecuteRun`. Proposed: new
+   `runner/shard.go`, keep `ExecuteRun` thin.
+
+```

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -31,6 +31,7 @@ type ChildMetrics struct {
 	Agent        string
 	InputTokens  int64
 	OutputTokens int64
+	Iterations   int
 	Model        string
 	Provider     string
 }
@@ -160,6 +161,7 @@ func (m *Metrics) AddChild(agent string, child *Metrics) {
 		Agent:        agent,
 		InputTokens:  child.InputTokens(),
 		OutputTokens: child.OutputTokens(),
+		Iterations:   child.Iterations(),
 		Model:        child.Model,
 		Provider:     child.Provider,
 	})
@@ -536,10 +538,31 @@ func (m *Metrics) String() string {
 // Summary returns a multi-line summary of the recorded metrics.
 func (m *Metrics) Summary() string {
 	cost := m.Cost()
-	costLine := "  Cost:       " + m.costString(cost)
 	in := m.InputTokens()
 	out := m.OutputTokens()
 	total := in + out
+
+	m.mu.Lock()
+	children := make([]ChildMetrics, len(m.Children))
+	copy(children, m.Children)
+	m.mu.Unlock()
+
+	// Header display values. When the parent ran no model calls itself but has
+	// children (a pure aggregator, e.g. a sharded run where every model call
+	// happens in a shard), the header would otherwise read 0 iterations / 0
+	// tokens / $0. Fall back to the children sum so the top line reflects the
+	// run. The per-child breakdown and "TOTAL (all agents)" line below stay
+	// computed from the parent's own counters + children, so no double-count.
+	dispIn, dispOut, dispIters, dispCost := in, out, m.Iterations(), cost
+	if total == 0 && len(children) > 0 {
+		for _, c := range children {
+			dispIn += c.InputTokens
+			dispOut += c.OutputTokens
+			dispIters += c.Iterations
+		}
+		dispCost = m.TotalCostWithChildren()
+	}
+	costLine := "  Cost:       " + m.costString(dispCost)
 
 	var warningLine string
 	loaded, _, err := PricingStatus()
@@ -557,20 +580,15 @@ Agent Metrics
 %s%s
 `,
 		m.Duration().Round(time.Millisecond),
-		m.Iterations(),
+		dispIters,
 		m.Model,
 		m.Provider,
-		in,
-		out,
-		total,
+		dispIn,
+		dispOut,
+		dispIn+dispOut,
 		costLine,
 		warningLine,
 	)
-
-	m.mu.Lock()
-	children := make([]ChildMetrics, len(m.Children))
-	copy(children, m.Children)
-	m.mu.Unlock()
 
 	if len(children) == 0 {
 		return base

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -320,6 +320,37 @@ func TestSummaryOutput(t *testing.T) {
 	}
 }
 
+func TestSummaryAggregatorFallback(t *testing.T) {
+	t.Parallel()
+	// A pure aggregator (e.g. a sharded run): the parent makes no model calls
+	// itself; every call happens in a child. The header must reflect the
+	// children sum, not the parent's own zeros — and the "TOTAL" line must not
+	// double-count.
+	parent := New("openai", "gpt-oss-120b")
+	parent.Finish()
+	for _, name := range []string{"shard-01", "shard-02", "shard-03"} {
+		child := New("openai", "gpt-oss-120b")
+		child.AddTokens(10000, 2000) // 12000 tokens each
+		child.IncrementIterations()
+		child.IncrementIterations() // 2 iterations each
+		parent.AddChild(name, child)
+	}
+
+	s := parent.Summary()
+	if strings.Contains(s, "Iterations: 0") {
+		t.Errorf("aggregator header shows 0 iterations:\n%s", s)
+	}
+	if !strings.Contains(s, "Iterations: 6") { // 3 × 2
+		t.Errorf("header should sum child iterations to 6:\n%s", s)
+	}
+	if !strings.Contains(s, "36000 total") { // 3 × 12000
+		t.Errorf("header should sum child tokens to 36000:\n%s", s)
+	}
+	if strings.Contains(s, "72000") {
+		t.Errorf("TOTAL line double-counted children:\n%s", s)
+	}
+}
+
 func TestSummaryOllama(t *testing.T) {
 	t.Parallel()
 	m := New("ollama", "llama3")

--- a/runner/apply.go
+++ b/runner/apply.go
@@ -58,6 +58,39 @@ func responseIndicatesNoChanges(response string) bool {
 	return strings.Contains(strings.ToLower(response), "no changes")
 }
 
+// claimsSpecificFilesTouched reports whether the response contains a
+// "files touched:" line that names at least one real file — i.e. anything
+// other than "none". A genuine no-changes report says "files touched: none";
+// a fabricated edit report names files it never wrote.
+//
+// This is deliberately independent of any "no changes" marker. A report that
+// both names a specific file AND says "no changes" is self-contradictory, and
+// that contradiction is itself a fabrication signature (observed from local
+// models that describe a rewrite in prose without ever calling an edit tool);
+// it must be cross-checked against the working tree rather than waved through.
+func claimsSpecificFilesTouched(response string) bool {
+	lines := strings.Split(response, "\n")
+	for i, line := range lines {
+		idx := strings.Index(strings.ToLower(line), "files touched")
+		if idx < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(line[idx+len("files touched"):])
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, ":"))
+		// The value may sit on the next line (e.g. a bullet list under the label).
+		if rest == "" && i+1 < len(lines) {
+			rest = strings.TrimSpace(lines[i+1])
+		}
+		// Strip surrounding markdown emphasis / list punctuation.
+		rest = strings.Trim(rest, " *_`-.|")
+		if rest == "" || strings.EqualFold(rest, "none") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // validateActionableChanges guards against fabricated "changes made" reports.
 // validateActionableResponse accepts a report that merely contains the text
 // "files touched", which a local model can emit without ever calling an edit
@@ -73,10 +106,11 @@ func validateActionableChanges(ctx context.Context, response, workingDir string)
 	if _, err := extractUnifiedDiff(response); err == nil {
 		return nil
 	}
-	// A genuine "no changes" report is fine. Only a "files touched" claim
-	// needs cross-checking against the working tree.
-	if responseIndicatesNoChanges(response) ||
-		!strings.Contains(strings.ToLower(response), "files touched") {
+	// Only a claim that specific files were touched needs cross-checking. A
+	// genuine "files touched: none" / no-changes report passes. A stray "no
+	// changes" marker does NOT exempt a report that also names specific files —
+	// that self-contradiction is exactly how some local models fabricate edits.
+	if !claimsSpecificFilesTouched(response) {
 		return nil
 	}
 	// Changes can only be verified inside a git repo; don't penalize others.

--- a/runner/apply_test.go
+++ b/runner/apply_test.go
@@ -173,6 +173,12 @@ func TestValidateActionableChanges(t *testing.T) {
 	const touched = "## Files Touched\n- a.yml — changed"
 	const noChanges = "No changes detected; codebase is clean."
 	const diff = "```diff\ndiff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-x\n+y\n```"
+	// A report that names a specific file AND says "no changes" — the
+	// self-contradictory shape a local model emits when it describes a rewrite
+	// in prose without ever calling an edit tool.
+	const contradictory = "## Summary\nRewrote one paragraph.\n\nFiles touched: OVERVIEW.md\nNo changes"
+	// A genuine no-findings report: explicit "none" plus the no-changes marker.
+	const noneTouched = "Files touched: none\nNo changes"
 
 	tests := []struct {
 		name    string
@@ -186,6 +192,9 @@ func TestValidateActionableChanges(t *testing.T) {
 		{"no changes report passes on clean tree", noChanges, false, false, false},
 		{"unified diff passes on clean tree", diff, false, false, false},
 		{"edits applied bypasses git check", touched, true, false, false},
+		{"specific file + 'no changes' on clean tree is fabrication", contradictory, false, false, true},
+		{"specific file + 'no changes' passes when edits applied", contradictory, true, false, false},
+		{"files touched: none with no changes passes", noneTouched, false, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runner/run.go
+++ b/runner/run.go
@@ -209,8 +209,23 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 	}
 
 	cmd.SetContext(ctx)
+	return invokeAndHandle(ctx, cmd, opts, bundle, prompt, workingDir, logger)
+}
+
+// invokeAndHandle runs the agent (sharded or single-loop), prints metrics, and
+// applies/writes the response. It owns the metrics object and the deferred
+// metrics/session teardown, keeping ExecuteRun's setup small.
+func invokeAndHandle(ctx context.Context, cmd *cobra.Command, opts *RunOptions, bundle *agent.Bundle, prompt, workingDir string, logger *session.Logger) (err error) {
 	tools.ResetEditsApplied(ctx)
-	response, m, err := InvokeModel(ctx, opts, bundle)
+
+	var response string
+	var m *metrics.Metrics
+	sharded := bundle.Sharded()
+	if sharded {
+		response, m, err = runSharded(ctx, cmd, opts, bundle, prompt, workingDir)
+	} else {
+		response, m, err = InvokeModel(ctx, opts, bundle)
+	}
 
 	defer func() {
 		logRunHistory(opts, m)
@@ -220,16 +235,24 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 		closeSession(logger, m, err)
 	}()
 
+	// Sharded runs already applied + validated edits per shard inside
+	// runSharded; the merged response is an aggregate report. Write it even when
+	// err is non-nil (failed shards) so partial results aren't lost, then
+	// surface the error for a non-zero exit.
+	if sharded {
+		if response != "" {
+			if writeErr := writeResponse(cmd, response, opts); writeErr != nil && err == nil {
+				return writeErr
+			}
+		}
+		return err
+	}
+
 	if err != nil {
 		handleBudgetExceeded(cmd, opts, m, response, workingDir, err)
 		return err
 	}
-
-	if err := handleResponse(cmd, opts, response, workingDir); err != nil {
-		return err
-	}
-
-	return nil
+	return handleResponse(cmd, opts, response, workingDir)
 }
 
 // initRunContext attaches per-run tool state (edits tracker, edit-deadline
@@ -242,6 +265,10 @@ func initRunContext(ctx context.Context, bundle *agent.Bundle) context.Context {
 	if bundle.CommentsOnly {
 		ctx = tools.InitCommentsOnlyMode(ctx)
 		logging.InfoContext(ctx, "comments-only mode: Edit/MultiEdit will reject non-comment changes")
+	}
+	if bundle.ASCIIOnly {
+		ctx = tools.InitASCIIOnlyMode(ctx)
+		logging.InfoContext(ctx, "ascii-only mode: Edit/MultiEdit will reject newly introduced non-ASCII characters")
 	}
 	return ctx
 }

--- a/runner/shard.go
+++ b/runner/shard.go
@@ -1,0 +1,303 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/spf13/cobra"
+
+	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
+	"github.com/cowdogmoo/squad/pipeline"
+	"github.com/cowdogmoo/squad/tools"
+)
+
+// shardSkipDirs are directories never globbed when building a shard work-list.
+// Mirrors pipeline's partition skip set.
+var shardSkipDirs = map[string]bool{
+	".git": true, ".venv": true, "venv": true, "node_modules": true,
+	"vendor": true, "__pycache__": true, ".tox": true, ".mypy_cache": true,
+	".pytest_cache": true, ".ruff_cache": true, "target": true,
+	"build": true, "dist": true, ".claude": true,
+}
+
+// shardOutcome is one shard's result in the merged report.
+type shardOutcome struct {
+	Files        []string `json:"files"`
+	EditsApplied bool     `json:"edits_applied"`
+	Error        string   `json:"error,omitempty"`
+	Report       string   `json:"report"`
+}
+
+// shardSummary is the roll-up across all shards.
+type shardSummary struct {
+	Files  int `json:"files"`
+	Shards int `json:"shards"`
+	Edited int `json:"edited"`
+	Clean  int `json:"clean"`
+	Failed int `json:"failed"`
+}
+
+// shardedResult is the structured merge of a sharded run.
+type shardedResult struct {
+	Agent   string         `json:"agent"`
+	Mode    string         `json:"mode"`
+	Summary shardSummary   `json:"summary"`
+	Shards  []shardOutcome `json:"shards"`
+}
+
+// runSharded executes a leaf agent that declared an execution.shard_by block.
+// It globs the work-list, splits it into shards of exec.ShardBatch files, and
+// runs the normal single-agent loop once per shard with FRESH context — so no
+// single run accumulates the whole repo. Edits are applied live per shard by
+// the agent's own Edit tool calls; this function aggregates metrics and merges
+// the per-shard reports. Shards run through a bounded worker pool sized by
+// exec.MaxParallel (1 = sequential).
+func runSharded(ctx context.Context, cmd *cobra.Command, opts *RunOptions, bundle *agent.Bundle, prompt, workingDir string) (string, *metrics.Metrics, error) {
+	exec := bundle.Execution
+	parent := metrics.New(opts.Provider, opts.Model)
+
+	files, err := globShardFiles(workingDir, exec.Glob, exec.Exclude)
+	if err != nil {
+		return "", parent, fmt.Errorf("shard globbing failed: %w", err)
+	}
+	shards := batchFiles(files, exec.ShardBatch)
+	logging.InfoContext(ctx, "sharded run: %d files → %d shards (batch=%d)", len(files), len(shards), exec.ShardBatch)
+
+	if len(shards) == 0 {
+		// No matching files is a correct, clean outcome.
+		res := shardedResult{Agent: opts.Agent, Mode: opts.Mode, Summary: shardSummary{}}
+		return mergeShards(res, exec.Merge), parent, nil
+	}
+
+	bundleOpts := &agent.BundleOptions{
+		SkillOverrides: opts.SkillOverrides,
+		CatalogPaths:   resolveSkillCatalogPaths(opts.Config),
+	}
+
+	// Bounded worker pool. MaxParallel == 1 is effectively sequential. Each
+	// shard gets its OWN edit-tracker (tools.InitEdits per shard) so concurrent
+	// shards don't race on the shared tracker; partitions are disjoint files,
+	// so concurrent edits never touch the same file.
+	results := make([]shardOutcome, len(shards))
+	childMetrics := make([]*metrics.Metrics, len(shards))
+	sem := make(chan struct{}, exec.MaxParallel)
+	var wg sync.WaitGroup
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var stopOnce sync.Once
+	stop := func() {
+		if exec.OnShardError == "stop" {
+			stopOnce.Do(cancel)
+		}
+	}
+	logging.InfoContext(ctx, "running %d shards (max_parallel=%d)", len(shards), exec.MaxParallel)
+
+	for i, shard := range shards {
+		wg.Add(1)
+		go func(idx int, files []string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if runCtx.Err() != nil {
+				results[idx] = shardOutcome{Files: files, Error: "skipped: an earlier shard failed (on_shard_error=stop)"}
+				return
+			}
+
+			oc, sm := runOneShard(runCtx, opts, bundleOpts, files, idx, len(shards), prompt, workingDir)
+			results[idx] = oc
+			childMetrics[idx] = sm
+			if oc.Error != "" {
+				logging.InfoContext(ctx, "  ✗ shard %d/%d (%s): %s", idx+1, len(shards), strings.Join(files, ", "), oc.Error)
+				stop()
+			}
+		}(i, shard)
+	}
+	wg.Wait()
+
+	// Aggregate in deterministic order: metrics rolled up as children, the
+	// first error preserved for the run's exit status.
+	outcomes := make([]shardOutcome, len(shards))
+	var firstErr error
+	for i := range shards {
+		if childMetrics[i] != nil {
+			parent.AddChild(fmt.Sprintf("shard-%02d", i+1), childMetrics[i])
+		}
+		outcomes[i] = results[i]
+		if outcomes[i].Error != "" && firstErr == nil {
+			firstErr = fmt.Errorf("shard %d (%s): %s", i+1, strings.Join(outcomes[i].Files, ", "), outcomes[i].Error)
+		}
+	}
+
+	res := summarize(opts, outcomes)
+	merged := mergeShards(res, exec.Merge)
+
+	// Aggregate failures fail the run honestly (non-zero exit), even in
+	// "continue" mode — continue only means other shards still ran.
+	if res.Summary.Failed > 0 {
+		return merged, parent, fmt.Errorf("%d of %d shards failed: %w", res.Summary.Failed, len(shards), firstErr)
+	}
+	return merged, parent, nil
+}
+
+// runOneShard builds the shard's bundle, runs the single-agent loop in an
+// isolated edit-tracker context, and classifies the outcome. Returning the
+// outcome + metrics keeps the goroutine in runSharded small.
+func runOneShard(runCtx context.Context, opts *RunOptions, bundleOpts *agent.BundleOptions, files []string, idx, total int, prompt, workingDir string) (shardOutcome, *metrics.Metrics) {
+	shardPrompt := pipeline.FormatPartitionPrompt(files, idx+1, total) + "\n\n" + prompt
+	shardBundle, buildErr := agent.BuildBundleWithOptions(opts.AgentsDir, opts.Agent, shardPrompt, workingDir, opts.Mode, opts.Vars, bundleOpts)
+	if buildErr != nil {
+		return shardOutcome{Files: files, Error: buildErr.Error()}, nil
+	}
+
+	shardCtx := tools.InitEdits(runCtx) // isolated edit-tracker per shard
+	resp, sm, runErr := InvokeModel(shardCtx, opts, shardBundle)
+	editsApplied := tools.EditsApplied(shardCtx)
+	oc := shardOutcome{Files: files, EditsApplied: editsApplied, Report: resp}
+	switch {
+	case runErr != nil:
+		oc.Error = runErr.Error()
+	case opts.RequireActionable:
+		if vErr := validateShard(resp, editsApplied); vErr != nil {
+			oc.Error = vErr.Error()
+		}
+	}
+	return oc, sm
+}
+
+// validateShard is the per-shard fabrication check. The edit-tracker (reset
+// before each shard) is authoritative ground truth, so it is reliable across
+// sequential shards in a way the whole-tree git check is not: a shard that
+// claims specific files were touched but recorded no edit is a fabrication.
+func validateShard(report string, editsApplied bool) error {
+	if editsApplied {
+		return nil
+	}
+	if claimsSpecificFilesTouched(report) {
+		return fmt.Errorf("report claims files touched but no edit was applied in this shard")
+	}
+	return nil
+}
+
+// globShardFiles builds the shard work-list: the union of include globs
+// (relative to workingDir), minus excludes and skip dirs, sorted and deduped.
+func globShardFiles(workingDir string, include, exclude []string) ([]string, error) {
+	fsys := os.DirFS(workingDir)
+	seen := map[string]bool{}
+	var out []string
+	for _, pattern := range include {
+		matches, err := doublestar.Glob(fsys, pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob %q: %w", pattern, err)
+		}
+		for _, rel := range matches {
+			if seen[rel] || skipPath(rel) || matchesAny(rel, exclude) {
+				continue
+			}
+			info, statErr := fs.Stat(fsys, rel)
+			if statErr != nil || info.IsDir() {
+				continue
+			}
+			seen[rel] = true
+			out = append(out, rel)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// skipPath reports whether any path segment is a skipped directory. rel comes
+// from an io/fs glob, so it is always "/"-separated regardless of OS.
+func skipPath(rel string) bool {
+	for _, seg := range strings.Split(rel, "/") {
+		if shardSkipDirs[seg] {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAny reports whether rel matches any of the exclude globs.
+func matchesAny(rel string, patterns []string) bool {
+	for _, p := range patterns {
+		if ok, _ := doublestar.Match(p, rel); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// batchFiles splits files into shards of at most size entries (size >= 1).
+func batchFiles(files []string, size int) [][]string {
+	if size < 1 {
+		size = 1
+	}
+	var shards [][]string
+	for i := 0; i < len(files); i += size {
+		end := i + size
+		if end > len(files) {
+			end = len(files)
+		}
+		shards = append(shards, files[i:end])
+	}
+	return shards
+}
+
+// summarize rolls per-shard outcomes into a shardedResult.
+func summarize(opts *RunOptions, outcomes []shardOutcome) shardedResult {
+	res := shardedResult{Agent: opts.Agent, Mode: opts.Mode, Shards: outcomes}
+	res.Summary.Shards = len(outcomes)
+	for _, oc := range outcomes {
+		res.Summary.Files += len(oc.Files)
+		switch {
+		case oc.Error != "":
+			res.Summary.Failed++
+		case oc.EditsApplied:
+			res.Summary.Edited++
+		default:
+			res.Summary.Clean++
+		}
+	}
+	return res
+}
+
+// mergeShards renders the merged output. "json" emits the structured aggregate;
+// "none" concatenates the per-shard reports verbatim under file headers.
+func mergeShards(res shardedResult, mode string) string {
+	if mode == "none" {
+		var sb strings.Builder
+		for _, oc := range res.Shards {
+			fmt.Fprintf(&sb, "## %s\n\n%s\n\n---\n\n", strings.Join(oc.Files, ", "), oc.Report)
+		}
+		fmt.Fprintf(&sb, "Files touched: %s\n", touchedList(res))
+		return sb.String()
+	}
+	b, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("{\"error\":\"merge failed: %v\"}", err)
+	}
+	return string(b)
+}
+
+// touchedList returns a human "files touched" line for the "none" merge.
+func touchedList(res shardedResult) string {
+	var touched []string
+	for _, oc := range res.Shards {
+		if oc.EditsApplied {
+			touched = append(touched, oc.Files...)
+		}
+	}
+	if len(touched) == 0 {
+		return "none"
+	}
+	return strings.Join(touched, ", ")
+}

--- a/runner/shard_test.go
+++ b/runner/shard_test.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBatchFiles(t *testing.T) {
+	t.Parallel()
+	files := []string{"a", "b", "c", "d", "e"}
+	tests := []struct {
+		size int
+		want int // number of shards
+	}{
+		{1, 5},
+		{2, 3}, // [a,b][c,d][e]
+		{5, 1},
+		{10, 1},
+		{0, 5}, // size < 1 coerced to 1
+	}
+	for _, tt := range tests {
+		got := batchFiles(files, tt.size)
+		if len(got) != tt.want {
+			t.Errorf("batchFiles(size=%d) = %d shards, want %d", tt.size, len(got), tt.want)
+		}
+	}
+	// Every file appears exactly once across shards.
+	shards := batchFiles(files, 2)
+	var flat []string
+	for _, s := range shards {
+		flat = append(flat, s...)
+	}
+	if strings.Join(flat, ",") != "a,b,c,d,e" {
+		t.Errorf("batchFiles lost/reordered files: %v", flat)
+	}
+}
+
+func TestGlobShardFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	must := func(rel, body string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("README.md", "x")
+	must("docs/a.md", "x")
+	must("docs/b.txt", "x")
+	must("node_modules/pkg/c.md", "x") // skipped dir
+	must("vendor/d.md", "x")           // skipped dir
+	must("generated.md", "x")          // excluded by pattern
+
+	got, err := globShardFiles(dir, []string{"**/*.md", "**/*.txt"}, []string{"generated.md"})
+	if err != nil {
+		t.Fatalf("globShardFiles: %v", err)
+	}
+	want := []string{"README.md", "docs/a.md", "docs/b.txt"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("globShardFiles = %v, want %v", got, want)
+	}
+}
+
+func TestValidateShard(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		report  string
+		edits   bool
+		wantErr bool
+	}{
+		{"edits applied passes", "Files touched: a.md", true, false},
+		{"claim without edit is fabrication", "Files touched: a.md", false, true},
+		{"no claim and no edit passes", "Files touched: none\nNo changes", false, false},
+		{"clean report passes", "No tells found.", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateShard(tt.report, tt.edits)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateShard() err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSummarizeAndMerge(t *testing.T) {
+	t.Parallel()
+	opts := &RunOptions{Agent: "degpt", Mode: "edit"}
+	outcomes := []shardOutcome{
+		{Files: []string{"a.md"}, EditsApplied: true, Report: "rewrote a"},
+		{Files: []string{"b.md"}, EditsApplied: false, Report: "clean"},
+		{Files: []string{"c.md"}, Error: "boom", Report: "x"},
+	}
+	res := summarize(opts, outcomes)
+	if res.Summary.Files != 3 || res.Summary.Edited != 1 || res.Summary.Clean != 1 || res.Summary.Failed != 1 {
+		t.Fatalf("summary = %+v", res.Summary)
+	}
+
+	jsonOut := mergeShards(res, "json")
+	for _, want := range []string{`"agent": "degpt"`, `"edited": 1`, `"failed": 1`, `a.md`} {
+		if !strings.Contains(jsonOut, want) {
+			t.Errorf("json merge missing %q in:\n%s", want, jsonOut)
+		}
+	}
+
+	noneOut := mergeShards(res, "none")
+	if !strings.Contains(noneOut, "Files touched: a.md") {
+		t.Errorf("none merge missing touched line:\n%s", noneOut)
+	}
+}

--- a/runner/shard_test.go
+++ b/runner/shard_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -123,6 +124,12 @@ func TestSummarizeAndMerge(t *testing.T) {
 	if !strings.Contains(noneOut, "Files touched: a.md") {
 		t.Errorf("none merge missing touched line:\n%s", noneOut)
 	}
+
+	// A none merge with nothing edited reports "Files touched: none".
+	clean := summarize(opts, []shardOutcome{{Files: []string{"x.md"}, Report: "clean"}})
+	if got := mergeShards(clean, "none"); !strings.Contains(got, "Files touched: none") {
+		t.Errorf("expected 'Files touched: none', got:\n%s", got)
+	}
 }
 
 // ollamaShardServer stands up a minimal Ollama-compatible chat endpoint that
@@ -155,6 +162,7 @@ func writeShardedAgent(t *testing.T, name, merge, onErr string, maxParallel int)
 version: 0.0.0
 entrypoint: system.md
 wrapper: wrapper.md
+ascii_only: true
 execution:
   shard_by: file
   glob:
@@ -231,6 +239,36 @@ func TestRunSharded_EndToEnd(t *testing.T) {
 	}
 	if res.Summary.Files != 2 || res.Summary.Shards != 2 || res.Summary.Clean != 2 || res.Summary.Failed != 0 {
 		t.Fatalf("summary = %+v", res.Summary)
+	}
+}
+
+func TestExecuteRun_Sharded(t *testing.T) {
+	// Full ExecuteRun path for a sharded agent: exercises invokeAndHandle's
+	// sharded branch (runSharded + writeResponse of the merged report) and
+	// initRunContext's ascii-only activation.
+	srv := ollamaShardServer(t, "ok")
+	agentsDir := writeShardedAgent(t, "degpt", "json", "continue", 1)
+	workingDir := writeWorkFiles(t, "a.md")
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	opts := &RunOptions{
+		Agent:           "degpt",
+		AgentsDir:       agentsDir,
+		WorkingDir:      workingDir,
+		Provider:        "ollama",
+		Model:           "mistral",
+		BaseURL:         srv.URL,
+		MaxIterations:   1,
+		Mode:            "edit",
+		ConfigAvailable: true,
+	}
+	if err := ExecuteRun(cmd, []string{"do work"}, opts); err != nil {
+		t.Fatalf("ExecuteRun: %v", err)
+	}
+	if !strings.Contains(out.String(), `"agent": "degpt"`) {
+		t.Fatalf("expected merged shard report in output, got:\n%s", out.String())
 	}
 }
 

--- a/runner/shard_test.go
+++ b/runner/shard_test.go
@@ -1,10 +1,19 @@
 package runner
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cowdogmoo/squad/agent"
 )
 
 func TestBatchFiles(t *testing.T) {
@@ -113,5 +122,186 @@ func TestSummarizeAndMerge(t *testing.T) {
 	noneOut := mergeShards(res, "none")
 	if !strings.Contains(noneOut, "Files touched: a.md") {
 		t.Errorf("none merge missing touched line:\n%s", noneOut)
+	}
+}
+
+// ollamaShardServer stands up a minimal Ollama-compatible chat endpoint that
+// replies to every request with the same assistant content, so a sharded run
+// can drive InvokeModel once per shard without a real backend.
+func ollamaShardServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	body := fmt.Sprintf(`{"model":"mistral","message":{"role":"assistant","content":%q},"done":true}`, content)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// writeShardedAgent writes a sharded ("shard_by: file") agent manifest globbing
+// **/*.md and returns the agents dir. merge/onErr/maxParallel are caller-set so
+// tests can exercise the json/none merges and the stop/continue error policies.
+func writeShardedAgent(t *testing.T, name, merge, onErr string, maxParallel int) string {
+	t.Helper()
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, name)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	manifest := fmt.Sprintf(`name: %s
+version: 0.0.0
+entrypoint: system.md
+wrapper: wrapper.md
+execution:
+  shard_by: file
+  glob:
+    - "**/*.md"
+  shard_batch: 1
+  merge: %s
+  max_parallel: %d
+  on_shard_error: %s
+`, name, merge, maxParallel, onErr)
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(agentDir, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	write("agent.yaml", manifest)
+	write("system.md", "System prompt.")
+	write("wrapper.md", "Wrapper prompt.")
+	return agentsDir
+}
+
+// writeWorkFiles creates named files under a fresh temp dir used as the sharded
+// run's working directory, and returns that directory.
+func writeWorkFiles(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("content"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+func buildShardBundle(t *testing.T, opts *RunOptions, workingDir string) *agent.Bundle {
+	t.Helper()
+	bundle, err := agent.BuildBundleWithOptions(opts.AgentsDir, opts.Agent, "do work", workingDir, opts.Mode, opts.Vars, &agent.BundleOptions{})
+	if err != nil {
+		t.Fatalf("BuildBundleWithOptions: %v", err)
+	}
+	if !bundle.Sharded() {
+		t.Fatal("expected sharded bundle")
+	}
+	return bundle
+}
+
+func TestRunSharded_EndToEnd(t *testing.T) {
+	srv := ollamaShardServer(t, "ok")
+	agentsDir := writeShardedAgent(t, "degpt", "json", "continue", 2)
+	workingDir := writeWorkFiles(t, "a.md", "b.md")
+	opts := &RunOptions{
+		Agent:           "degpt",
+		AgentsDir:       agentsDir,
+		Provider:        "ollama",
+		Model:           "mistral",
+		BaseURL:         srv.URL,
+		MaxIterations:   1,
+		Mode:            "edit",
+		ConfigAvailable: true,
+	}
+	bundle := buildShardBundle(t, opts, workingDir)
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	resp, m, err := runSharded(context.Background(), cmd, opts, bundle, "do work", workingDir)
+	if err != nil {
+		t.Fatalf("runSharded: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+	var res shardedResult
+	if jerr := json.Unmarshal([]byte(resp), &res); jerr != nil {
+		t.Fatalf("merged output not valid json: %v\n%s", jerr, resp)
+	}
+	if res.Summary.Files != 2 || res.Summary.Shards != 2 || res.Summary.Clean != 2 || res.Summary.Failed != 0 {
+		t.Fatalf("summary = %+v", res.Summary)
+	}
+}
+
+func TestRunSharded_NoMatchingFiles(t *testing.T) {
+	srv := ollamaShardServer(t, "ok")
+	agentsDir := writeShardedAgent(t, "degpt", "json", "continue", 1)
+	workingDir := writeWorkFiles(t, "ignored.txt") // no .md files to glob
+	opts := &RunOptions{
+		Agent:           "degpt",
+		AgentsDir:       agentsDir,
+		Provider:        "ollama",
+		Model:           "mistral",
+		BaseURL:         srv.URL,
+		MaxIterations:   1,
+		Mode:            "edit",
+		ConfigAvailable: true,
+	}
+	bundle := buildShardBundle(t, opts, workingDir)
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	resp, _, err := runSharded(context.Background(), cmd, opts, bundle, "do work", workingDir)
+	if err != nil {
+		t.Fatalf("runSharded with no files should be a clean outcome, got %v", err)
+	}
+	var res shardedResult
+	if jerr := json.Unmarshal([]byte(resp), &res); jerr != nil {
+		t.Fatalf("merged output not valid json: %v\n%s", jerr, resp)
+	}
+	if res.Summary.Shards != 0 || res.Summary.Files != 0 {
+		t.Fatalf("expected empty summary, got %+v", res.Summary)
+	}
+}
+
+func TestRunSharded_ShardFailureStops(t *testing.T) {
+	// Every shard gets a fabricated "files touched" report with no real edit;
+	// with require-actionable on, the first shard fails validation and (stop
+	// policy) cancels the rest, so the second shard records a skip.
+	srv := ollamaShardServer(t, "Files touched: a.md")
+	agentsDir := writeShardedAgent(t, "degpt", "json", "stop", 1)
+	workingDir := writeWorkFiles(t, "a.md", "b.md")
+	opts := &RunOptions{
+		Agent:             "degpt",
+		AgentsDir:         agentsDir,
+		Provider:          "ollama",
+		Model:             "mistral",
+		BaseURL:           srv.URL,
+		MaxIterations:     1,
+		Mode:              "edit",
+		ConfigAvailable:   true,
+		RequireActionable: true,
+	}
+	bundle := buildShardBundle(t, opts, workingDir)
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	resp, _, err := runSharded(context.Background(), cmd, opts, bundle, "do work", workingDir)
+	if err == nil {
+		t.Fatal("expected an aggregate shard failure")
+	}
+	if !strings.Contains(err.Error(), "shards failed") {
+		t.Fatalf("error = %v, want it to mention failed shards", err)
+	}
+	var res shardedResult
+	if jerr := json.Unmarshal([]byte(resp), &res); jerr != nil {
+		t.Fatalf("merged output not valid json: %v\n%s", jerr, resp)
+	}
+	if res.Summary.Failed != 2 {
+		t.Fatalf("expected both shards failed (one validation, one skipped), got %+v", res.Summary)
+	}
+	if !strings.Contains(resp, "skipped") {
+		t.Errorf("expected a skipped shard in merged output:\n%s", resp)
 	}
 }

--- a/tools/asciiguard.go
+++ b/tools/asciiguard.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type asciiOnlyKeyType struct{}
+
+// InitASCIIOnlyMode marks ctx as ASCII-only. While set, Edit and MultiEdit
+// reject any change whose replacement text introduces non-ASCII characters
+// that were not already present in the text being replaced.
+func InitASCIIOnlyMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, asciiOnlyKeyType{}, true)
+}
+
+// IsASCIIOnlyMode reports whether ctx is in ASCII-only mode.
+func IsASCIIOnlyMode(ctx context.Context) bool {
+	v, ok := ctx.Value(asciiOnlyKeyType{}).(bool)
+	return ok && v
+}
+
+// ValidateASCIIOnly returns nil unless newText introduces non-ASCII runes that
+// oldText did not contain (counted per rune, so an edit may keep or remove
+// existing non-ASCII but never add more). This is a hard backstop for agents
+// whose job is to REMOVE typographic tells — smart quotes (’ “ ”), em/en
+// dashes (— –), non-breaking hyphens (‑), the ellipsis char (…) — so a model
+// that "cleans" prose while sneaking in the very characters it should strip is
+// rejected at the tool boundary rather than merely discouraged by prompt.
+func ValidateASCIIOnly(oldText, newText string) error {
+	oldCounts := nonASCIICounts(oldText)
+	introduced := map[rune]int{}
+	for r, n := range nonASCIICounts(newText) {
+		if excess := n - oldCounts[r]; excess > 0 {
+			introduced[r] = excess
+		}
+	}
+	if len(introduced) == 0 {
+		return nil
+	}
+	runes := make([]rune, 0, len(introduced))
+	for r := range introduced {
+		runes = append(runes, r)
+	}
+	sort.Slice(runes, func(i, j int) bool { return runes[i] < runes[j] })
+	var parts []string
+	for _, r := range runes {
+		parts = append(parts, fmt.Sprintf("%q (U+%04X)×%d", string(r), r, introduced[r]))
+	}
+	return fmt.Errorf(
+		"ascii-only edit rejected: replacement introduces non-ASCII character(s) not in the original: %s. "+
+			"Use plain ASCII instead (straight quotes ' \", hyphen -, three dots ...). "+
+			"Introducing typographic characters is itself an LLM tell",
+		strings.Join(parts, ", "))
+}
+
+// editGuardError returns the first active edit-guard violation (comments-only,
+// then ascii-only) for a replacement, or nil if all active guards pass. It
+// centralizes the guard checks shared by the Edit and MultiEdit tools.
+func editGuardError(ctx context.Context, oldText, newText string) error {
+	if IsCommentsOnlyMode(ctx) {
+		if err := ValidateCommentsOnly(oldText, newText); err != nil {
+			return err
+		}
+	}
+	if IsASCIIOnlyMode(ctx) {
+		if err := ValidateASCIIOnly(oldText, newText); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// nonASCIICounts returns a multiset of the non-ASCII runes in text.
+func nonASCIICounts(text string) map[rune]int {
+	out := map[rune]int{}
+	for _, r := range text {
+		if r > 127 {
+			out[r]++
+		}
+	}
+	return out
+}

--- a/tools/asciiguard_test.go
+++ b/tools/asciiguard_test.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateASCIIOnly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		old     string
+		new     string
+		wantErr bool
+	}{
+		{"plain ascii rewrite passes", "the old text", "the new text", false},
+		{"introduces smart quote rejected", "the model's job", "the model’s job", true},
+		{"introduces em dash rejected", "a - b", "a — b", true},
+		{"introduces ellipsis char rejected", "wait...", "wait…", true},
+		{"introduces nbhyphen rejected", "built-in", "built‑in", true},
+		{"keeps existing non-ascii passes", "café menu here", "the café menu", false},
+		{"removes non-ascii passes", "a — b dash", "a - b dash", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateASCIIOnly(tt.old, tt.new)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateASCIIOnly(%q,%q) err = %v, wantErr %v", tt.old, tt.new, err, tt.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "ascii-only edit rejected") {
+				t.Errorf("unexpected error text: %v", err)
+			}
+		})
+	}
+}
+
+func TestASCIIOnlyMode(t *testing.T) {
+	t.Parallel()
+	if IsASCIIOnlyMode(context.Background()) {
+		t.Fatal("background ctx should not be ascii-only")
+	}
+	ctx := InitASCIIOnlyMode(context.Background())
+	if !IsASCIIOnlyMode(ctx) {
+		t.Fatal("InitASCIIOnlyMode did not set the mode")
+	}
+}

--- a/tools/asciiguard_test.go
+++ b/tools/asciiguard_test.go
@@ -36,6 +36,38 @@ func TestValidateASCIIOnly(t *testing.T) {
 	}
 }
 
+func TestEditGuardError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		old     string
+		new     string
+		wantErr string // substring; "" means expect nil
+	}{
+		{"no modes active passes", context.Background(), "x := 1", "y := 2", ""},
+		{"ascii-only rejects introduced char", InitASCIIOnlyMode(context.Background()), "a - b", "a — b", "ascii-only edit rejected"},
+		{"ascii-only passes plain rewrite", InitASCIIOnlyMode(context.Background()), "old", "new", ""},
+		{"comments-only rejects added code", InitCommentsOnlyMode(context.Background()), "x := 1", "x := 1\ny := 2", "comment"},
+		{"comments-only passes comment edit", InitCommentsOnlyMode(context.Background()), "# old comment\ncode = 1", "code = 1", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := editGuardError(tt.ctx, tt.old, tt.new)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("editGuardError() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("editGuardError() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestASCIIOnlyMode(t *testing.T) {
 	t.Parallel()
 	if IsASCIIOnlyMode(context.Background()) {

--- a/tools/multiedit.go
+++ b/tools/multiedit.go
@@ -107,15 +107,13 @@ func multiEditTool(workingDir string) func(ctx context.Context, rawArgs []byte) 
 				})
 				continue
 			}
-			if IsCommentsOnlyMode(ctx) {
-				if err := ValidateCommentsOnly(edit.Old, edit.New); err != nil {
-					failed = append(failed, FailedEdit{
-						Index: i,
-						Old:   edit.Old,
-						Error: err.Error(),
-					})
-					continue
-				}
+			if err := editGuardError(ctx, edit.Old, edit.New); err != nil {
+				failed = append(failed, FailedEdit{
+					Index: i,
+					Old:   edit.Old,
+					Error: err.Error(),
+				})
+				continue
 			}
 			if bool(edit.ReplaceAll) {
 				content = strings.ReplaceAll(content, edit.Old, edit.New)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1679,10 +1679,8 @@ func editTool(workingDir string) func(ctx context.Context, rawArgs []byte) (stri
 		if !strings.Contains(content, payload.Old) {
 			return "", fmt.Errorf("text not found in %s", payload.Path)
 		}
-		if IsCommentsOnlyMode(ctx) {
-			if err := ValidateCommentsOnly(payload.Old, payload.New); err != nil {
-				return "", err
-			}
+		if err := editGuardError(ctx, payload.Old, payload.New); err != nil {
+			return "", err
 		}
 		var updated string
 		replaced := 1


### PR DESCRIPTION
**Key Changes:**

- Introduced opt-in sharded execution that partitions an agent's file work-list and runs the single-agent loop once per shard with isolated context, eliminating context bloat for per-file agents like `degpt` and `go-scrub-comments`
- Added `ASCIIOnly` mode that rejects Edit/MultiEdit calls introducing non-ASCII characters not already present in the replaced text, providing a hard tool-boundary backstop for de-slop agents
- Strengthened the fabrication guard to catch self-contradictory reports (a model that names specific files as touched while also claiming "no changes") rather than letting a stray "no changes" marker exempt a fabricated claim
- Added a comprehensive design document covering the sharded execution architecture, merge semantics, guard interactions, parallelism plan, and open questions

**Added:**

- `ExecutionConfig` struct with `ShardBy`, `Glob`, `Exclude`, `ShardBatch`, `Merge`, `MaxParallel`, and `OnShardError` fields; includes `Validate()`, `fillDefaults()`, and `validateEnums()` methods that surface misconfiguration at bundle load rather than mid-run - `agent/bundle.go`
- `runner/shard.go` implementing `runSharded` (bounded worker pool, per-shard isolated edit-tracker context), `runOneShard`, `globShardFiles` (include/exclude glob with skip-dir filtering), `batchFiles`, `summarize`, and `mergeShards` (JSON structured or verbatim concat)
- `tools/asciiguard.go` with `InitASCIIOnlyMode`, `IsASCIIOnlyMode`, `ValidateASCIIOnly`, and a shared `editGuardError` helper that centralizes comments-only and ascii-only guard checks for both Edit and MultiEdit tools
- `docs/design/sharded-execution.md` — draft design covering problem statement, manifest schema, execution model, merge semantics, guard/budget interactions, parallelism roadmap, failure handling, edge cases, testing plan, and backward compatibility
- Tests for `ExecutionConfig.Validate` covering nil, unsupported shard_by, missing glob, invalid patterns, bad enum values, and default-filling - `agent/bundle_test.go`
- Tests for `batchFiles`, `globShardFiles`, `validateShard`, `summarize`, and `mergeShards` (JSON and none modes) - `runner/shard_test.go`
- Tests for `ValidateASCIIOnly` and `InitASCIIOnlyMode`/`IsASCIIOnlyMode` - `tools/asciiguard_test.go`

**Changed:**

- `Manifest` and `Bundle` structs gain `Execution *ExecutionConfig` and `ASCIIOnly bool` fields; `BuildBundleWithOptions` propagates both from manifest to bundle - `agent/bundle.go`
- `Manifest.Validate` now calls `m.Execution.Validate()` so the execution block is checked at bundle load alongside other manifest validation - `agent/composed.go`
- `ExecuteRun` refactored to extract `invokeAndHandle`, which branches on `bundle.Sharded()` to call `runSharded` or the existing `InvokeModel` path; sharded runs write partial results even on error and skip the single-loop `handleResponse`/`handleBudgetExceeded` path - `runner/run.go`
- `initRunContext` now initializes ASCII-only mode when `bundle.ASCIIOnly` is set, logging the activation alongside the existing comments-only mode log - `runner/run.go`
- Edit and MultiEdit tools now delegate guard checks to the shared `editGuardError` helper instead of each inlining an `IsCommentsOnlyMode` check, enabling both guards to apply uniformly - `tools/tools.go`, `tools/multiedit.go`
- Fabrication guard (`validateActionableChanges`) replaced the `responseIndicatesNoChanges || !contains("files touched")` short-circuit with `claimsSpecificFilesTouched`, a new parser that recognizes `files touched: none` as a genuine clean report while treating a response that names a specific file as requiring git cross-check regardless of any "no changes" marker - `runner/apply.go`
- Test cases added for the contradictory report shape and the `files touched: none` clean report - `runner/apply_test.go`