### PR TITLE
feat: scaffold knowledge base as shared skill with symlinked reference

### DIFF
--- a/docs/creating-agents.md
+++ b/docs/creating-agents.md
@@ -27,8 +27,8 @@ my-review/
 ├── system.md       # Main prompt - identity, rules, workflow (required)
 ├── agent.md        # Execution wrapper (required)
 ├── task.md         # Default task instructions (required)
-└── references/     # Knowledge base docs (optional)
-    └── criteria.md
+└── references/     # Knowledge base links (optional)
+    └── criteria.md #   -> ../../skills/criteria/SKILL.md (see References)
 ```
 
 ### agent.yaml (Manifest)
@@ -184,10 +184,16 @@ Write the body plain — no template syntax:
 - **Includes**: no `{{include}}`. Inline shared content, or move it into a
   [skill](./skills.md) and reference it as `Skill("name")` — skill
   references resolve in both hosts.
-- **References**: squad injects `agent.yaml` `references:` into the
-  prompt; Claude Code does not. Phrase the knowledge-base section for both
-  hosts: "If the host has not already injected `criteria.md` into your
-  prompt, Read `<absolute path>` on your FIRST iteration."
+- **References**: ship the knowledge base as a skill and let the body load
+  it by name. The document lives at `<agents-dir>/skills/<name>/SKILL.md`
+  (YAML frontmatter + content), and `<agent>/references/<doc>.md` is a
+  relative symlink to it — squad injects it via `agent.yaml` `references:`
+  (the SKILL frontmatter is stripped on injection), while Claude Code loads
+  it on demand. Phrase the knowledge-base section for both hosts: "If the
+  host has not already injected `criteria.md` into your prompt, load
+  `Skill("criteria")` on your FIRST iteration." `squad init agent`
+  scaffolds this layout automatically. Never hardcode absolute paths in
+  the body — they break on every other machine.
 
 ### Running the Same Agent in Claude Code
 

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -75,12 +75,11 @@ func CreateAgent(ctx context.Context, opts CreateOptions) error {
 	}
 
 	files := map[string]string{
-		"agent.yaml":                            "agent.yaml.tmpl",
-		"system.md":                             "system.md.tmpl",
-		"agent.md":                              "agent.md.tmpl",
-		"task.md":                               "task.md.tmpl",
-		"README.md":                             "README.md.tmpl",
-		"references/" + opts.Name + "-guide.md": "reference.md.tmpl",
+		"agent.yaml": "agent.yaml.tmpl",
+		"system.md":  "system.md.tmpl",
+		"agent.md":   "agent.md.tmpl",
+		"task.md":    "task.md.tmpl",
+		"README.md":  "README.md.tmpl",
 	}
 
 	for outFile, tmplFile := range files {
@@ -96,12 +95,50 @@ func CreateAgent(ctx context.Context, opts CreateOptions) error {
 		logging.InfoContext(ctx, "Created %s", outPath)
 	}
 
+	if err := writeReferenceSkill(ctx, opts, data); err != nil {
+		return err
+	}
+
 	logging.InfoContext(ctx, "Agent %q created successfully at %s", opts.Name, agentPath)
 	logging.InfoContext(ctx, "Next steps:")
-	logging.InfoContext(ctx, "  1. Edit references/%s-guide.md with domain knowledge", opts.Name)
+	logging.InfoContext(ctx, "  1. Edit skills/%s-guide/SKILL.md with domain knowledge", opts.Name)
 	logging.InfoContext(ctx, "  2. Customize system.md with agent-specific rules")
 	logging.InfoContext(ctx, "  3. Test with: squad run --agent %s", opts.Name)
 
+	return nil
+}
+
+// writeReferenceSkill materializes the agent's knowledge base in the shared
+// fleet layout: the document lives at <agentsDir>/skills/<name>-guide/SKILL.md
+// (loadable by name via the Skill tool in any host) and
+// <agent>/references/<name>-guide.md is a relative symlink to it, which keeps
+// agent.yaml `references:` injection working for squad runs.
+func writeReferenceSkill(ctx context.Context, opts CreateOptions, data AgentData) error {
+	skillName := opts.Name + "-guide"
+	skillDir := filepath.Join(opts.AgentsDir, "skills", skillName)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create skill directory: %w", err)
+	}
+
+	content, err := Render("reference.md.tmpl", data)
+	if err != nil {
+		return fmt.Errorf("failed to render reference.md.tmpl: %w", err)
+	}
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", skillPath, err)
+	}
+	logging.InfoContext(ctx, "Created %s", skillPath)
+
+	linkPath := filepath.Join(opts.AgentsDir, opts.Name, "references", skillName+".md")
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to replace reference link %s: %w", linkPath, err)
+	}
+	target := filepath.Join("..", "..", "skills", skillName, "SKILL.md")
+	if err := os.Symlink(target, linkPath); err != nil {
+		return fmt.Errorf("failed to create reference symlink %s: %w", linkPath, err)
+	}
+	logging.InfoContext(ctx, "Created %s -> %s", linkPath, target)
 	return nil
 }
 

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -601,3 +601,61 @@ func TestCopyAgent_DestExists_NoForce(t *testing.T) {
 		t.Fatal("expected error when destination exists without force")
 	}
 }
+
+// TestCreateAgent_ReferenceSkillErrors drives the failure branches of the
+// reference-skill scaffolding: an unusable skills dir, an unwritable
+// SKILL.md path, an irremovable stale reference link, and a read-only
+// references dir that blocks symlink creation.
+func TestCreateAgent_ReferenceSkillErrors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("skills dir is a file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "skills"), []byte("not a dir"), 0o644); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err := scaffold.CreateAgent(ctx, scaffold.CreateOptions{Name: "my-agent", Lang: "go", AgentsDir: dir})
+		if err == nil || !strings.Contains(err.Error(), "skill directory") {
+			t.Fatalf("expected skill directory error, got: %v", err)
+		}
+	})
+
+	t.Run("SKILL.md path is a directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "skills", "my-agent-guide", "SKILL.md"), 0o755); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err := scaffold.CreateAgent(ctx, scaffold.CreateOptions{Name: "my-agent", Lang: "go", AgentsDir: dir})
+		if err == nil || !strings.Contains(err.Error(), "failed to write") {
+			t.Fatalf("expected write error, got: %v", err)
+		}
+	})
+
+	t.Run("stale reference link is an irremovable dir", func(t *testing.T) {
+		dir := t.TempDir()
+		stale := filepath.Join(dir, "my-agent", "references", "my-agent-guide.md")
+		if err := os.MkdirAll(filepath.Join(stale, "occupied"), 0o755); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err := scaffold.CreateAgent(ctx, scaffold.CreateOptions{Name: "my-agent", Lang: "go", AgentsDir: dir, Force: true})
+		if err == nil || !strings.Contains(err.Error(), "replace reference link") {
+			t.Fatalf("expected replace-link error, got: %v", err)
+		}
+	})
+
+	t.Run("references dir is read-only", func(t *testing.T) {
+		dir := t.TempDir()
+		refs := filepath.Join(dir, "my-agent", "references")
+		if err := os.MkdirAll(refs, 0o755); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := os.Chmod(refs, 0o555); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(refs, 0o755) })
+		err := scaffold.CreateAgent(ctx, scaffold.CreateOptions{Name: "my-agent", Lang: "go", AgentsDir: dir, Force: true})
+		if err == nil || !strings.Contains(err.Error(), "reference symlink") {
+			t.Fatalf("expected symlink error, got: %v", err)
+		}
+	})
+}

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -132,6 +132,29 @@ func TestCreateAgent_Success(t *testing.T) {
 			t.Errorf("expected file %s to exist: %v", f, err)
 		}
 	}
+
+	// The knowledge base is scaffolded in the fleet layout: a skill at the
+	// agents-dir level with the agent's references/ entry symlinked to it.
+	skillPath := filepath.Join(dir, "skills", "my-agent-guide", "SKILL.md")
+	skillContent, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("expected reference skill at %s: %v", skillPath, err)
+	}
+	if !strings.HasPrefix(string(skillContent), "---\nname: my-agent-guide\n") {
+		t.Errorf("SKILL.md missing frontmatter, got: %.60q", string(skillContent))
+	}
+
+	linkPath := filepath.Join(agentPath, "references", "my-agent-guide.md")
+	if fi, lerr := os.Lstat(linkPath); lerr != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected %s to be a symlink (err=%v)", linkPath, lerr)
+	}
+	linked, err := os.ReadFile(linkPath)
+	if err != nil {
+		t.Fatalf("reference symlink does not resolve: %v", err)
+	}
+	if string(linked) != string(skillContent) {
+		t.Error("reference symlink content does not match SKILL.md")
+	}
 }
 
 func TestCreateAgent_Force(t *testing.T) {

--- a/scaffold/templates/README.md.tmpl
+++ b/scaffold/templates/README.md.tmpl
@@ -23,7 +23,7 @@ squad run --agent {{.Name}} "Focus on the src/ directory"
 | `system.md` | Core system prompt (identity, rules, workflow) |
 | `agent.md` | Execution wrapper with mode-specific rules |
 | `task.md` | Default task instructions |
-| `references/{{.Name}}-guide.md` | Domain knowledge base |
+| `../skills/{{.Name}}-guide/SKILL.md` | Domain knowledge base (loadable as `Skill("{{.Name}}-guide")`; `references/{{.Name}}-guide.md` symlinks to it for squad injection) |
 
 ## Modes
 

--- a/scaffold/templates/reference.md.tmpl
+++ b/scaffold/templates/reference.md.tmpl
@@ -1,3 +1,7 @@
+---
+name: {{.Name}}-guide
+description: "Reference knowledge base for the {{.Name}} agent. Loaded by that agent on its first iteration when the host has not already injected it; not intended for direct invocation."
+---
 # {{.NameTitle}} Guide
 
 This document contains domain knowledge for the {{.NameTitle}} agent.

--- a/scaffold/templates/system.md.tmpl
+++ b/scaffold/templates/system.md.tmpl
@@ -1,7 +1,7 @@
 ---
 name: {{.Name}}
 description: "{{.Description}}. Use proactively when asked to [describe the trigger, e.g. review X, audit Y]. By default it fixes issues in place and verifies the result; say \"readonly\", \"report only\", \"analysis only\", or \"do not modify\" to get a prioritized findings report with no edits."
-tools: "Bash, Glob, Grep, Read, Edit, MultiEdit"
+tools: "Bash, Glob, Grep, Read, Edit, MultiEdit, Skill"
 model: opus
 ---
 # IDENTITY and PURPOSE
@@ -22,9 +22,9 @@ using Glob, Read, and Grep.
 # KNOWLEDGE BASE
 
 You need `{{.Name}}-guide.md` in context before starting your review. If
-the host has not already injected it into your prompt, Read it from the
-`references/` directory next to this agent on your FIRST iteration. Apply
-ALL relevant criteria from that document; read it once — do not re-read.
+the host has not already injected it into your prompt, load
+`Skill("{{.Name}}-guide")` on your FIRST iteration. Apply ALL relevant
+criteria from that document; read it once — do not re-read.
 
 **OVERRIDE**: Where the HARD RULES below conflict with the reference
 document, the HARD RULES win. The reference is a general guide; the hard


### PR DESCRIPTION
**Key Changes:**

- Knowledge base documents are now created as fleet-level skills (`skills/<name>-guide/SKILL.md`) instead of inline reference files, enabling cross-host portability via `Skill("name")` loading
- Agent scaffolding creates a relative symlink from `references/<name>-guide.md` to the skill file, preserving squad's `agent.yaml` injection while supporting on-demand loading in Claude Code
- System prompt template updated to load the knowledge base via `Skill()` instead of hardcoded `Read` paths, eliminating machine-specific absolute path breakage
- Documentation and tests updated to reflect the new fleet layout and symlink-based reference strategy

**Added:**

- `writeReferenceSkill` function in `scaffold/scaffold.go` that creates the skill directory at `<agentsDir>/skills/<name>-guide/SKILL.md`, renders the reference template into it, then creates a relative symlink from `<agent>/references/<name>-guide.md` back to the skill file
- YAML frontmatter block to `reference.md.tmpl` with `name` and `description` fields, making the rendered document a valid named skill loadable by the `Skill` tool
- `Skill` added to the default `tools:` list in `system.md.tmpl` so agents can invoke `Skill("name")` out of the box
- Test coverage in `scaffold_test.go` for the happy-path fleet layout (skill exists, symlink resolves, content matches) and four error branches: skills dir blocked by a file, SKILL.md path occupied by a directory, stale reference link that cannot be removed, and read-only references directory blocking symlink creation

**Changed:**

- Agent scaffolding in `scaffold.go` replaced the direct `references/<name>-guide.md` file entry in the `files` map with a call to `writeReferenceSkill`, and updated the post-creation log message to point users to `skills/<name>-guide/SKILL.md`
- Knowledge base loading instruction in `system.md.tmpl` changed from `Read` with a relative path to `Skill("{{.Name}}-guide")`, removing any dependency on filesystem path resolution
- `README.md.tmpl` file table updated to reference `../skills/<name>-guide/SKILL.md` as the canonical location, with a note that `references/<name>-guide.md` symlinks to it for squad injection
- Documentation in `creating-agents.md` updated to describe the skill-plus-symlink layout, replace the absolute-path fallback phrasing with `Skill("criteria")`, and explicitly warn against hardcoding absolute paths in agent bodies