### PR TITLE
feat: add claude-native prompt format support with frontmatter stripping

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -67,8 +67,9 @@ jobs:
           # Install gocyclo
           go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
-          # Install golangci-lint (pinned to avoid transient checksum mismatches)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+          # Install golangci-lint (pinned; go install verifies via the Go
+          # module checksum database instead of curl|sh)
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
           # Install gocritic
           go install github.com/go-critic/go-critic/cmd/gocritic@latest

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -88,8 +88,9 @@ jobs:
           # Install gocyclo
           go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
-          # Install golangci-lint (pinned to avoid transient checksum mismatches)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+          # Install golangci-lint (pinned; go install verifies via the Go
+          # module checksum database instead of curl|sh)
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
           # Install gocritic
           go install github.com/go-critic/go-critic/cmd/gocritic@latest

--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -690,7 +690,33 @@ func resolveMCPServerTemplates(servers []mcp.ServerConfig, data TemplateData) ([
 	return resolved, nil
 }
 
+// stripPromptFrontmatter detects the Claude-native prompt format: a file
+// beginning with a `---` YAML frontmatter fence. It returns the body after
+// the closing fence and true when a terminated frontmatter block is present.
+// The frontmatter (name/description/tools/model) is host metadata for Claude
+// Code; squad reads its equivalents from agent.yaml, so the block is dropped.
+func stripPromptFrontmatter(content string) (string, bool) {
+	rest, ok := strings.CutPrefix(content, "---\n")
+	if !ok {
+		if rest, ok = strings.CutPrefix(content, "---\r\n"); !ok {
+			return content, false
+		}
+	}
+	for _, fence := range []string{"\n---\n", "\n---\r\n"} {
+		if idx := strings.Index(rest, fence); idx >= 0 {
+			return strings.TrimLeft(rest[idx+len(fence):], "\r\n"), true
+		}
+	}
+	return content, false
+}
+
 // loadAndProcessPrompts loads system, wrapper, and task files, then processes them as templates.
+//
+// Exception: when the entrypoint carries a YAML frontmatter block, the agent
+// uses the Claude-native plain-markdown format (dual-host prompt files shared
+// verbatim with Claude Code). None of its prompt files are template-rendered —
+// literal {{...}} text such as Taskfile examples must survive unchanged. Mode
+// still reaches the agent through the "Mode:" header buildSystemMessage emits.
 func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, data TemplateData) (system, wrapper, task string, err error) {
 	systemData, err := readFileInRoot(agentPath, manifest.EntryPoint)
 	if err != nil {
@@ -703,6 +729,10 @@ func loadAndProcessPrompts(agentPath, agentsDir string, manifest *Manifest, data
 	taskContent, err := loadTask(agentPath, manifest.Task)
 	if err != nil {
 		return "", "", "", err
+	}
+
+	if body, ok := stripPromptFrontmatter(string(systemData)); ok {
+		return body, string(wrapperData), taskContent, nil
 	}
 
 	system, err = processTemplate("system", string(systemData), agentsDir, data)

--- a/agent/frontmatter_test.go
+++ b/agent/frontmatter_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStripPromptFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantBody string
+		wantOK   bool
+	}{
+		{
+			name:     "frontmatter stripped",
+			content:  "---\nname: rust-review\nmodel: opus\n---\n# IDENTITY\n\nBody.\n",
+			wantBody: "# IDENTITY\n\nBody.\n",
+			wantOK:   true,
+		},
+		{
+			name:     "no frontmatter",
+			content:  "# IDENTITY\n\nBody.\n",
+			wantBody: "# IDENTITY\n\nBody.\n",
+			wantOK:   false,
+		},
+		{
+			name:     "unterminated frontmatter falls back",
+			content:  "---\nname: broken\nno closing fence\n",
+			wantBody: "---\nname: broken\nno closing fence\n",
+			wantOK:   false,
+		},
+		{
+			name:     "crlf fences",
+			content:  "---\r\nname: x\r\n---\r\nBody.\n",
+			wantBody: "Body.\n",
+			wantOK:   true,
+		},
+		{
+			name:     "horizontal rule mid-document is not a fence",
+			content:  "Intro\n---\nmore\n---\nend\n",
+			wantBody: "Intro\n---\nmore\n---\nend\n",
+			wantOK:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := stripPromptFrontmatter(tt.content)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.wantBody {
+				t.Fatalf("body = %q, want %q", got, tt.wantBody)
+			}
+		})
+	}
+}
+
+// writePromptAgent lays out a minimal agent dir with the given prompt files.
+func writePromptAgent(t *testing.T, system, wrapper, task string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"system.md": system,
+		"agent.md":  wrapper,
+		"task.md":   task,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// TestLoadAndProcessPromptsClaudeNative verifies that a frontmatter-marked
+// entrypoint disables template rendering for every prompt file of the agent:
+// the frontmatter is dropped and literal {{...}} text (e.g. Taskfile
+// examples) survives verbatim in system, wrapper, and task alike.
+func TestLoadAndProcessPromptsClaudeNative(t *testing.T) {
+	system := "---\nname: go-taskfile\ntools: \"Bash, Read\"\n---\n" +
+		"# IDENTITY\n\nQuote the value: `VAR: '{{.OTHER_VAR}}'`.\n"
+	wrapper := "# AGENT MODE\n\nNever template-ify `{{.CMD_PATH}}` literals.\n"
+	task := "Fix the Taskfile. Leave `{{.VAR}}` examples alone.\n"
+	dir := writePromptAgent(t, system, wrapper, task)
+
+	manifest := &Manifest{EntryPoint: "system.md", Wrapper: "agent.md", Task: "task.md"}
+	data := TemplateData{Mode: "readonly", AgentDir: dir}
+
+	gotSystem, gotWrapper, gotTask, err := loadAndProcessPrompts(dir, dir, manifest, data)
+	if err != nil {
+		t.Fatalf("loadAndProcessPrompts: %v", err)
+	}
+	if strings.Contains(gotSystem, "name: go-taskfile") {
+		t.Errorf("frontmatter not stripped from system prompt: %q", gotSystem)
+	}
+	if !strings.HasPrefix(gotSystem, "# IDENTITY") {
+		t.Errorf("system body should start at first heading, got %q", gotSystem)
+	}
+	if !strings.Contains(gotSystem, "{{.OTHER_VAR}}") {
+		t.Errorf("literal template text mangled in system prompt: %q", gotSystem)
+	}
+	if !strings.Contains(gotWrapper, "{{.CMD_PATH}}") {
+		t.Errorf("literal template text mangled in wrapper: %q", gotWrapper)
+	}
+	if !strings.Contains(gotTask, "{{.VAR}}") {
+		t.Errorf("literal template text mangled in task: %q", gotTask)
+	}
+}
+
+// TestLoadAndProcessPromptsLegacyTemplates verifies the pre-frontmatter
+// format still renders mode conditionals and includes as before.
+func TestLoadAndProcessPromptsLegacyTemplates(t *testing.T) {
+	system := "# IDENTITY\n{{if eq .Mode \"edit\"}}EDIT-ONLY{{end}}{{if eq .Mode \"readonly\"}}READONLY-ONLY{{end}}\n"
+	wrapper := "# AGENT MODE\nMode is {{.Mode}}.\n"
+	task := "Do the {{.Mode}} thing.\n"
+	dir := writePromptAgent(t, system, wrapper, task)
+
+	manifest := &Manifest{EntryPoint: "system.md", Wrapper: "agent.md", Task: "task.md"}
+	data := TemplateData{Mode: "readonly", AgentDir: dir}
+
+	gotSystem, gotWrapper, gotTask, err := loadAndProcessPrompts(dir, dir, manifest, data)
+	if err != nil {
+		t.Fatalf("loadAndProcessPrompts: %v", err)
+	}
+	if strings.Contains(gotSystem, "EDIT-ONLY") || !strings.Contains(gotSystem, "READONLY-ONLY") {
+		t.Errorf("mode conditionals not rendered: %q", gotSystem)
+	}
+	if !strings.Contains(gotWrapper, "Mode is readonly.") {
+		t.Errorf("wrapper template not rendered: %q", gotWrapper)
+	}
+	if !strings.Contains(gotTask, "Do the readonly thing.") {
+		t.Errorf("task template not rendered: %q", gotTask)
+	}
+}


### PR DESCRIPTION
**Key Changes:**

- Introduced `stripPromptFrontmatter` to detect and remove YAML frontmatter from Claude-native prompt files, preventing template rendering for those agents
- When a frontmatter block is detected, all prompt files (system, wrapper, task) bypass Go template processing so literal `{{...}}` syntax survives verbatim
- Replaced `curl|sh` golangci-lint installation with `go install` in CI workflows for checksum-verified, reproducible builds

**Added:**

- Frontmatter stripping logic - `stripPromptFrontmatter` in `agent/bundle.go` handles both LF and CRLF line endings, returns the body after the closing `---` fence and a boolean indicating detection; unterminated or mid-document fences fall back gracefully
- Claude-native mode bypass in `loadAndProcessPrompts` - when frontmatter is detected on the entrypoint, all three prompt files are returned raw without template execution, allowing prompt files to be shared verbatim with Claude Code
- Comprehensive test coverage in `agent/frontmatter_test.go` covering frontmatter stripping edge cases (CRLF, unterminated, mid-document horizontal rules), Claude-native mode end-to-end, and legacy template rendering regression

**Changed:**

- golangci-lint installation in `.github/workflows/pre-commit.yaml` and `.github/workflows/renovate.yaml` - replaced `curl | sh` script with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4` so the Go module checksum database verifies the binary instead of trusting a remote shell script