### PR TITLE
feat: add symlink and frontmatter support for shared agent references

### DIFF
--- a/agent/bundle.go
+++ b/agent/bundle.go
@@ -557,17 +557,36 @@ func readFileInRoot(root, path string) (data []byte, retErr error) {
 	return io.ReadAll(f)
 }
 
-func loadReferences(agentPath string, refs []string) ([]string, error) {
+// loadReferences reads each manifest reference and returns it as an injectable
+// prompt block. References normally live inside the agent directory; a
+// reference may also be a symlink into a shared location elsewhere under
+// agentsDir (e.g. `references/foo.md -> ../../skills/foo/SKILL.md`), so when
+// the agent-rooted read fails the lookup is retried with agentsDir as the
+// traversal root. A leading YAML frontmatter block (present when the
+// reference doubles as a SKILL.md) is stripped — it is host metadata, not
+// reference content.
+func loadReferences(agentPath, agentsDir string, refs []string) ([]string, error) {
 	var result []string
 	for _, ref := range refs {
 		if strings.TrimSpace(ref) == "" {
 			continue
 		}
 		refData, err := readFileInRoot(agentPath, ref)
+		if err != nil && agentsDir != "" {
+			if rel, rerr := filepath.Rel(agentsDir, filepath.Join(agentPath, ref)); rerr == nil {
+				if wide, werr := readFileInRoot(agentsDir, rel); werr == nil {
+					refData, err = wide, nil
+				}
+			}
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read reference %s: %w", ref, err)
 		}
-		result = append(result, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(string(refData))))
+		content := string(refData)
+		if body, ok := stripPromptFrontmatter(content); ok {
+			content = body
+		}
+		result = append(result, fmt.Sprintf("## Reference: %s\n\n%s\n", ref, strings.TrimSpace(content)))
 	}
 	return result, nil
 }
@@ -1054,7 +1073,7 @@ func BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode strin
 		if lerr != nil {
 			return nil, lerr
 		}
-		refs, rerr := loadReferences(agentPath, manifest.References)
+		refs, rerr := loadReferences(agentPath, agentsDir, manifest.References)
 		if rerr != nil {
 			return nil, rerr
 		}
@@ -1210,10 +1229,10 @@ func BuildBundleInline(baseDir string, cfg *InlineAgentConfig, prompt, workingDi
 	}
 
 	// References are resolved from baseDir (shared) or promptDir (stage-specific).
-	refs, err := loadReferences(promptDir, manifest.References)
+	refs, err := loadReferences(promptDir, includeRoot, manifest.References)
 	if err != nil {
 		// Fall back to baseDir for shared references.
-		refs, err = loadReferences(baseDir, manifest.References)
+		refs, err = loadReferences(baseDir, includeRoot, manifest.References)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/bundle_internal_test.go
+++ b/agent/bundle_internal_test.go
@@ -685,7 +685,7 @@ func TestLoadReferences_SkipsBlankRefs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "ref.md"), []byte("body"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	got, err := loadReferences(root, []string{"", "   ", "ref.md", "\t"})
+	got, err := loadReferences(root, "", []string{"", "   ", "ref.md", "\t"})
 	if err != nil {
 		t.Fatalf("loadReferences: %v", err)
 	}
@@ -701,7 +701,7 @@ func TestLoadReferences_SkipsBlankRefs(t *testing.T) {
 func TestLoadReferences_MissingFile(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	_, err := loadReferences(root, []string{"nope.md"})
+	_, err := loadReferences(root, "", []string{"nope.md"})
 	if err == nil {
 		t.Fatal("expected error for missing reference")
 	}

--- a/agent/references_test.go
+++ b/agent/references_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadReferencesSharedSymlink verifies a reference that is a symlink into
+// a shared top-level skills/ directory resolves via the agentsDir retry, and
+// that a leading SKILL.md frontmatter block is stripped from the injected
+// content.
+func TestLoadReferencesSharedSymlink(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	skillDir := filepath.Join(agentsDir, "skills", "foo-guide")
+	agentDir := filepath.Join(agentsDir, "my-agent")
+	refsDir := filepath.Join(agentDir, "references")
+	for _, d := range []string{skillDir, refsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	skillMD := "---\nname: foo-guide\ndescription: Guide for foo\n---\n# Foo Guide\n\nAlways foo before bar.\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMD), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "skills", "foo-guide", "SKILL.md"),
+		filepath.Join(refsDir, "foo-guide.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	refs, err := loadReferences(agentDir, agentsDir, []string{"references/foo-guide.md"})
+	if err != nil {
+		t.Fatalf("loadReferences: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d", len(refs))
+	}
+	if !strings.Contains(refs[0], "Always foo before bar.") {
+		t.Errorf("reference content missing body: %q", refs[0])
+	}
+	if strings.Contains(refs[0], "name: foo-guide") {
+		t.Errorf("frontmatter not stripped from injected reference: %q", refs[0])
+	}
+	if !strings.Contains(refs[0], "## Reference: references/foo-guide.md") {
+		t.Errorf("reference header missing: %q", refs[0])
+	}
+}
+
+// TestLoadReferencesLocalFile verifies plain in-agent references keep working
+// and pass through untouched when they carry no frontmatter.
+func TestLoadReferencesLocalFile(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "my-agent")
+	refsDir := filepath.Join(agentDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(refsDir, "criteria.md"), []byte("# Criteria\n\nBe correct.\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	refs, err := loadReferences(agentDir, agentsDir, []string{"references/criteria.md"})
+	if err != nil {
+		t.Fatalf("loadReferences: %v", err)
+	}
+	if len(refs) != 1 || !strings.Contains(refs[0], "Be correct.") {
+		t.Fatalf("unexpected refs: %v", refs)
+	}
+}
+
+// TestLoadReferencesMissing verifies a missing reference still errors even
+// with the agentsDir retry in place.
+func TestLoadReferencesMissing(t *testing.T) {
+	t.Parallel()
+
+	agentsDir := t.TempDir()
+	agentDir := filepath.Join(agentsDir, "my-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := loadReferences(agentDir, agentsDir, []string{"references/nope.md"}); err == nil {
+		t.Fatal("expected error for missing reference, got nil")
+	}
+}


### PR DESCRIPTION
**Key Changes:**

- Extended `loadReferences` to accept an `agentsDir` fallback root, enabling references that are symlinks into shared skill directories to resolve correctly
- Added automatic stripping of YAML frontmatter from reference content so SKILL.md files used as references don't inject host metadata into prompts
- Added a dedicated test file covering the new symlink resolution, local file, and missing file error scenarios

**Added:**

- Shared symlink resolution for references - when an agent-rooted read fails, `loadReferences` now retries the lookup using `agentsDir` as the traversal root, allowing symlinks like `references/foo.md -> ../../skills/foo/SKILL.md` to resolve correctly
- YAML frontmatter stripping - reference content is passed through `stripPromptFrontmatter` before injection so that SKILL.md files doubling as references don't pollute the prompt with metadata fields like `name` and `description`
- Comprehensive reference loading tests in `agent/references_test.go` covering symlink resolution with frontmatter stripping, plain local references with no frontmatter, and missing-file error behavior with the agentsDir retry path active

**Changed:**

- `loadReferences` signature extended from `(agentPath string, refs []string)` to `(agentPath, agentsDir string, refs []string)` - all three call sites in `BuildBundleWithOptions` and `BuildBundleInline` updated accordingly, and existing internal tests updated to pass an empty string for `agentsDir` to preserve prior behavior
- Inline documentation added to `loadReferences` explaining the fallback lookup strategy and frontmatter stripping rationale