### PR TITLE
ci: move govulncheck from pre-commit to dedicated workflow

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,75 @@
+---
+name: Govulncheck
+on:
+  # Gate PRs that actually change dependencies.
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - go.mod
+      - go.sum
+      - .hooks/govulncheck-scan.sh
+      - .github/workflows/govulncheck.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+  # Catch newly published advisories against unchanged code. This runs on a
+  # schedule rather than in pre-commit so a fresh CVE reddens one scheduled run
+  # instead of every open PR.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  govulncheck:
+    name: Run govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+
+      # The module pulls in the docker client, which needs these headers to
+      # load packages for analysis.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential \
+                                  btrfs-progs \
+                                  libgpgme-dev \
+                                  libbtrfs-dev \
+                                  pkg-config
+
+      - name: Install govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      # Reuses the same script as local runs so the ignore list for
+      # vulnerabilities with no upstream fix lives in exactly one place.
+      - name: Run govulncheck
+        run: .hooks/govulncheck-scan.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,12 +105,19 @@ repos:
         language: script
         types: [json, yaml]
 
+      # Manual-only: CI runs `pre-commit run --all-files`, which ignores the
+      # `files` filter below and so ran this on every PR. A newly published
+      # advisory then blocked unrelated PRs without any code change. The
+      # Govulncheck workflow now gates dependency changes and scans daily.
+      # Run locally with:
+      #   pre-commit run govulncheck-scan --hook-stage manual
       - id: govulncheck-scan
         name: govulncheck vulnerability scan
         entry: .hooks/govulncheck-scan.sh
         language: script
         pass_filenames: false
         files: '(go\.mod|go\.sum)$'
+        stages: [manual]
         description: "Run govulncheck to check for vulnerabilities in Go dependencies"
 
       - id: goreleaser-check


### PR DESCRIPTION
**Key Changes:**

- Added a dedicated GitHub Actions workflow to run govulncheck on dependency changes, daily schedule, and manual dispatch
- Converted the local govulncheck pre-commit hook to manual-only to prevent newly published advisories from blocking unrelated PRs
- Reused the existing scan script across CI and local runs so the vulnerability ignore list lives in one place

**Added:**

- Govulncheck CI workflow - Created `.github/workflows/govulncheck.yaml` that gates PRs and pushes touching `go.mod`/`go.sum`, runs on a daily cron to catch newly published advisories against unchanged code, and supports manual dispatch; installs required system dependencies (btrfs/gpgme headers) for the docker client's package analysis and invokes the shared `.hooks/govulncheck-scan.sh` script

**Changed:**

- Pre-commit govulncheck hook behavior - Set the `govulncheck-scan` hook to `stages: [manual]` in `.pre-commit-config.yaml` so it no longer runs during CI's `pre-commit run --all-files`, avoiding scenarios where a fresh CVE reddens every open PR; documented how to run it locally via `pre-commit run govulncheck-scan --hook-stage manual`