### PR TITLE
ci: bump go version to 1.26.5 in renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,7 +36,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.25.7
+  GO_VERSION: 1.26.5
   PYTHON_VERSION: 3.13.3
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 


### PR DESCRIPTION
**Key Changes:**

- Updated the Go version used in the Renovate CI workflow from 1.25.7 to 1.26.5

**Changed:**

- Go version for CI - Bumped `GO_VERSION` from `1.25.7` to `1.26.5` in `.github/workflows/renovate.yaml` to keep the Renovate workflow aligned with the current Go release