### PR TITLE
feat: add dry-run fallback for unauthenticated model resolution

### DIFF
--- a/runner/dryrun_credentials_test.go
+++ b/runner/dryrun_credentials_test.go
@@ -45,3 +45,32 @@ func TestResolveModelPrecedenceDryRunWithoutCredentials(t *testing.T) {
 		t.Fatalf("error should list env vars, got: %v", err)
 	}
 }
+
+// TestResolveModelPrecedenceDryRunBundleBaseURL covers the bundle-level
+// BaseURL fallback: when neither the options nor the selected manifest entry
+// carry a base URL, the dry-run pick inherits the bundle's.
+func TestResolveModelPrecedenceDryRunBundleBaseURL(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_COMPAT_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	bundle := &agent.Bundle{
+		BaseURL: "https://llm.internal/api",
+		Models: []agent.ModelPreference{
+			{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		},
+	}
+
+	opts := &RunOptions{DryRun: true}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil {
+		t.Fatalf("dry-run without credentials should not error, got: %v", err)
+	}
+	if opts.BaseURL != "https://llm.internal/api" {
+		t.Fatalf("dry-run should inherit bundle BaseURL, got %q", opts.BaseURL)
+	}
+	if warn == "" {
+		t.Fatal("expected a dry-run warning")
+	}
+}

--- a/runner/dryrun_credentials_test.go
+++ b/runner/dryrun_credentials_test.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
+)
+
+// TestResolveModelPrecedenceDryRunWithoutCredentials pins the rule-4a-dry
+// behavior: a --dry-run with a real-provider manifest and no credentials
+// anywhere proceeds on the manifest's top model with a warning (bundle
+// assembly never calls the model), while a real run still aborts with the
+// env-var guidance.
+func TestResolveModelPrecedenceDryRunWithoutCredentials(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_COMPAT_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	bundle := &agent.Bundle{Models: []agent.ModelPreference{
+		{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		{Model: "gemini-2.5-flash", Provider: "google"},
+	}}
+
+	opts := &RunOptions{DryRun: true}
+	warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+	if err != nil {
+		t.Fatalf("dry-run without credentials should not error, got: %v", err)
+	}
+	if opts.Model != "claude-sonnet-4-6" || opts.Provider != "anthropic" {
+		t.Fatalf("dry-run should pick manifest top model, got %s (%s)", opts.Model, opts.Provider)
+	}
+	if !strings.Contains(warn, "Dry run proceeding") {
+		t.Fatalf("expected dry-run warning, got %q", warn)
+	}
+
+	real := &RunOptions{}
+	_, err = ResolveModelPrecedence(context.Background(), real, bundle)
+	if err == nil {
+		t.Fatal("real run without credentials should still error")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Fatalf("error should list env vars, got: %v", err)
+	}
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -338,6 +338,9 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 	if opts.ConfigModel != "" {
 		return applyConfigDefaultUnauthenticated(ctx, opts, bundle), nil
 	}
+	if opts.DryRun && len(skipped) > 0 {
+		return applyManifestTopUnauthenticated(ctx, opts, bundle), nil
+	}
 	if err := noCredentialsError(skipped); err != nil {
 		return "", err
 	}
@@ -455,6 +458,30 @@ func applyConfigDefaultUnauthenticated(ctx context.Context, opts *RunOptions, bu
 		"⚠  No provider has detected credentials. Proceeding with config default %q (%s);\n"+
 			"   the model call will likely fail authentication. Set the relevant API key to fix.",
 		opts.Model, opts.Provider)
+}
+
+// applyManifestTopUnauthenticated handles rule 4a-dry: nothing anywhere has
+// credentials, but the run is a --dry-run — bundle assembly and cost
+// estimation never call the model, so proceed with the manifest's top
+// preference and a warning instead of failing. Real runs without credentials
+// still abort via noCredentialsError.
+func applyManifestTopUnauthenticated(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) string {
+	top := bundle.Models[0]
+	opts.Model = top.Model
+	if opts.Provider == "" {
+		opts.Provider = top.Provider
+	}
+	if opts.BaseURL == "" {
+		opts.BaseURL = top.BaseURL
+	}
+	if opts.BaseURL == "" && bundle.BaseURL != "" {
+		opts.BaseURL = bundle.BaseURL
+	}
+	logging.WarnContext(ctx, "dry-run without credentials; using manifest top model %q (%s)", top.Model, top.Provider)
+	return fmt.Sprintf(
+		"⚠  No provider has detected credentials. Dry run proceeding with manifest model %q (%s);\n"+
+			"   a real run will fail until one of the provider API keys is set.",
+		top.Model, top.Provider)
 }
 
 // noCredentialsError handles rule 4b: manifest had entries but none had


### PR DESCRIPTION
**Key Changes:**

- Introduced a new rule (4a-dry) that allows `--dry-run` executions to proceed without credentials by falling back to the manifest's top model with a warning, rather than aborting
- Added `applyManifestTopUnauthenticated` to handle BaseURL inheritance from both the manifest entry and bundle-level fallback
- Added tests covering the no-credentials dry-run path and bundle-level BaseURL propagation

**Added:**

- Dry-run credential bypass logic - New `applyManifestTopUnauthenticated` function in `runner/run.go` picks the top manifest model, inherits `BaseURL` from the manifest entry or bundle, logs a warning, and returns a human-readable warning string instead of erroring
- Test coverage for unauthenticated dry-run behavior - `runner/dryrun_credentials_test.go` adds two tests: `TestResolveModelPrecedenceDryRunWithoutCredentials` pins that a dry-run proceeds on the manifest's top model while a real run still aborts with env-var guidance, and `TestResolveModelPrecedenceDryRunBundleBaseURL` verifies that the bundle-level `BaseURL` is correctly inherited when neither options nor the manifest entry provide one

**Changed:**

- Model resolution branching in `ResolveModelPrecedence` - Added an early-exit branch in `runner/run.go` that checks `opts.DryRun && len(skipped) > 0` before reaching `noCredentialsError`, routing unauthenticated dry-runs to `applyManifestTopUnauthenticated` while leaving real-run failure behavior unchanged