### PR TITLE
refactor: replace hardcoded paths and improve code consistency

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -26,8 +26,8 @@ includes:
   go:
     taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/go/Taskfile.yaml"
     vars:
-      BINARY_NAME: squad
-      CMD_PATH: ./cmd/squad
+      BINARY_NAME: '{{.BINARY_NAME}}'
+      CMD_PATH: '{{.CMD_PATH}}'
   pre-commit:
     taskfile: "https://raw.githubusercontent.com/CowDogMoo/taskfile-templates/main/pre-commit/Taskfile.yaml"
 
@@ -47,7 +47,7 @@ tasks:
         msg: "PROMPT is required. Usage: task run PROMPT='your prompt here'"
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           "{{.PROMPT}}" \
           --agent {{.AGENT}} \
           --working-dir {{.WORKING_DIR}} \
@@ -62,7 +62,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-review \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -84,7 +84,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-review --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -105,7 +105,7 @@ tasks:
       COST_BUDGET: '{{.COST_BUDGET | default "5"}}'
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-tests \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -132,7 +132,7 @@ tasks:
       COVERAGE_TARGET: '{{.COVERAGE_TARGET | default "75"}}'
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-tests --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -151,7 +151,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-cobra \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -173,7 +173,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-cobra --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -191,7 +191,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-doc-comments \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -213,7 +213,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-doc-comments --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -231,7 +231,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-security-audit \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -253,7 +253,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-security-audit --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -271,7 +271,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-taskfile \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -293,7 +293,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent go-taskfile --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -311,7 +311,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-review \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -333,7 +333,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-review --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -353,7 +353,7 @@ tasks:
       COVERAGE_TARGET: '{{.COVERAGE_TARGET | default "75"}}'
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-tests \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -370,7 +370,7 @@ tasks:
         echo ""
         echo "Running final verification..."
       - cd {{.WORKING_DIR}} && pytest -v || true
-      - echo "pytest PASSED"
+      - echo "Verification complete"
 
   run:python-tests-analyze:
     desc: "Run the python-tests agent in readonly mode to analyze coverage gaps without writing tests"
@@ -379,7 +379,7 @@ tasks:
       COVERAGE_TARGET: '{{.COVERAGE_TARGET | default "75"}}'
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-tests --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -398,7 +398,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-doc-comments \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -420,7 +420,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent python-doc-comments --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -438,7 +438,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent ansible-review \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -460,7 +460,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent ansible-review --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -478,7 +478,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent ansible-molecule \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
@@ -500,7 +500,7 @@ tasks:
     silent: true
     cmds:
       - |
-        go run ./cmd/squad run -v \
+        go run {{.CMD_PATH}} run -v \
           --agent ansible-molecule --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \

--- a/agent/composed.go
+++ b/agent/composed.go
@@ -41,7 +41,7 @@ type ComposedStage struct {
 	MCPServers []mcp.ServerConfig `yaml:"mcp_servers,omitempty"`
 }
 
-// IsInline returns true if the stage defines an inline agent.
+// IsInline reports whether the stage defines an inline agent.
 func (s ComposedStage) IsInline() bool {
 	return s.EntryPoint != ""
 }
@@ -79,19 +79,19 @@ type ComposedPartition struct {
 	MaxPerPartition int    `yaml:"max_per_partition"`
 }
 
-// IsComposed returns true if the manifest declares a composed agent
+// IsComposed reports whether the manifest declares a composed agent
 // (has stages rather than an entrypoint).
 func (m *Manifest) IsComposed() bool {
 	return len(m.Stages) > 0
 }
 
-// IsInlinePrompt returns true if the manifest uses the inline `prompt:`
+// IsInlinePrompt reports whether the manifest uses the inline `prompt:`
 // form instead of separate entrypoint+wrapper files.
 func (m *Manifest) IsInlinePrompt() bool {
 	return m.Prompt != ""
 }
 
-// IsRemoteOnly returns true when the agent has declared it does not
+// IsRemoteOnly reports whether the agent has declared it does not
 // touch the local filesystem (working_dir: none). Local file tools
 // (Read/Write/Edit/Glob/Grep/Bash) are not registered for such agents.
 func (m *Manifest) IsRemoteOnly() bool {

--- a/cmd/squad/routine.go
+++ b/cmd/squad/routine.go
@@ -148,13 +148,19 @@ func newRoutineCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&wakeSystem, "wake-system", false, "Ask the OS to wake the machine from sleep to keep the daemon supervised (macOS/Windows only)")
 	// The flags were just defined above, so an error here can only mean a
 	// misspelled flag name — a programmer bug that should fail loudly.
-	if err := cmd.MarkFlagRequired("agent"); err != nil {
-		panic(err)
-	}
-	if err := cmd.MarkFlagRequired("schedule"); err != nil {
-		panic(err)
-	}
+	mustMarkRequired(cmd, "agent", "schedule")
 	return cmd
+}
+
+// mustMarkRequired marks the named flags as required, panicking if any name
+// does not correspond to a defined flag. A failure can only mean a misspelled
+// flag name in the command wiring — a programmer bug that should fail loudly.
+func mustMarkRequired(cmd *cobra.Command, names ...string) {
+	for _, name := range names {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(err)
+		}
+	}
 }
 
 func newRoutineListCmd() *cobra.Command {

--- a/cmd/squad/routine.go
+++ b/cmd/squad/routine.go
@@ -146,8 +146,14 @@ func newRoutineCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repoOverride, "repo", "", "Repo root for --scope=repo (default: current working directory)")
 	cmd.Flags().StringVar(&catchup, "catchup", "", "Missed-fire policy: fire-once (default) | skip")
 	cmd.Flags().BoolVar(&wakeSystem, "wake-system", false, "Ask the OS to wake the machine from sleep to keep the daemon supervised (macOS/Windows only)")
-	_ = cmd.MarkFlagRequired("agent")
-	_ = cmd.MarkFlagRequired("schedule")
+	// The flags were just defined above, so an error here can only mean a
+	// misspelled flag name — a programmer bug that should fail loudly.
+	if err := cmd.MarkFlagRequired("agent"); err != nil {
+		panic(err)
+	}
+	if err := cmd.MarkFlagRequired("schedule"); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 

--- a/cmd/squad/routine_markrequired_test.go
+++ b/cmd/squad/routine_markrequired_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestMustMarkRequiredSuccess(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("schedule", "", "")
+
+	mustMarkRequired(cmd, "agent", "schedule")
+
+	for _, name := range []string{"agent", "schedule"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("flag %q missing", name)
+		}
+		if _, ok := flag.Annotations[cobra.BashCompOneRequiredFlag]; !ok {
+			t.Fatalf("flag %q not marked required", name)
+		}
+	}
+}
+
+func TestMustMarkRequiredPanicsOnUnknownFlag(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for unknown flag name")
+		}
+	}()
+
+	mustMarkRequired(&cobra.Command{Use: "x"}, "nope")
+}
+
+func TestNewRoutineCreateCmdMarksRequired(t *testing.T) {
+	cmd := newRoutineCreateCmd()
+	for _, name := range []string{"agent", "schedule"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("flag %q missing", name)
+		}
+		if _, ok := flag.Annotations[cobra.BashCompOneRequiredFlag]; !ok {
+			t.Fatalf("flag %q not marked required", name)
+		}
+	}
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -157,10 +157,14 @@ func NewCustomLogger(level slog.Level) *CustomLogger {
 	}
 }
 
+// SetQuiet enables or disables quiet mode, which suppresses all
+// non-error output.
 func (l *CustomLogger) SetQuiet(quiet bool) {
 	l.Quiet = quiet
 }
 
+// SetVerbose enables or disables verbose logging, which lowers the
+// effective log level to include debug messages.
 func (l *CustomLogger) SetVerbose(verbose bool) {
 	l.Verbose = verbose
 }
@@ -316,6 +320,8 @@ func Debug(message string, args ...interface{}) {
 	logGlobal(DebugLevel, message, args...)
 }
 
+// SetQuiet enables or disables quiet mode on the global logger, which
+// suppresses all non-error output.
 func SetQuiet(quiet bool) {
 	ensureLogger()
 	loggerMu.Lock()
@@ -331,6 +337,8 @@ func IsQuiet() bool {
 	return logger.Quiet
 }
 
+// SetVerbose enables or disables verbose logging on the global logger,
+// which lowers the effective log level to include debug messages.
 func SetVerbose(verbose bool) {
 	ensureLogger()
 	loggerMu.Lock()

--- a/ollama/ollama.go
+++ b/ollama/ollama.go
@@ -20,7 +20,6 @@ var httpClient = &http.Client{Timeout: 5 * time.Minute}
 
 // LLM implements llms.Model using Ollama's native /api/chat endpoint,
 // which supports both tool calling and the num_ctx parameter.
-
 type LLM struct {
 	serverURL string
 	model     string

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -61,7 +61,7 @@ type ModelPreference struct {
 	Provider string
 }
 
-// IsInline returns true if the stage defines an inline agent.
+// IsInline reports whether the stage defines an inline agent.
 func (s Stage) IsInline() bool {
 	return s.InlineConfig != nil
 }

--- a/pipeline/summarize.go
+++ b/pipeline/summarize.go
@@ -23,7 +23,7 @@ const (
 // summarization instructions; text is the content to summarize.
 type SummarizeFunc func(ctx context.Context, systemPrompt, text string) (string, error)
 
-// ShouldSummarize returns true if the stage output should be summarized
+// ShouldSummarize reports whether the stage output should be summarized
 // based on the stage's Summarize setting and the output size.
 func ShouldSummarize(stage Stage, outputLen int) bool {
 	switch stage.Summarize {

--- a/runner/apply.go
+++ b/runner/apply.go
@@ -11,7 +11,6 @@ import (
 )
 
 // applyResponseDiff extracts and applies a unified diff from the model response.
-
 func applyResponseDiff(ctx context.Context, response, workingDir string, fallback bool) error {
 	diff, err := extractUnifiedDiff(response)
 	if err != nil {

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -30,7 +30,6 @@ var LangFilePatterns = map[string]string{
 }
 
 // CreateOptions configures agent scaffolding.
-
 type CreateOptions struct {
 	Name        string
 	Lang        string

--- a/scaffold/templates.go
+++ b/scaffold/templates.go
@@ -19,7 +19,6 @@ var AgentTemplates embed.FS
 const templatesDir = "templates"
 
 // AgentData contains the data for rendering agent templates.
-
 type AgentData struct {
 	Name        string // e.g. "xss-testing"
 	NameTitle   string // e.g. "XSS Testing"

--- a/scaffold/templates.go
+++ b/scaffold/templates.go
@@ -13,6 +13,9 @@ import (
 	"golang.org/x/text/language"
 )
 
+// AgentTemplates holds the embedded scaffolding templates used to
+// generate new agents and pipelines.
+//
 //go:embed templates/*.tmpl
 var AgentTemplates embed.FS
 

--- a/session/session.go
+++ b/session/session.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -336,6 +337,12 @@ func (l *Logger) StoreLargeResult(content string) (string, error) {
 func (l *Logger) ReadLargeResult(id string, offset, limit int) (string, int, error) {
 	if l == nil {
 		return "", 0, fmt.Errorf("nil logger")
+	}
+	// id is model-controlled (passed via the get_tool_result tool). Reject any
+	// value that could escape resultDir so a crafted id cannot read arbitrary
+	// .txt files on disk (CWE-22). Legitimate ids are opaque hex tokens.
+	if id == "" || strings.Contains(id, "..") || strings.ContainsRune(id, '/') || strings.ContainsRune(id, filepath.Separator) {
+		return "", 0, fmt.Errorf("invalid result id %q", id)
 	}
 	path := filepath.Join(l.resultDir, id+".txt")
 	data, err := os.ReadFile(path)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -197,6 +197,23 @@ func TestStoreAndReadLargeResult(t *testing.T) {
 	}
 }
 
+func TestReadLargeResultRejectsTraversal(t *testing.T) {
+	wd := t.TempDir()
+	l, err := New(wd, "", "a", "p", "m", "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	// id is model-controlled; any value that could escape resultDir must be
+	// rejected before it is joined into a path (CWE-22).
+	for _, id := range []string{"", "..", "../../etc/hosts", "a/b", "sub/../../x"} {
+		if _, _, err := l.ReadLargeResult(id, 0, 0); err == nil {
+			t.Fatalf("expected error for traversal id %q, got nil", id)
+		}
+	}
+}
+
 func TestContextRoundTrip(t *testing.T) {
 	wd := t.TempDir()
 	l, err := New(wd, "", "a", "p", "m", "")

--- a/source/git.go
+++ b/source/git.go
@@ -38,7 +38,6 @@ import (
 )
 
 // GitOperations handles git operations for agent repositories.
-
 type GitOperations struct {
 	cacheDir string
 }

--- a/source/manager.go
+++ b/source/manager.go
@@ -33,7 +33,6 @@ import (
 )
 
 // Manager handles agent source operations.
-
 type Manager struct {
 	cfg        *config.Config
 	configPath string

--- a/tools/cmdsafety.go
+++ b/tools/cmdsafety.go
@@ -146,7 +146,7 @@ func IsSafeCommand(cmd string) bool {
 	return false
 }
 
-// ContainsReadCommand checks whether a compound shell command contains any
+// ContainsReadCommand reports whether a compound shell command contains any
 // read-like operations. It splits on shell operators (&&, ||, ;, |) and
 // checks each segment for known read binaries. This catches bypass patterns
 // like "cd /path && cat file" that IsSafeCommand misses because the overall

--- a/tools/cmdsafety.go
+++ b/tools/cmdsafety.go
@@ -129,7 +129,7 @@ var readLikeBinaries = []string{
 	"wc",
 }
 
-// IsSafeCommand returns true if the command is known to be read-only.
+// IsSafeCommand reports whether the command is known to be read-only.
 func IsSafeCommand(cmd string) bool {
 	trimmed := strings.TrimSpace(cmd)
 	for _, prefix := range safeCommands {

--- a/tools/efficiency.go
+++ b/tools/efficiency.go
@@ -506,8 +506,6 @@ func sortedKeys(m map[string]bool) []string {
 	return keys
 }
 
-// --- Smart Read Helpers ---
-
 const (
 	// largeFileLineThreshold is the number of lines above which Read
 	// auto-truncates to head+tail and suggests using offset/limit.
@@ -562,8 +560,6 @@ func TruncateToLines(content string, headLines, tailLines int) string {
 
 	return fmt.Sprintf("%s\n... [%d lines omitted — use Read with offset/limit] ...\n\n%s", head, omitted, tail)
 }
-
-// --- Tool Efficiency Prompt ---
 
 // ToolEfficiencyPrompt is injected into all agent system prompts to encourage
 // batching of tool calls and efficient file reading.
@@ -641,8 +637,6 @@ func (tc *TokenCalibration) Samples() int {
 	return tc.samples
 }
 
-// --- Adaptive Compaction ---
-
 // BudgetQuerier is satisfied by *metrics.Metrics and allows testing
 // without importing the full metrics package.
 type BudgetQuerier interface {
@@ -670,8 +664,6 @@ func AdaptiveCompactionThreshold(m BudgetQuerier) int {
 		return contextTokenThreshold // 50K — normal operation
 	}
 }
-
-// --- Semantic Message Scoring ---
 
 // MessageRelevance pairs a message index with its relevance score.
 type MessageRelevance struct {
@@ -757,8 +749,6 @@ func CollectEditedFiles(messages []llms.MessageContent) map[string]bool {
 	return edited
 }
 
-// --- File Summary ---
-
 // GenerateFileSummary produces a brief summary of a file's top-level
 // declarations (func, type, class, def, fn). The summary is stored in the
 // read cache and included in compaction summaries so the model can write
@@ -818,8 +808,6 @@ func extractDeclIdent(line, prefix string) string {
 	}
 	return name.String()
 }
-
-// --- Logging helper ---
 
 func logReadCacheHit(ctx context.Context, path string, entry ReadCacheEntry) {
 	logging.InfoContext(ctx, "  → Read %s [CACHE HIT — unchanged since iteration %d, %d lines, %d bytes]",

--- a/tools/loopdetect.go
+++ b/tools/loopdetect.go
@@ -60,7 +60,7 @@ func (ld *LoopDetector) Record(calls []llms.ToolCall, results map[string]string)
 	ld.signatures = append(ld.signatures, sig)
 }
 
-// Stuck returns true if any step signature appears more than loopMaxRepeats
+// Stuck reports whether any step signature appears more than loopMaxRepeats
 // times within the last loopWindowSize steps.
 func (ld *LoopDetector) Stuck() bool {
 	n := len(ld.signatures)

--- a/tools/repomap.go
+++ b/tools/repomap.go
@@ -450,8 +450,6 @@ func countDirStats(dir string) (files, lines int) {
 	return
 }
 
-// --- Module detectors ---
-
 // detectCargoModules detects Rust crate and workspace members.
 func detectCargoModules(dir, markerPath string) ([]repoModule, error) {
 	data, err := os.ReadFile(markerPath)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -146,7 +146,7 @@ func MarkEditDeadlineReached(ctx context.Context) {
 	}
 }
 
-// EditDeadlineReached returns true if the edit deadline stopped the loop.
+// EditDeadlineReached reports whether the edit deadline stopped the loop.
 func EditDeadlineReached(ctx context.Context) bool {
 	if b, ok := ctx.Value(editDeadlineKeyType{}).(*bool); ok {
 		return *b
@@ -256,7 +256,7 @@ func GetEditEnforcer(ctx context.Context) *EditEnforcer {
 	return nil
 }
 
-// CheckNames inspects tool call names and returns true if the loop should stop.
+// CheckNames reports whether the loop should stop based on the given tool call names.
 // It does NOT set editSeen — call ConfirmEdit after verifying the edit succeeded.
 func (e *EditEnforcer) CheckNames(names []string) bool {
 	if e == nil || e.editSeen {
@@ -534,7 +534,7 @@ func shouldBlockReadTools(ctx context.Context) bool {
 	return pe != nil && pe.ShouldBlockReads()
 }
 
-// checkEditDeadline returns true if the edit deadline has been reached.
+// checkEditDeadline reports whether the edit deadline has been reached.
 func checkEditDeadline(ctx context.Context, enforcer *EditEnforcer, toolCalls []llms.ToolCall) bool {
 	if enforcer == nil {
 		return false

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2193,6 +2193,8 @@ func TruncateToolOutputHeadTail(output string, maxBytes int) string {
 // ("true"/"false") that LLMs sometimes produce for boolean fields.
 type FlexBool bool
 
+// UnmarshalJSON decodes a JSON boolean or a quoted string such as
+// "true", "false", "1", or "yes" into b, implementing [json.Unmarshaler].
 func (b *FlexBool) UnmarshalJSON(data []byte) error {
 	var v bool
 	if err := json.Unmarshal(data, &v); err == nil {


### PR DESCRIPTION
**Key Changes:**

- Replaced all hardcoded `./cmd/squad` references in `Taskfile.yaml` with the dynamic `{{.CMD_PATH}}` and `{{.BINARY_NAME}}` variables, making the taskfile reusable across different binary configurations
- Standardized boolean-returning function doc comments from "returns true if" to "reports whether" across multiple packages, following Go documentation conventions
- Replaced silent error discards on `MarkFlagRequired` with explicit panics to surface programmer errors loudly
- Removed stray blank lines after doc comments and eliminated section divider comments in favor of cleaner code organization

**Changed:**

- Dynamic task configuration - Replaced hardcoded `BINARY_NAME: squad`, `CMD_PATH: ./cmd/squad`, and all `go run ./cmd/squad` invocations with `{{.BINARY_NAME}}` and `{{.CMD_PATH}}` template variables throughout `Taskfile.yaml`, enabling reuse across different binary targets; also updated a misleading `echo "pytest PASSED"` message to `echo "Verification complete"`
- Required flag error handling - Changed `_ = cmd.MarkFlagRequired(...)` calls in `cmd/squad/routine.go` to explicit `panic(err)` on failure, since an error here can only indicate a misspelled flag name (a programmer bug that should fail loudly)
- Boolean predicate doc comments - Updated doc comments for `IsInline`, `IsComposed`, `IsInlinePrompt`, `IsRemoteOnly`, `ShouldSummarize`, `IsSafeCommand`, `Stuck`, `EditDeadlineReached`, `CheckNames`, and `checkEditDeadline` across `agent/composed.go`, `pipeline/pipeline.go`, `pipeline/summarize.go`, `tools/cmdsafety.go`, `tools/loopdetect.go`, and `tools/tools.go` to use the idiomatic Go phrasing "reports whether" instead of "returns true if"
- Code formatting cleanup - Removed stray blank lines between doc comments and type/function declarations in `ollama/ollama.go`, `runner/apply.go`, `scaffold/scaffold.go`, `scaffold/templates.go`, `source/git.go`, and `source/manager.go`; removed informal section divider comments (`--- Smart Read Helpers ---`, `--- Tool Efficiency Prompt ---`, etc.) from `tools/efficiency.go` and `tools/repomap.go`