### PR TITLE
refactor: rename go-taskfile agent to taskfile-review

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,13 +266,13 @@ tasks:
           --out {{.OUT_DIR}}/squad-go-security-audit-analysis.txt
       - echo "Security audit analysis written to {{.OUT_DIR}}/squad-go-security-audit-analysis.txt"
 
-  run:go-taskfile:
-    desc: "Run the go-taskfile agent to autonomously fix Taskfile.yaml best-practice violations"
+  run:taskfile-review:
+    desc: "Run the taskfile-review agent to autonomously fix Taskfile.yaml best-practice violations"
     silent: true
     cmds:
       - |
         go run {{.CMD_PATH}} run -v \
-          --agent go-taskfile \
+          --agent taskfile-review \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
@@ -280,21 +280,21 @@ tasks:
           --model {{.MODEL}} \
           --require-actionable=true \
           --temperature 0.3 \
-          --out {{.OUT_DIR}}/squad-go-taskfile.txt
-      - echo "Taskfile review output written to {{.OUT_DIR}}/squad-go-taskfile.txt"
+          --out {{.OUT_DIR}}/squad-taskfile-review.txt
+      - echo "Taskfile review output written to {{.OUT_DIR}}/squad-taskfile-review.txt"
       - |
         echo ""
         echo "Running final verification..."
       - task --list
       - echo "task --list PASSED"
 
-  run:go-taskfile-analyze:
-    desc: "Run the go-taskfile agent in readonly mode to analyze Taskfile violations without applying fixes"
+  run:taskfile-review-analyze:
+    desc: "Run the taskfile-review agent in readonly mode to analyze Taskfile violations without applying fixes"
     silent: true
     cmds:
       - |
         go run {{.CMD_PATH}} run -v \
-          --agent go-taskfile --mode readonly \
+          --agent taskfile-review --mode readonly \
           --working-dir {{.WORKING_DIR}} \
           {{._API_KEY_FLAG}} \
           --provider {{.PROVIDER}} \
@@ -303,8 +303,8 @@ tasks:
           --require-actionable=false \
           --temperature 0.3 \
           --print=false \
-          --out {{.OUT_DIR}}/squad-go-taskfile-analysis.txt
-      - echo "Taskfile analysis written to {{.OUT_DIR}}/squad-go-taskfile-analysis.txt"
+          --out {{.OUT_DIR}}/squad-taskfile-review-analysis.txt
+      - echo "Taskfile analysis written to {{.OUT_DIR}}/squad-taskfile-review-analysis.txt"
 
   run:python-review:
     desc: "Run the python-review agent to autonomously fix Python code quality issues"

--- a/agent/frontmatter_test.go
+++ b/agent/frontmatter_test.go
@@ -79,7 +79,7 @@ func writePromptAgent(t *testing.T, system, wrapper, task string) string {
 // the frontmatter is dropped and literal {{...}} text (e.g. Taskfile
 // examples) survives verbatim in system, wrapper, and task alike.
 func TestLoadAndProcessPromptsClaudeNative(t *testing.T) {
-	system := "---\nname: go-taskfile\ntools: \"Bash, Read\"\n---\n" +
+	system := "---\nname: taskfile-review\ntools: \"Bash, Read\"\n---\n" +
 		"# IDENTITY\n\nQuote the value: `VAR: '{{.OTHER_VAR}}'`.\n"
 	wrapper := "# AGENT MODE\n\nNever template-ify `{{.CMD_PATH}}` literals.\n"
 	task := "Fix the Taskfile. Leave `{{.VAR}}` examples alone.\n"
@@ -92,7 +92,7 @@ func TestLoadAndProcessPromptsClaudeNative(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadAndProcessPrompts: %v", err)
 	}
-	if strings.Contains(gotSystem, "name: go-taskfile") {
+	if strings.Contains(gotSystem, "name: taskfile-review") {
 		t.Errorf("frontmatter not stripped from system prompt: %q", gotSystem)
 	}
 	if !strings.HasPrefix(gotSystem, "# IDENTITY") {


### PR DESCRIPTION
**Key Changes:**

- Renamed the `go-taskfile` agent to `taskfile-review` for clearer, language-agnostic naming
- Updated all Taskfile targets and output file paths to reflect the new agent name
- Aligned test fixtures with the renamed agent identifier

**Changed:**

- Taskfile agent tasks - Renamed `run:go-taskfile` and `run:go-taskfile-analyze` targets to `run:taskfile-review` and `run:taskfile-review-analyze`, updating their descriptions, `--agent` flags, and output file names (e.g., `squad-go-taskfile.txt` to `squad-taskfile-review.txt`) in `Taskfile.yaml`
- Test frontmatter fixtures - Updated the agent name from `go-taskfile` to `taskfile-review` in the prompt frontmatter and assertion strings within `agent/frontmatter_test.go` to keep the frontmatter-stripping test in sync with the rename