### PR TITLE
feat: add package-level sharding mode for whole-repo coverage

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -184,15 +184,19 @@ type ChildBudget struct {
 // the legacy behavior, unchanged.
 type ExecutionConfig struct {
 	// ShardBy selects the partitioning unit. "" (default) = no sharding;
-	// "file" = one shard per file (or per ShardBatch files).
+	// "file" = one shard per file (or per ShardBatch files); "package" = one
+	// shard per directory, so every package's files run together in one shard
+	// with full intra-package context (the unit for guaranteed whole-repo
+	// coverage). ShardBatch does not apply to "package".
 	ShardBy string `yaml:"shard_by,omitempty"`
 	// Glob lists the patterns squad globs (relative to the working dir) to
-	// build the work-list. Required when ShardBy is "file".
+	// build the work-list. Required when ShardBy is "file" or "package".
 	Glob []string `yaml:"glob,omitempty"`
 	// Exclude lists glob patterns to drop from the work-list (vendored,
 	// generated, VCS dirs).
 	Exclude []string `yaml:"exclude,omitempty"`
 	// ShardBatch is how many files go in one shard. Default 1 (strict per-file).
+	// Ignored when ShardBy is "package" (one shard per directory).
 	ShardBatch int `yaml:"shard_batch,omitempty"`
 	// Merge controls how per-shard outputs are combined: "json" (default,
 	// structured aggregate + per-shard sections) or "none" (verbatim concat).
@@ -215,11 +219,11 @@ func (e *ExecutionConfig) Validate() error {
 	if e == nil || e.ShardBy == "" {
 		return nil
 	}
-	if e.ShardBy != "file" {
-		return fmt.Errorf("execution.shard_by: unsupported value %q (only \"file\" is supported)", e.ShardBy)
+	if e.ShardBy != "file" && e.ShardBy != "package" {
+		return fmt.Errorf("execution.shard_by: unsupported value %q (want \"file\" or \"package\")", e.ShardBy)
 	}
 	if len(e.Glob) == 0 {
-		return fmt.Errorf("execution.shard_by: \"file\" requires a non-empty execution.glob")
+		return fmt.Errorf("execution.shard_by %q requires a non-empty execution.glob", e.ShardBy)
 	}
 	if err := e.validatePatterns(); err != nil {
 		return err

--- a/agent/bundle_test.go
+++ b/agent/bundle_test.go
@@ -1535,6 +1535,8 @@ func TestExecutionConfigValidate(t *testing.T) {
 		{"unsupported shard_by", &ExecutionConfig{ShardBy: "dir", Glob: []string{"*.go"}}, true},
 		{"file requires glob", &ExecutionConfig{ShardBy: "file"}, true},
 		{"valid file shard", &ExecutionConfig{ShardBy: "file", Glob: []string{"**/*.go"}}, false},
+		{"package requires glob", &ExecutionConfig{ShardBy: "package"}, true},
+		{"valid package shard", &ExecutionConfig{ShardBy: "package", Glob: []string{"**/*.go"}}, false},
 		{"invalid glob pattern", &ExecutionConfig{ShardBy: "file", Glob: []string{"[bad"}}, true},
 		{"invalid exclude pattern", &ExecutionConfig{ShardBy: "file", Glob: []string{"**/*.go"}, Exclude: []string{"[bad"}}, true},
 		{"negative shard_batch", &ExecutionConfig{ShardBy: "file", Glob: []string{"*.go"}, ShardBatch: -1}, true},
@@ -1571,6 +1573,7 @@ func TestSharded(t *testing.T) {
 		{"nil execution", nil, false},
 		{"empty shard_by", &ExecutionConfig{}, false},
 		{"file shard_by", &ExecutionConfig{ShardBy: "file"}, true},
+		{"package shard_by", &ExecutionConfig{ShardBy: "package"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/design/sharded-execution.md
+++ b/docs/design/sharded-execution.md
@@ -37,8 +37,11 @@ preserving edit mode, readonly mode, the fabrication guard, and metrics.
   tracing, `go-review`) must be unaffected. Sharding is opt-in per agent.
 - Not a replacement for pipelines (which compose *different* agents). This
   shards *one* agent over *data*.
-- v1 does not shard by non-file units (function, package). File/glob only;
-  the schema leaves room to extend.
+- Sharding is by file or by package (directory). `shard_by: package` groups a
+  glob's matches by parent directory so every package runs as one shard with
+  full intra-package context — the unit for guaranteed whole-repo coverage
+  (see NEWBIE.md). Finer units (function) are out of scope; the schema leaves
+  room to extend.
 
 ## 3. Manifest schema
 
@@ -47,9 +50,9 @@ New optional `execution:` block on the leaf-agent manifest
 
 ```yaml
 execution:
-  shard_by: file          # "" (default, no sharding) | "file"
+  shard_by: file          # "" (default, no sharding) | "file" | "package"
   glob:                   # patterns squad globs to build the work-list.
-    - "**/*.md"           #   Required when shard_by: file.
+    - "**/*.md"           #   Required when shard_by is "file" or "package".
     - "**/*.txt"
   exclude:                # optional ignore globs (node_modules, vendor, .git…)
     - "**/node_modules/**"
@@ -62,7 +65,7 @@ execution:
 ```go
 // agent/bundle.go
 type ExecutionConfig struct {
-    ShardBy      string   `yaml:"shard_by,omitempty"`      // "" | "file"
+    ShardBy      string   `yaml:"shard_by,omitempty"`      // "" | "file" | "package"
     Glob         []string `yaml:"glob,omitempty"`
     Exclude      []string `yaml:"exclude,omitempty"`
     ShardBatch   int      `yaml:"shard_batch,omitempty"`   // default 1
@@ -73,8 +76,10 @@ type ExecutionConfig struct {
 // Manifest gains:  Execution *ExecutionConfig `yaml:"execution,omitempty"`
 ```
 
-Validation at bundle-load: `shard_by: file` requires non-empty `glob`;
-`merge` ∈ {reports,none}; `shard_batch` ≥ 1; `max_parallel` ≥ 1.
+Validation at bundle-load: `shard_by: file`/`package` requires non-empty
+`glob`; `merge` ∈ {reports,none}; `shard_batch` ≥ 1; `max_parallel` ≥ 1.
+`shard_by: package` groups the globbed files by parent directory (one shard
+per directory); `shard_batch` does not apply.
 
 ## 4. Execution model
 

--- a/runner/shard.go
+++ b/runner/shard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -69,8 +70,8 @@ func runSharded(ctx context.Context, cmd *cobra.Command, opts *RunOptions, bundl
 	if err != nil {
 		return "", parent, fmt.Errorf("shard globbing failed: %w", err)
 	}
-	shards := batchFiles(files, exec.ShardBatch)
-	logging.InfoContext(ctx, "sharded run: %d files → %d shards (batch=%d)", len(files), len(shards), exec.ShardBatch)
+	shards := shardFiles(files, exec)
+	logging.InfoContext(ctx, "sharded run (by %s): %d files → %d shards", exec.ShardBy, len(files), len(shards))
 
 	if len(shards) == 0 {
 		// No matching files is a correct, clean outcome.
@@ -234,6 +235,41 @@ func matchesAny(rel string, patterns []string) bool {
 		}
 	}
 	return false
+}
+
+// shardFiles partitions the work-list into shards according to exec.ShardBy:
+// "package" groups by directory (one shard per package), anything else batches
+// by ShardBatch count.
+func shardFiles(files []string, exec *agent.ExecutionConfig) [][]string {
+	if exec.ShardBy == "package" {
+		return groupByPackage(files)
+	}
+	return batchFiles(files, exec.ShardBatch)
+}
+
+// groupByPackage buckets files into one shard per parent directory. A Go
+// package is a directory, so this yields exactly one shard per package with all
+// of that package's files together, giving each shard full intra-package
+// context — the unit NEWBIE.md calls for when guaranteeing every package is
+// read. Shards are ordered by directory; files keep their sorted order within a
+// shard. ShardBatch does not apply. Input is assumed sorted (globShardFiles
+// sorts), so each directory's files are already contiguous and ordered.
+func groupByPackage(files []string) [][]string {
+	groups := map[string][]string{}
+	var dirs []string
+	for _, f := range files {
+		dir := path.Dir(f)
+		if _, seen := groups[dir]; !seen {
+			dirs = append(dirs, dir)
+		}
+		groups[dir] = append(groups[dir], f)
+	}
+	sort.Strings(dirs)
+	shards := make([][]string, 0, len(dirs))
+	for _, dir := range dirs {
+		shards = append(shards, groups[dir])
+	}
+	return shards
 }
 
 // batchFiles splits files into shards of at most size entries (size >= 1).

--- a/runner/shard_test.go
+++ b/runner/shard_test.go
@@ -47,6 +47,38 @@ func TestBatchFiles(t *testing.T) {
 	}
 }
 
+func TestGroupByPackage(t *testing.T) {
+	t.Parallel()
+	// Two files in agent/, one each in runner/ and the repo root: three
+	// packages → three shards, each holding exactly its directory's files.
+	files := []string{"agent/bundle.go", "agent/composed.go", "main.go", "runner/run.go"}
+	got := groupByPackage(files)
+	want := [][]string{
+		{"main.go"}, // dir "." sorts before "agent" and "runner"
+		{"agent/bundle.go", "agent/composed.go"},
+		{"runner/run.go"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("groupByPackage = %d shards, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if strings.Join(got[i], ",") != strings.Join(want[i], ",") {
+			t.Errorf("shard %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	// shardFiles dispatches on ShardBy: "package" groups by directory, the
+	// default path batches by count.
+	pkgShards := shardFiles(files, &agent.ExecutionConfig{ShardBy: "package"})
+	if len(pkgShards) != 3 {
+		t.Errorf("shardFiles(package) = %d shards, want 3", len(pkgShards))
+	}
+	fileShards := shardFiles(files, &agent.ExecutionConfig{ShardBy: "file", ShardBatch: 1})
+	if len(fileShards) != 4 {
+		t.Errorf("shardFiles(file, batch=1) = %d shards, want 4", len(fileShards))
+	}
+}
+
 func TestGlobShardFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
**Key Changes:**

- Introduced `shard_by: package` as a new sharding strategy that groups files by parent directory, ensuring each package's files run together in a single shard with full intra-package context
- Implemented `groupByPackage` and `shardFiles` dispatch functions in `runner/shard.go` to support the new partitioning logic
- Updated validation in `ExecutionConfig` to accept `"package"` as a valid `shard_by` value alongside `"file"`
- Updated design documentation and struct comments to reflect the expanded sharding options

**Added:**

- `groupByPackage` function - buckets a sorted file list into one shard per parent directory, preserving file order within each shard; `ShardBatch` does not apply to this mode (`runner/shard.go`)
- `shardFiles` dispatch function - routes to `groupByPackage` when `ShardBy == "package"`, otherwise delegates to existing `batchFiles` logic (`runner/shard.go`)
- Tests for `groupByPackage` and `shardFiles` dispatch covering multi-directory inputs, root-level files, and comparison against file-batch behavior (`runner/shard_test.go`)
- Validation test cases for `shard_by: package` requiring a non-empty glob and confirming it is recognized as a sharded mode (`agent/bundle_test.go`)

**Changed:**

- `ExecutionConfig.Validate` now accepts `"package"` in addition to `"file"`, and updated the error message to list both valid values; glob requirement now applies to both modes (`agent/bundle.go`)
- `runSharded` call site replaced `batchFiles` with `shardFiles` and updated the log message to include the active `ShardBy` value (`runner/shard.go`)
- `ExecutionConfig` struct comments clarified that `ShardBatch` is ignored for `"package"` mode and that `Glob` is required for both `"file"` and `"package"` (`agent/bundle.go`)
- Sharded execution design doc updated to replace the v1 file-only limitation note with a description of `shard_by: package` semantics, and schema examples updated to show the new valid value (`docs/design/sharded-execution.md`)