### PR TITLE
fix: add "google" provider alias for gemini credential detection and routing

### DIFF
--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -39,6 +39,13 @@ var providerAPIKeyEnv = map[string][]string{
 	"openai-compat":    {"OPENAI_COMPAT_API_KEY", "OPENAI_API_KEY"},
 	"anthropic":        {"ANTHROPIC_API_KEY"},
 	"gemini":           {"GOOGLE_API_KEY"},
+	// "google" is the provider name agent manifests commonly use for
+	// Gemini models; the runner aliases it to "gemini" (see
+	// runner.normalizeProvider). Listing it here keeps credential
+	// detection consistent — without this entry an unknown provider is
+	// treated as "no key needed" and fallback selection picks it even
+	// when GOOGLE_API_KEY is absent.
+	"google": {"GOOGLE_API_KEY"},
 }
 
 // KeyStatus mirrors provider token precedence used by the runner: an

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -13,6 +13,7 @@ func TestKeyStatusProviderEnvTable(t *testing.T) {
 		{"openai-compat", "OPENAI_COMPAT_API_KEY"},
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"gemini", "GOOGLE_API_KEY"},
+		{"google", "GOOGLE_API_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.provider, func(t *testing.T) {

--- a/runner/model.go
+++ b/runner/model.go
@@ -544,7 +544,14 @@ func buildGeminiLLM(ctx context.Context, opts *RunOptions, model string) (llms.M
 }
 
 func normalizeProvider(provider string) string {
-	return strings.ToLower(strings.TrimSpace(provider))
+	p := strings.ToLower(strings.TrimSpace(provider))
+	// Agent manifests commonly write "google" for Gemini models; the
+	// implemented provider is "gemini" (metrics/apikey.go carries the
+	// matching credential entry for both spellings).
+	if p == "google" {
+		return "gemini"
+	}
+	return p
 }
 
 func buildNativeOllamaLLM(opts *RunOptions, model string) llms.Model {

--- a/runner/model_provider_test.go
+++ b/runner/model_provider_test.go
@@ -1,0 +1,25 @@
+package runner
+
+import "testing"
+
+// TestNormalizeProviderGoogleAlias pins the manifest-facing "google" spelling
+// to the implemented "gemini" provider so buildLLM and telemetry treat them
+// identically. Without the alias, fallback selection could pick a
+// google-provider manifest entry and then fail at buildLLM with
+// "provider not implemented: google".
+func TestNormalizeProviderGoogleAlias(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"google":    "gemini",
+		" Google ":  "gemini",
+		"gemini":    "gemini",
+		"anthropic": "anthropic",
+		"":          "",
+		" OpenAI ":  "openai",
+	}
+	for in, want := range cases {
+		if got := normalizeProvider(in); got != want {
+			t.Errorf("normalizeProvider(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
**Key Changes:**

- `normalizeProvider` now maps the "google" provider name to "gemini", preventing runtime failures when agent manifests use "google" to reference Gemini models
- Credential detection in `providerAPIKeyEnv` now includes "google" mapped to `GOOGLE_API_KEY`, preventing fallback selection from incorrectly treating "google" as a keyless provider
- Tests added to pin both the alias behavior and credential lookup for the "google" provider spelling

**Added:**

- Provider alias test - Added `runner/model_provider_test.go` with `TestNormalizeProviderGoogleAlias` to pin the "google" → "gemini" normalization across casing and whitespace variants, guarding against regressions that would cause `buildLLM` to fail with "provider not implemented: google"
- `"google"` credential entry - Added `"google": {"GOOGLE_API_KEY"}` to `providerAPIKeyEnv` in `metrics/apikey.go` with a test case in `metrics/apikey_test.go`, ensuring fallback selection correctly requires `GOOGLE_API_KEY` to be present before picking a google-provider manifest entry

**Changed:**

- Provider normalization logic - Extended `normalizeProvider` in `runner/model.go` to alias `"google"` to `"gemini"` after lowercasing and trimming, so both `buildLLM` dispatch and telemetry treat the two spellings identically regardless of how agent manifests spell the provider name