### PR TITLE
feat: add agentic CLI providers for Claude Code and Augment

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ squad run --agent go-review --provider openai --model gpt-4.1-mini
 # Run with local Ollama (no API key required)
 squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
 
+# Run through an installed agentic CLI on its subscription (no API key required)
+squad run --agent go-review --provider claude-code   # Claude Code
+squad run --agent go-review --provider agy           # Augment CLI
+
 # Estimate cost without calling the model
 squad run --agent go-review --dry-run
 
@@ -188,7 +192,7 @@ Run `squad <subcommand> --help` for full flag documentation.
 | Flag                  | Description                                                       | Default       |
 | --------------------- | ----------------------------------------------------------------- | ------------- |
 | `--agent`             | Agent name (required)                                             | —             |
-| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, …)       | config        |
+| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, `claude-code`, `agy`, …) | config        |
 | `--model`             | Model identifier                                                  | config        |
 | `--working-dir`       | Target directory the agent operates on                            | current dir   |
 | `--max-cost`          | USD budget cap (0 = unlimited)                                    | `5.00`        |

--- a/agenticcli/agenticcli.go
+++ b/agenticcli/agenticcli.go
@@ -1,0 +1,243 @@
+// Package agenticcli drives locally installed agentic coding CLIs — Claude
+// Code (`claude`) and Augment's `agy` — in non-interactive print mode as
+// squad model providers. The CLI owns the entire agent loop: its own tools,
+// permission handling, and authentication (typically a subscription login).
+// Squad hands it the assembled prompt bundle, waits for the final report,
+// and never needs a provider API key.
+package agenticcli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/cowdogmoo/squad/logging"
+)
+
+// agyPrintTimeout overrides agy's 5-minute default print-mode wait, which is
+// far too short for a real agent run. Context cancellation still kills the
+// subprocess earlier when squad's own deadline fires.
+const agyPrintTimeout = "4h"
+
+// readOnlyDisallowedTools mirrors squad's readonly gate (Write/Edit/MultiEdit
+// rejected, reads and Bash allowed) in Claude Code's tool-permission terms.
+const readOnlyDisallowedTools = "Write,Edit,MultiEdit,NotebookEdit"
+
+// Spec describes one supported agentic CLI.
+type Spec struct {
+	// Provider is the squad provider name ("claude-code", "agy").
+	Provider string
+	// Binary is the executable looked up on PATH.
+	Binary string
+	// Install is a one-line install-and-login hint for missing-binary errors.
+	Install string
+}
+
+var specs = map[string]Spec{
+	"claude-code": {
+		Provider: "claude-code",
+		Binary:   "claude",
+		Install:  "npm install -g @anthropic-ai/claude-code, then run `claude` once to log in",
+	},
+	"agy": {
+		Provider: "agy",
+		Binary:   "agy",
+		Install:  "https://docs.augmentcode.com/cli — then run `agy` once to log in",
+	},
+}
+
+// Lookup returns the Spec for a squad provider name. Callers pass the
+// already-normalized provider string (lowercase, canonical aliases applied).
+func Lookup(provider string) (Spec, bool) {
+	s, ok := specs[provider]
+	return s, ok
+}
+
+// Request carries one print-mode invocation.
+type Request struct {
+	// Provider selects the CLI ("claude-code" or "agy").
+	Provider string
+	// Model is passed through to the CLI's --model flag; empty uses the
+	// CLI's own configured default, which is the common subscription case.
+	Model string
+	// SystemPrompt is squad's assembled agent system prompt.
+	SystemPrompt string
+	// UserPrompt is the task prompt.
+	UserPrompt string
+	// WorkDir is the directory the CLI runs in.
+	WorkDir string
+	// ReadOnly maps squad's readonly mode onto the CLI's native
+	// restriction flags.
+	ReadOnly bool
+}
+
+// Result is the parsed outcome of a print-mode run.
+type Result struct {
+	Response     string
+	InputTokens  int64
+	OutputTokens int64
+	Turns        int
+}
+
+// Run executes the CLI for req and parses its JSON output. The subprocess
+// inherits the parent environment so the CLI's own credential store keeps
+// working.
+func Run(ctx context.Context, req Request) (Result, error) {
+	spec, ok := Lookup(req.Provider)
+	if !ok {
+		return Result{}, fmt.Errorf("unknown agentic CLI provider: %q", req.Provider)
+	}
+	path, err := exec.LookPath(spec.Binary)
+	if err != nil {
+		return Result{}, fmt.Errorf("provider %q requires the %q CLI on PATH (install: %s): %w",
+			spec.Provider, spec.Binary, spec.Install, err)
+	}
+
+	args, stdin := buildArgs(req)
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Dir = req.WorkDir
+	cmd.Stdin = strings.NewReader(stdin)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return Result{}, fmt.Errorf("%s CLI failed: %w%s", spec.Binary, err,
+			outputTail(stderr.Bytes(), stdout.Bytes()))
+	}
+	return parseOutput(spec.Provider, stdout.Bytes())
+}
+
+// buildArgs maps a Request onto CLI-specific flags and returns the argv tail
+// plus the stdin payload. Both CLIs run with permission prompts bypassed:
+// squad runs are unattended, matching squad's own tool loop, which executes
+// Bash and edits without prompting.
+func buildArgs(req Request) (args []string, stdin string) {
+	switch req.Provider {
+	case "claude-code":
+		args = []string{"--print", "--output-format", "json", "--dangerously-skip-permissions"}
+		if req.SystemPrompt != "" {
+			args = append(args, "--append-system-prompt", req.SystemPrompt)
+		}
+		if req.Model != "" {
+			args = append(args, "--model", req.Model)
+		}
+		if req.ReadOnly {
+			args = append(args, "--disallowed-tools", readOnlyDisallowedTools)
+		}
+		return args, req.UserPrompt
+	case "agy":
+		// agy has no separate system-prompt flag; prepend it to the task.
+		prompt := req.UserPrompt
+		if req.SystemPrompt != "" {
+			prompt = req.SystemPrompt + "\n\n" + req.UserPrompt
+		}
+		args = []string{"--print", prompt, "--output-format", "json", "--print-timeout", agyPrintTimeout,
+			"--dangerously-skip-permissions"}
+		if req.Model != "" {
+			args = append(args, "--model", req.Model)
+		}
+		if req.ReadOnly {
+			args = append(args, "--mode", "plan")
+		}
+		return args, ""
+	}
+	return nil, ""
+}
+
+// claudeOutput is the envelope `claude -p --output-format json` prints.
+type claudeOutput struct {
+	IsError  bool   `json:"is_error"`
+	Result   string `json:"result"`
+	NumTurns int    `json:"num_turns"`
+	Usage    struct {
+		InputTokens              int64 `json:"input_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// agyOutput is the envelope `agy --print --output-format json` prints.
+type agyOutput struct {
+	Status   string `json:"status"`
+	Response string `json:"response"`
+	NumTurns int    `json:"num_turns"`
+	Usage    struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// parseOutput decodes the CLI's JSON envelope. A zero-exit run whose output
+// isn't the expected JSON (e.g. an older CLI version) falls back to the raw
+// stdout as the response rather than failing the run.
+func parseOutput(provider string, stdout []byte) (Result, error) {
+	switch provider {
+	case "claude-code":
+		var out claudeOutput
+		if err := json.Unmarshal(stdout, &out); err != nil {
+			logging.Warn("claude output is not the expected JSON envelope (%v); using raw output", err)
+			return Result{Response: string(stdout)}, nil
+		}
+		res := Result{
+			Response:     out.Result,
+			InputTokens:  out.Usage.InputTokens + out.Usage.CacheCreationInputTokens + out.Usage.CacheReadInputTokens,
+			OutputTokens: out.Usage.OutputTokens,
+			Turns:        out.NumTurns,
+		}
+		if out.IsError {
+			return res, fmt.Errorf("claude run failed: %s", strings.TrimSpace(out.Result))
+		}
+		return res, nil
+	case "agy":
+		var out agyOutput
+		if err := json.Unmarshal(stdout, &out); err != nil {
+			logging.Warn("agy output is not the expected JSON envelope (%v); using raw output", err)
+			return Result{Response: string(stdout)}, nil
+		}
+		res := Result{
+			Response:     out.Response,
+			InputTokens:  out.Usage.InputTokens,
+			OutputTokens: out.Usage.OutputTokens,
+			Turns:        out.NumTurns,
+		}
+		if !strings.EqualFold(out.Status, "SUCCESS") {
+			return res, fmt.Errorf("agy run failed (status=%s): %s", out.Status, truncate(out.Response, 500))
+		}
+		return res, nil
+	}
+	return Result{}, fmt.Errorf("unknown agentic CLI provider: %q", provider)
+}
+
+// outputTail formats the tail of stderr and stdout for error messages, so a
+// failed CLI run surfaces its own diagnostics without dumping megabytes.
+func outputTail(stderr, stdout []byte) string {
+	var sb strings.Builder
+	if s := strings.TrimSpace(string(stderr)); s != "" {
+		sb.WriteString("\nstderr: ")
+		sb.WriteString(tail(s, 2000))
+	}
+	if s := strings.TrimSpace(string(stdout)); s != "" {
+		sb.WriteString("\nstdout: ")
+		sb.WriteString(tail(s, 2000))
+	}
+	return sb.String()
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n:]
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/agenticcli/agenticcli_test.go
+++ b/agenticcli/agenticcli_test.go
@@ -1,0 +1,253 @@
+package agenticcli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		provider   string
+		wantBinary string
+		wantOK     bool
+	}{
+		{provider: "claude-code", wantBinary: "claude", wantOK: true},
+		{provider: "agy", wantBinary: "agy", wantOK: true},
+		{provider: "anthropic", wantOK: false},
+		{provider: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		spec, ok := Lookup(tt.provider)
+		if ok != tt.wantOK {
+			t.Errorf("Lookup(%q) ok = %v, want %v", tt.provider, ok, tt.wantOK)
+			continue
+		}
+		if ok && spec.Binary != tt.wantBinary {
+			t.Errorf("Lookup(%q).Binary = %q, want %q", tt.provider, spec.Binary, tt.wantBinary)
+		}
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		req       Request
+		wantArgs  []string
+		wantStdin string
+	}{
+		{
+			name: "claude minimal",
+			req:  Request{Provider: "claude-code", UserPrompt: "do the thing"},
+			wantArgs: []string{
+				"--print", "--output-format", "json", "--dangerously-skip-permissions",
+			},
+			wantStdin: "do the thing",
+		},
+		{
+			name: "claude full",
+			req: Request{
+				Provider: "claude-code", Model: "sonnet",
+				SystemPrompt: "be brief", UserPrompt: "task", ReadOnly: true,
+			},
+			wantArgs: []string{
+				"--print", "--output-format", "json", "--dangerously-skip-permissions",
+				"--append-system-prompt", "be brief",
+				"--model", "sonnet",
+				"--disallowed-tools", readOnlyDisallowedTools,
+			},
+			wantStdin: "task",
+		},
+		{
+			name: "agy minimal",
+			req:  Request{Provider: "agy", UserPrompt: "task"},
+			wantArgs: []string{
+				"--print", "task", "--output-format", "json",
+				"--print-timeout", agyPrintTimeout, "--dangerously-skip-permissions",
+			},
+		},
+		{
+			name: "agy system prompt prepended and readonly",
+			req: Request{
+				Provider: "agy", Model: "gpt5",
+				SystemPrompt: "be brief", UserPrompt: "task", ReadOnly: true,
+			},
+			wantArgs: []string{
+				"--print", "be brief\n\ntask", "--output-format", "json",
+				"--print-timeout", agyPrintTimeout, "--dangerously-skip-permissions",
+				"--model", "gpt5",
+				"--mode", "plan",
+			},
+		},
+		{
+			name: "unknown provider",
+			req:  Request{Provider: "nope"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args, stdin := buildArgs(tt.req)
+			if len(args) != len(tt.wantArgs) {
+				t.Fatalf("args = %q, want %q", args, tt.wantArgs)
+			}
+			for i := range args {
+				if args[i] != tt.wantArgs[i] {
+					t.Fatalf("args[%d] = %q, want %q (full: %q)", i, args[i], tt.wantArgs[i], args)
+				}
+			}
+			if stdin != tt.wantStdin {
+				t.Errorf("stdin = %q, want %q", stdin, tt.wantStdin)
+			}
+		})
+	}
+}
+
+func TestParseOutput(t *testing.T) {
+	t.Parallel()
+	claudeSuccess := `{"is_error":false,"num_turns":3,"result":"done","usage":{"input_tokens":6,"cache_creation_input_tokens":100,"cache_read_input_tokens":200,"output_tokens":9},"type":"result"}`
+	agySuccess := `{"conversation_id":"abc","status":"SUCCESS","response":"done\n","num_turns":2,"usage":{"input_tokens":500,"output_tokens":40,"total_tokens":540}}`
+
+	tests := []struct {
+		name       string
+		provider   string
+		stdout     string
+		wantErr    string
+		wantResp   string
+		wantInput  int64
+		wantOutput int64
+		wantTurns  int
+	}{
+		{
+			name: "claude success", provider: "claude-code", stdout: claudeSuccess,
+			wantResp: "done", wantInput: 306, wantOutput: 9, wantTurns: 3,
+		},
+		{
+			name: "claude is_error", provider: "claude-code",
+			stdout:  `{"is_error":true,"result":"credit exhausted","num_turns":1,"usage":{}}`,
+			wantErr: "credit exhausted",
+		},
+		{
+			name: "claude non-JSON falls back to raw", provider: "claude-code",
+			stdout: "plain text answer", wantResp: "plain text answer",
+		},
+		{
+			name: "agy success", provider: "agy", stdout: agySuccess,
+			wantResp: "done\n", wantInput: 500, wantOutput: 40, wantTurns: 2,
+		},
+		{
+			name: "agy failure status", provider: "agy",
+			stdout:  `{"status":"ERROR","response":"boom","num_turns":1,"usage":{}}`,
+			wantErr: "status=ERROR",
+		},
+		{
+			name: "agy non-JSON falls back to raw", provider: "agy",
+			stdout: "plain", wantResp: "plain",
+		},
+		{
+			name: "unknown provider", provider: "nope", stdout: "{}",
+			wantErr: "unknown agentic CLI provider",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := parseOutput(tt.provider, []byte(tt.stdout))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.Response != tt.wantResp {
+				t.Errorf("Response = %q, want %q", res.Response, tt.wantResp)
+			}
+			if res.InputTokens != tt.wantInput || res.OutputTokens != tt.wantOutput {
+				t.Errorf("tokens = %d/%d, want %d/%d", res.InputTokens, res.OutputTokens, tt.wantInput, tt.wantOutput)
+			}
+			if res.Turns != tt.wantTurns {
+				t.Errorf("Turns = %d, want %d", res.Turns, tt.wantTurns)
+			}
+		})
+	}
+}
+
+// writeFakeCLI installs an executable shell script named binary into dir that
+// records its argv and stdin next to itself and prints canned stdout.
+func writeFakeCLI(t *testing.T, dir, binary, stdout string) {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		`printf '%s\n' "$@" > "` + filepath.Join(dir, "args.txt") + `"` + "\n" +
+		`cat > "` + filepath.Join(dir, "stdin.txt") + `"` + "\n" +
+		`printf '%s' '` + stdout + `'` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, binary), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunSpawnsBinary(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeCLI(t, dir, "claude",
+		`{"is_error":false,"num_turns":2,"result":"ran","usage":{"input_tokens":10,"output_tokens":5}}`)
+	// Prepend so the fake wins over any real install while /bin/cat stays
+	// reachable for the script's stdin capture.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	res, err := Run(context.Background(), Request{
+		Provider:     "claude-code",
+		SystemPrompt: "sys",
+		UserPrompt:   "user task",
+		WorkDir:      dir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Response != "ran" || res.Turns != 2 || res.InputTokens != 10 || res.OutputTokens != 5 {
+		t.Errorf("unexpected result: %+v", res)
+	}
+
+	args, err := os.ReadFile(filepath.Join(dir, "args.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"--print", "--append-system-prompt", "sys", "--dangerously-skip-permissions"} {
+		if !strings.Contains(string(args), want) {
+			t.Errorf("args missing %q: %s", want, args)
+		}
+	}
+	stdin, err := os.ReadFile(filepath.Join(dir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stdin) != "user task" {
+		t.Errorf("stdin = %q, want %q", stdin, "user task")
+	}
+}
+
+func TestRunMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := Run(context.Background(), Request{Provider: "agy", UserPrompt: "x", WorkDir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "requires the \"agy\" CLI on PATH") {
+		t.Fatalf("err = %v, want missing-binary error", err)
+	}
+}
+
+func TestRunNonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\necho 'auth expired' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	_, err := Run(context.Background(), Request{Provider: "claude-code", UserPrompt: "x", WorkDir: dir})
+	if err == nil || !strings.Contains(err.Error(), "auth expired") {
+		t.Fatalf("err = %v, want stderr tail included", err)
+	}
+}

--- a/agenticcli/agenticcli_test.go
+++ b/agenticcli/agenticcli_test.go
@@ -239,6 +239,42 @@ func TestRunMissingBinary(t *testing.T) {
 	}
 }
 
+func TestRunUnknownProvider(t *testing.T) {
+	t.Parallel()
+	_, err := Run(context.Background(), Request{Provider: "nope", UserPrompt: "x"})
+	if err == nil || !strings.Contains(err.Error(), "unknown agentic CLI provider") {
+		t.Fatalf("err = %v, want unknown-provider error", err)
+	}
+}
+
+func TestOutputTailTruncatesLongStreams(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("e", 3000)
+	got := outputTail([]byte(long), []byte("out"))
+	if !strings.Contains(got, "stderr: …") {
+		t.Errorf("long stderr should be tail-truncated with ellipsis: %.80s", got)
+	}
+	if !strings.Contains(got, "stdout: out") {
+		t.Errorf("stdout tail missing: %.80s", got)
+	}
+	if len(got) > 4200 {
+		t.Errorf("tail output too long: %d bytes", len(got))
+	}
+	if outputTail(nil, nil) != "" {
+		t.Error("empty streams should produce empty tail")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("truncate(short) = %q", got)
+	}
+	if got := truncate("abcdef", 3); got != "abc…" {
+		t.Errorf("truncate long = %q, want abc…", got)
+	}
+}
+
 func TestRunNonZeroExit(t *testing.T) {
 	dir := t.TempDir()
 	script := "#!/bin/sh\necho 'auth expired' >&2\nexit 1\n"

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -325,7 +325,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	cmd.Flags().String("api-version", "", "API version (Azure/OpenAI-compatible)")
 	cmd.Flags().String("api-type", "", "API type (openai or azure)")
 	cmd.Flags().Bool("openai-compat-max-tokens", false, "Use max_tokens for OpenAI-compatible endpoints")
-	cmd.Flags().String("provider", "", "Model provider (openai, anthropic, gemini, ollama, etc)")
+	cmd.Flags().String("provider", "", "Model provider (openai, anthropic, gemini, ollama, claude-code, agy, etc)")
 	cmd.Flags().String("model", "", "Model name")
 	cmd.Flags().Float64("temperature", -1, "Sampling temperature (default from config)")
 	cmd.Flags().Int("max-tokens", -1, "Max output tokens (default from config)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,6 +320,8 @@ variables, or config file.
 | Google AI | supported | Google AI endpoints | required | Gemini models via LangChainGo |
 | Ollama | supported | `http://localhost:11434/v1` (default) | optional | Local models; use `--num-ctx` for context size |
 | OpenAI-compatible | supported | provider-specific (required) | optional | Any `/v1/chat/completions` endpoint; use `--base-url` |
+| Claude Code CLI | supported | n/a | not needed | `claude-code`; runs the installed `claude` binary in print mode on your subscription |
+| Augment CLI | supported | n/a | not needed | `agy`; runs the installed `agy` binary in print mode on your subscription |
 
 ### OpenAI
 
@@ -432,6 +434,51 @@ provider:
 model:
   default: databricks-gpt-5-5-pro
 ```
+
+### Agentic CLI providers (no API key)
+
+The `claude-code` and `agy` providers run an installed agentic CLI — Claude
+Code's `claude` or Augment's `agy` — in non-interactive print mode instead of
+calling a model API. The CLI brings its own tools, permissions, and
+authentication (typically a subscription login), so no API key or token is
+needed; squad assembles the agent's prompt bundle, hands it to the CLI in the
+working directory, and records the reported token usage and turn count from
+the CLI's JSON output.
+
+```bash
+# Claude Code (uses the CLI's default model when --model is omitted)
+squad run --agent go-review --provider claude-code
+
+# Pin a model alias understood by the CLI
+squad run --agent go-review --provider claude-code --model sonnet
+
+# Augment CLI
+squad run --agent go-review --provider agy
+```
+
+Agent manifests can rank a CLI ahead of an API fallback; the CLI entry is
+selected only when its binary is on `PATH`:
+
+```yaml
+models:
+  - provider: claude-code
+    model: sonnet
+  - provider: anthropic
+    model: claude-sonnet-4-6
+```
+
+Behavior differences from API providers:
+
+- The CLI runs its own agent loop, so squad's tool surface, `--max-iterations`,
+  `--temperature`, `--max-tokens`, and `--stream` do not apply.
+- Cost is reported as `$0` — usage is billed through the CLI's subscription.
+- `--mode readonly` maps to the CLI's native restrictions (`claude`:
+  edit tools disallowed; `agy`: plan mode).
+- Permission prompts are bypassed (`--dangerously-skip-permissions`), matching
+  squad's unattended tool loop.
+- `environment` types other than `local`, `comments_only`, and `ascii_only`
+  are rejected — those guarantees live in squad's own tool gates.
+- MCP servers from the manifest are not forwarded; configure them in the CLI.
 
 Example Databricks endpoint names: `databricks-gpt-5-5-pro`,
 `databricks-claude-sonnet-4-5`, `databricks-meta-llama-3-3-70b-instruct`.

--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -20,8 +21,25 @@ type APIKeySource string
 const (
 	APIKeySourceConfig APIKeySource = "config"
 	APIKeySourceEnv    APIKeySource = "env"
+	APIKeySourceBinary APIKeySource = "binary"
 	APIKeySourceNone   APIKeySource = "none"
 )
+
+// AgenticCLIBinaries maps subscription-based agentic CLI providers to the
+// binary each one shells out to. These providers need no API key — the CLI
+// carries its own authentication (typically a subscription login) — so
+// credential detection checks that the binary is installed instead.
+var AgenticCLIBinaries = map[string]string{
+	"claude-code": "claude",
+	"agy":         "agy",
+}
+
+// IsAgenticCLI reports whether provider runs through a local agentic CLI
+// binary rather than a direct model API.
+func IsAgenticCLI(provider string) bool {
+	_, ok := AgenticCLIBinaries[strings.ToLower(strings.TrimSpace(provider))]
+	return ok
+}
 
 // APIKeyStatus reports whether a provider has the credential it needs.
 type APIKeyStatus struct {
@@ -58,6 +76,15 @@ func KeyStatus(provider, providerToken string) APIKeyStatus {
 	}
 	if provider == "ollama" {
 		return APIKeyStatus{State: APIKeyNotNeeded, Source: APIKeySourceNone}
+	}
+	// Agentic CLI providers authenticate through the installed binary, so
+	// "credential present" means "binary on PATH". This lets manifest model
+	// walks fall back to an API provider when the CLI isn't installed.
+	if bin, ok := AgenticCLIBinaries[provider]; ok {
+		if _, err := exec.LookPath(bin); err != nil {
+			return APIKeyStatus{State: APIKeyMissing, EnvVar: bin + " CLI", Source: APIKeySourceNone}
+		}
+		return APIKeyStatus{State: APIKeyOK, EnvVar: bin + " CLI", Source: APIKeySourceBinary}
 	}
 	envVars, ok := providerAPIKeyEnv[provider]
 	if !ok || len(envVars) == 0 {

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestKeyStatusProviderEnvTable(t *testing.T) {
 	cases := []struct {
@@ -70,5 +74,44 @@ func TestKeyStatusUnknownProviderNotNeeded(t *testing.T) {
 	got := KeyStatus("not-a-real-provider", "")
 	if got.State != APIKeyNotNeeded || got.EnvVar != "" || got.Source != APIKeySourceNone {
 		t.Fatalf("unknown provider status = %+v, want not-needed/no env", got)
+	}
+}
+
+func TestKeyStatusAgenticCLIBinaryPresent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	got := KeyStatus("claude-code", "")
+	if got.State != APIKeyOK || got.Source != APIKeySourceBinary || got.EnvVar != "claude CLI" {
+		t.Fatalf("claude-code with binary on PATH = %+v, want ok from binary", got)
+	}
+}
+
+func TestKeyStatusAgenticCLIBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	got := KeyStatus("agy", "")
+	if got.State != APIKeyMissing || got.EnvVar != "agy CLI" || got.Source != APIKeySourceNone {
+		t.Fatalf("agy without binary = %+v, want missing agy CLI", got)
+	}
+}
+
+func TestIsAgenticCLI(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"claude-code", true},
+		{" Claude-Code", true},
+		{"agy", true},
+		{"anthropic", false},
+		{"claude", false}, // alias resolution happens in runner.normalizeProvider
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsAgenticCLI(tc.in); got != tc.want {
+			t.Errorf("IsAgenticCLI(%q) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -129,6 +129,18 @@ func (m *Metrics) IncrementIterations() {
 	m.iterations++
 }
 
+// AddIterations adds n iterations to the run total. Agentic CLI providers
+// report the whole run's turn count at once rather than incrementing per
+// loop pass; non-positive n is ignored.
+func (m *Metrics) AddIterations(n int) {
+	if n <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.iterations += n
+}
+
 // InputTokens returns the current input token count.
 func (m *Metrics) InputTokens() int64 {
 	m.mu.Lock()
@@ -262,6 +274,8 @@ var SupportedProviders = []string{
 	"gemini",
 	"ollama",
 	"openai-compat",
+	"claude-code",
+	"agy",
 }
 
 // providerMappings maps a squad provider name to the LiteLLM
@@ -628,6 +642,8 @@ func (m *Metrics) costString(cost float64) string {
 		return fmt.Sprintf("$%.4f", cost)
 	case strings.ToLower(m.Provider) == "ollama":
 		return "$0.00 (local)"
+	case IsAgenticCLI(m.Provider):
+		return "$0.00 (subscription)"
 	default:
 		return "N/A (pricing not available yet)"
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -110,6 +110,32 @@ func TestIncrementIterations(t *testing.T) {
 	}
 }
 
+func TestAddIterations(t *testing.T) {
+	t.Parallel()
+	m := New("claude-code", "")
+
+	m.AddIterations(0)
+	m.AddIterations(-5)
+	if m.Iterations() != 0 {
+		t.Fatalf("Iterations = %d, want 0 after non-positive adds", m.Iterations())
+	}
+
+	m.AddIterations(3)
+	m.AddIterations(2)
+	if m.Iterations() != 5 {
+		t.Fatalf("Iterations = %d, want 5", m.Iterations())
+	}
+}
+
+func TestCostStringSubscriptionProvider(t *testing.T) {
+	t.Parallel()
+	m := New("claude-code", "some-model")
+	m.AddTokens(1000, 100)
+	if got := m.String(); !strings.Contains(got, "$0.00 (subscription)") {
+		t.Fatalf("String() = %q, want subscription cost marker", got)
+	}
+}
+
 func TestFinish(t *testing.T) {
 	t.Parallel()
 	m := New("openai", "gpt-4o")

--- a/runner/agentic.go
+++ b/runner/agentic.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/agenticcli"
+	"github.com/cowdogmoo/squad/logging"
+	"github.com/cowdogmoo/squad/metrics"
+	"github.com/cowdogmoo/squad/skill"
+	"github.com/cowdogmoo/squad/tools"
+)
+
+// invokeAgenticCLI runs the prompt through a locally installed agentic CLI
+// (claude-code or agy) in non-interactive print mode. The CLI executes its
+// own tool loop directly in the working directory with its own
+// authentication, so squad's executor, tool registry, MCP plumbing, and API
+// keys are all bypassed.
+func invokeAgenticCLI(ctx context.Context, opts *RunOptions, provider, model, systemPrompt string, bundle *agent.Bundle, m *metrics.Metrics) (string, *metrics.Metrics, error) {
+	defer m.Finish()
+
+	if bundle.Environment != nil && bundle.Environment.Type != "" && bundle.Environment.Type != "local" {
+		return "", m, fmt.Errorf("provider %q runs a CLI on the local host; environment type %q is not supported", provider, bundle.Environment.Type)
+	}
+	// comments_only and ascii_only are enforced inside squad's Edit tool,
+	// which an external CLI never calls; running anyway would silently drop
+	// the guarantee the manifest asked for.
+	if bundle.CommentsOnly || bundle.ASCIIOnly {
+		return "", m, fmt.Errorf("provider %q cannot enforce comments_only/ascii_only (squad's edit gates do not apply to an external CLI); use an API provider for this agent", provider)
+	}
+	if n := len(bundle.MCPServers) + len(opts.MCPServers); n > 0 {
+		logging.WarnContext(ctx, "%d MCP server(s) configured but not passed to the %s CLI; configure them in the CLI itself", n, provider)
+	}
+	if opts.ResumeID != "" {
+		logging.Warn("resume is not supported for agentic CLI providers; starting fresh")
+	}
+	if opts.Stream {
+		logging.InfoContext(ctx, "--stream is not supported for agentic CLI providers; ignoring")
+	}
+
+	systemPrompt += skillFileFallback(bundle.SkillEntries)
+
+	before := agenticWorktreeSnapshot(ctx, bundle.WorkDir)
+	logging.InfoContext(ctx, "agentic CLI run started (provider=%s model=%s dir=%s)", provider, model, bundle.WorkDir)
+	res, err := agenticcli.Run(ctx, agenticcli.Request{
+		Provider:     provider,
+		Model:        model,
+		SystemPrompt: systemPrompt,
+		UserPrompt:   bundle.User,
+		WorkDir:      bundle.WorkDir,
+		ReadOnly:     opts.Mode == "readonly",
+	})
+	m.AddTokens(res.InputTokens, res.OutputTokens)
+	m.AddIterations(res.Turns)
+	if err != nil {
+		return "", m, fmt.Errorf("model call failed: %w", err)
+	}
+	if before != "" && agenticWorktreeSnapshot(ctx, bundle.WorkDir) != before {
+		tools.MarkEditsApplied(ctx)
+		logging.InfoContext(ctx, "working tree changed during %s run; marking edits applied", provider)
+	}
+	logging.InfoContext(ctx, "agentic CLI run finished in %s (turns=%d response-bytes=%d)",
+		m.Duration().Round(time.Millisecond), res.Turns, len(res.Response))
+	return res.Response, m, nil
+}
+
+// skillFileFallback rewrites squad's Skill-tool affordance for external CLIs:
+// the system prompt's "Available skills" block tells the model to call
+// Skill(name), which doesn't exist in a CLI session, so append an override
+// pointing at each SKILL.md to read directly instead.
+func skillFileFallback(entries []skill.Entry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	sorted := make([]skill.Entry, len(entries))
+	copy(sorted, entries)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Name() < sorted[j].Name() })
+
+	var sb strings.Builder
+	sb.WriteString("\n\n## Skill loading override\n\n")
+	sb.WriteString("The `Skill` tool is NOT available in this session. To load a skill listed above, read its SKILL.md file directly:\n\n")
+	for _, e := range sorted {
+		fmt.Fprintf(&sb, "- %s: %s\n", e.Name(), filepath.Join(e.Dir, skill.FileName))
+	}
+	return sb.String()
+}
+
+// agenticWorktreeSnapshot fingerprints the git working tree (porcelain status
+// plus tracked-file diff) so edits made out-of-band by an agentic CLI can be
+// detected afterwards. Returns "" when the tree can't be fingerprinted (not a
+// git repo, or git failed) — callers treat that as "detection unavailable".
+func agenticWorktreeSnapshot(ctx context.Context, dir string) string {
+	if !isGitRepo(ctx, dir) {
+		return ""
+	}
+	h := sha256.New()
+	for _, args := range [][]string{{"status", "--porcelain"}, {"diff", "HEAD"}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			return ""
+		}
+		h.Write(out)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/runner/agentic_test.go
+++ b/runner/agentic_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/cowdogmoo/squad/agent"
 	"github.com/cowdogmoo/squad/executor"
+	"github.com/cowdogmoo/squad/mcp"
 	"github.com/cowdogmoo/squad/metrics"
 	"github.com/cowdogmoo/squad/skill"
 	"github.com/cowdogmoo/squad/tools"
+	"github.com/spf13/cobra"
 )
 
 func TestInvokeAgenticCLIRejectsNonLocalEnvironment(t *testing.T) {
@@ -196,5 +198,108 @@ func TestInvokeAgenticCLINoEditsNoMark(t *testing.T) {
 	}
 	if tools.EditsApplied(ctx) {
 		t.Error("EditsApplied = true, want false for a read-only run")
+	}
+}
+
+// TestInvokeAgenticCLIWarnsOnIgnoredOptions pins that MCP servers, --resume,
+// and --stream are warn-and-continue for CLI providers, not errors.
+func TestInvokeAgenticCLIWarnsOnIgnoredOptions(t *testing.T) {
+	repo := initTestGitRepo(t)
+	installFakeAgenticCLI(t, ":")
+
+	bundle := &agent.Bundle{
+		WorkDir:    repo,
+		User:       "task",
+		MCPServers: []mcp.ServerConfig{{Name: "srv"}},
+	}
+	opts := &RunOptions{ResumeID: "prior-session", Stream: true}
+	m := metrics.New("claude-code", "")
+	resp, _, err := invokeAgenticCLI(tools.InitEdits(context.Background()), opts, "claude-code", "", "sys", bundle, m)
+	if err != nil {
+		t.Fatalf("invokeAgenticCLI: %v", err)
+	}
+	if resp != "done" {
+		t.Errorf("response = %q, want %q", resp, "done")
+	}
+}
+
+func TestInvokeAgenticCLIWrapsCLIFailure(t *testing.T) {
+	binDir := t.TempDir()
+	script := "#!/bin/sh\ncat > /dev/null\necho boom >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	bundle := &agent.Bundle{WorkDir: t.TempDir(), User: "task"}
+	m := metrics.New("claude-code", "")
+	_, _, err := invokeAgenticCLI(tools.InitEdits(context.Background()), &RunOptions{}, "claude-code", "", "sys", bundle, m)
+	if err == nil || !strings.Contains(err.Error(), "model call failed") || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want wrapped CLI failure with stderr tail", err)
+	}
+}
+
+func TestAgenticWorktreeSnapshot(t *testing.T) {
+	ctx := context.Background()
+	if got := agenticWorktreeSnapshot(ctx, t.TempDir()); got != "" {
+		t.Errorf("non-git dir snapshot = %q, want empty", got)
+	}
+
+	// A repo with no commits makes `git diff HEAD` fail, which must degrade
+	// to "detection unavailable" rather than a partial fingerprint.
+	empty := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = empty
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if got := agenticWorktreeSnapshot(ctx, empty); got != "" {
+		t.Errorf("commitless repo snapshot = %q, want empty", got)
+	}
+
+	repo := initTestGitRepo(t)
+	first := agenticWorktreeSnapshot(ctx, repo)
+	if first == "" {
+		t.Fatal("committed repo snapshot empty, want fingerprint")
+	}
+	if err := os.WriteFile(filepath.Join(repo, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if second := agenticWorktreeSnapshot(ctx, repo); second == first {
+		t.Error("snapshot unchanged after adding a file")
+	}
+}
+
+func TestBuildLLMRejectsAgenticCLIProviders(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"claude-code", "agy"} {
+		_, err := buildLLM(context.Background(), &RunOptions{}, provider, "")
+		if err == nil || !strings.Contains(err.Error(), "agentic CLI provider") {
+			t.Errorf("buildLLM(%q) err = %v, want agentic-CLI rejection", provider, err)
+		}
+	}
+}
+
+// TestExecuteRunAgenticCLIOutsideGitRepo drives the full ExecuteRun path with
+// a CLI provider in a non-git working dir: the require-actionable guard must
+// disable itself and the run must route through the fake CLI end to end.
+func TestExecuteRunAgenticCLIOutsideGitRepo(t *testing.T) {
+	installFakeAgenticCLI(t, ":")
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	agentsDir := writeTestAgent(t, "smoke")
+	opts := &RunOptions{
+		Agent:             "smoke",
+		AgentsDir:         agentsDir,
+		Provider:          "claude-code",
+		WorkingDir:        t.TempDir(),
+		RequireActionable: true,
+		ConfigAvailable:   true,
+	}
+	if err := ExecuteRun(cmd, []string{"hello"}, opts); err != nil {
+		t.Fatalf("ExecuteRun() error = %v", err)
+	}
+	if opts.RequireActionable {
+		t.Error("RequireActionable still true, want auto-disabled outside a git repo")
 	}
 }

--- a/runner/agentic_test.go
+++ b/runner/agentic_test.go
@@ -1,0 +1,200 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/executor"
+	"github.com/cowdogmoo/squad/metrics"
+	"github.com/cowdogmoo/squad/skill"
+	"github.com/cowdogmoo/squad/tools"
+)
+
+func TestInvokeAgenticCLIRejectsNonLocalEnvironment(t *testing.T) {
+	t.Parallel()
+	bundle := &agent.Bundle{
+		Environment: &executor.Config{Type: "docker"},
+		WorkDir:     t.TempDir(),
+	}
+	m := metrics.New("claude-code", "")
+	_, _, err := invokeAgenticCLI(context.Background(), &RunOptions{}, "claude-code", "", "sys", bundle, m)
+	if err == nil || !strings.Contains(err.Error(), `environment type "docker" is not supported`) {
+		t.Fatalf("err = %v, want non-local environment rejection", err)
+	}
+}
+
+func TestInvokeAgenticCLIRejectsEditGates(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		bundle *agent.Bundle
+	}{
+		{name: "comments_only", bundle: &agent.Bundle{CommentsOnly: true, WorkDir: "."}},
+		{name: "ascii_only", bundle: &agent.Bundle{ASCIIOnly: true, WorkDir: "."}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := metrics.New("agy", "")
+			_, _, err := invokeAgenticCLI(context.Background(), &RunOptions{}, "agy", "", "sys", tt.bundle, m)
+			if err == nil || !strings.Contains(err.Error(), "cannot enforce comments_only/ascii_only") {
+				t.Fatalf("err = %v, want edit-gate rejection", err)
+			}
+		})
+	}
+}
+
+func TestSkillFileFallback(t *testing.T) {
+	t.Parallel()
+	if got := skillFileFallback(nil); got != "" {
+		t.Fatalf("skillFileFallback(nil) = %q, want empty", got)
+	}
+	entries := []skill.Entry{
+		{Manifest: &skill.Manifest{Name: "zeta"}, Dir: "/skills/zeta"},
+		{Manifest: &skill.Manifest{Name: "alpha"}, Dir: "/skills/alpha"},
+	}
+	got := skillFileFallback(entries)
+	if !strings.Contains(got, "## Skill loading override") {
+		t.Errorf("missing override header: %s", got)
+	}
+	alphaIdx := strings.Index(got, filepath.Join("/skills/alpha", skill.FileName))
+	zetaIdx := strings.Index(got, filepath.Join("/skills/zeta", skill.FileName))
+	if alphaIdx < 0 || zetaIdx < 0 {
+		t.Fatalf("missing SKILL.md paths: %s", got)
+	}
+	if alphaIdx > zetaIdx {
+		t.Errorf("entries not sorted by name: %s", got)
+	}
+}
+
+// initTestGitRepo creates a git repo with one committed file and returns its path.
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("-c", "commit.gpgsign=false", "commit", "-m", "init")
+	return dir
+}
+
+// installFakeAgenticCLI puts a fake `claude` on PATH whose behavior is the
+// given shell body, followed by printing a canned success envelope.
+func installFakeAgenticCLI(t *testing.T, body string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\ncat > /dev/null\n" + body + "\n" +
+		`printf '%s' '{"is_error":false,"num_turns":4,"result":"done","usage":{"input_tokens":100,"output_tokens":20}}'` + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// git must stay reachable for the worktree snapshot.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestInvokeAgenticCLIMarksEditsOnTreeChange(t *testing.T) {
+	repo := initTestGitRepo(t)
+	installFakeAgenticCLI(t, `echo changed >> a.txt`)
+
+	ctx := tools.InitEdits(context.Background())
+	bundle := &agent.Bundle{WorkDir: repo, User: "edit the file"}
+	m := metrics.New("claude-code", "")
+	resp, m, err := invokeAgenticCLI(ctx, &RunOptions{}, "claude-code", "", "sys", bundle, m)
+	if err != nil {
+		t.Fatalf("invokeAgenticCLI: %v", err)
+	}
+	if resp != "done" {
+		t.Errorf("response = %q, want %q", resp, "done")
+	}
+	if !tools.EditsApplied(ctx) {
+		t.Error("EditsApplied = false, want true after working tree changed")
+	}
+	if m.InputTokens() != 100 || m.OutputTokens() != 20 || m.Iterations() != 4 {
+		t.Errorf("metrics = %d/%d tokens, %d iterations; want 100/20, 4",
+			m.InputTokens(), m.OutputTokens(), m.Iterations())
+	}
+}
+
+// TestResolveModelPrecedence_AgenticCLIProvider pins the short-circuit for
+// explicitly requested CLI providers: the config default model (which belongs
+// to a different API provider) must not be paired with the CLI, the model may
+// stay empty so the CLI's own default is used, and a manifest entry for the
+// CLI provider pins the model when present.
+func TestResolveModelPrecedence_AgenticCLIProvider(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		provider  string
+		bundle    *agent.Bundle
+		wantModel string
+	}{
+		{
+			name:      "no manifest model stays empty despite config default",
+			provider:  "claude-code",
+			bundle:    &agent.Bundle{},
+			wantModel: "",
+		},
+		{
+			name:     "manifest entry for the CLI provider pins the model",
+			provider: "claude-code",
+			bundle: &agent.Bundle{Models: []agent.ModelPreference{
+				{Provider: "openai", Model: "gpt-4o"},
+				{Provider: "claude-code", Model: "sonnet"},
+			}},
+			wantModel: "sonnet",
+		},
+		{
+			name:      "claude alias resolves",
+			provider:  "claude",
+			bundle:    &agent.Bundle{Models: []agent.ModelPreference{{Provider: "claude-code", Model: "opus"}}},
+			wantModel: "opus",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &RunOptions{Provider: tt.provider, ConfigModel: "gpt-4o", ConfigProvider: "openai"}
+			warn, err := ResolveModelPrecedence(context.Background(), opts, tt.bundle)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if warn != "" {
+				t.Fatalf("unexpected warning: %q", warn)
+			}
+			if opts.Model != tt.wantModel {
+				t.Errorf("Model = %q, want %q", opts.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestInvokeAgenticCLINoEditsNoMark(t *testing.T) {
+	repo := initTestGitRepo(t)
+	installFakeAgenticCLI(t, ":")
+
+	ctx := tools.InitEdits(context.Background())
+	bundle := &agent.Bundle{WorkDir: repo, User: "look around"}
+	m := metrics.New("claude-code", "")
+	if _, _, err := invokeAgenticCLI(ctx, &RunOptions{}, "claude-code", "", "sys", bundle, m); err != nil {
+		t.Fatalf("invokeAgenticCLI: %v", err)
+	}
+	if tools.EditsApplied(ctx) {
+		t.Error("EditsApplied = true, want false for a read-only run")
+	}
+}

--- a/runner/model.go
+++ b/runner/model.go
@@ -173,6 +173,13 @@ func InvokeModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle) (s
 		systemPrompt += "\n\n## System Override\n\n" + strings.TrimSpace(opts.System) + "\n"
 	}
 
+	// Agentic CLI providers run the entire agent loop inside the external
+	// binary with its own tools and auth; squad's executor, MCP, and tool
+	// plumbing must not be set up for them.
+	if metrics.IsAgenticCLI(provider) {
+		return invokeAgenticCLI(ctx, opts, provider, model, systemPrompt, bundle, m)
+	}
+
 	ex, err := executor.New(bundle.Environment, bundle.WorkDir)
 	if err != nil {
 		m.Finish()
@@ -462,6 +469,10 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildGeminiLLM(ctx, opts, model)
 	case "openai-compat":
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
+	case "claude-code", "agy":
+		// Defence in depth: these are dispatched in InvokeModel before the
+		// LangChain path; reaching here means a call path skipped that branch.
+		return nil, fmt.Errorf("provider %q is an agentic CLI provider and cannot be used as a LangChain model", provider)
 	default:
 		return nil, fmt.Errorf("provider not implemented: %s", provider)
 	}
@@ -545,11 +556,15 @@ func buildGeminiLLM(ctx context.Context, opts *RunOptions, model string) (llms.M
 
 func normalizeProvider(provider string) string {
 	p := strings.ToLower(strings.TrimSpace(provider))
+	switch p {
 	// Agent manifests commonly write "google" for Gemini models; the
 	// implemented provider is "gemini" (metrics/apikey.go carries the
 	// matching credential entry for both spellings).
-	if p == "google" {
+	case "google":
 		return "gemini"
+	// "claude" is the natural spelling for the Claude Code CLI provider.
+	case "claude":
+		return "claude-code"
 	}
 	return p
 }

--- a/runner/model_provider_test.go
+++ b/runner/model_provider_test.go
@@ -10,12 +10,16 @@ import "testing"
 func TestNormalizeProviderGoogleAlias(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"google":    "gemini",
-		" Google ":  "gemini",
-		"gemini":    "gemini",
-		"anthropic": "anthropic",
-		"":          "",
-		" OpenAI ":  "openai",
+		"google":      "gemini",
+		" Google ":    "gemini",
+		"gemini":      "gemini",
+		"anthropic":   "anthropic",
+		"":            "",
+		" OpenAI ":    "openai",
+		"claude":      "claude-code",
+		" Claude ":    "claude-code",
+		"claude-code": "claude-code",
+		"agy":         "agy",
 	}
 	for in, want := range cases {
 		if got := normalizeProvider(in); got != want {

--- a/runner/run.go
+++ b/runner/run.go
@@ -191,6 +191,15 @@ func ExecuteRun(cmd *cobra.Command, args []string, opts *RunOptions) error {
 		logging.InfoContext(cmd.Context(), "remote-only agent: disabling require-actionable")
 	}
 
+	// Agentic CLI providers edit files directly on disk, so actionable-output
+	// detection relies on comparing git working-tree fingerprints; outside a
+	// git repo there is nothing to compare and the CLI's prose report would
+	// false-fail the guard.
+	if opts.RequireActionable && metrics.IsAgenticCLI(normalizeProvider(opts.Provider)) && !isGitRepo(cmd.Context(), workingDir) {
+		opts.RequireActionable = false
+		logging.InfoContext(cmd.Context(), "agentic CLI provider outside a git repo: disabling require-actionable")
+	}
+
 	ctx := initRunContext(cmd.Context(), bundle)
 
 	logger, err := openSession(opts, bundle, prompt)
@@ -326,6 +335,22 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 	}
 	if opts.Model != "" {
 		applyExplicitModel(opts, bundle)
+		return "", nil
+	}
+	// An explicitly requested agentic CLI provider (claude-code, agy)
+	// authenticates through the local CLI, so the credential-driven walk
+	// below doesn't apply — and the config default model (rule 2) belongs
+	// to a different API provider and must not be paired with the CLI. The
+	// model may stay empty: the CLI then uses its own configured default,
+	// unless the manifest pins one for this provider.
+	if p := normalizeProvider(opts.Provider); metrics.IsAgenticCLI(p) {
+		for i := range bundle.Models {
+			if normalizeProvider(bundle.Models[i].Provider) == p {
+				opts.Model = bundle.Models[i].Model
+				break
+			}
+		}
+		logging.InfoContext(ctx, "using agentic CLI provider %s (model=%q)", p, opts.Model)
 		return "", nil
 	}
 	if warn, ok := applyConfigDefault(ctx, opts, bundle); ok {


### PR DESCRIPTION
**Key Changes:**

- Introduced `claude-code` and `agy` as subscription-based model providers that run installed agentic CLIs in non-interactive print mode, requiring no API key
- Added a dedicated `agenticcli` package that owns CLI invocation, argument construction, and JSON output parsing for both supported CLIs
- Wired the new providers into the runner so squad bypasses its own executor, tool loop, and MCP plumbing when a CLI provider is selected
- Adapted credential detection, metrics, and cost reporting to treat CLI binaries as the "credential" and report `$0.00 (subscription)` cost

**Added:**

- New `agenticcli` package with full test coverage — Implements `Lookup`, `Run`, `buildArgs`, and `parseOutput` to drive Claude Code (`claude`) and Augment (`agy`) in print mode, mapping squad's readonly mode onto native CLI restrictions and parsing token usage and turn counts from each CLI's JSON envelope (`agenticcli/agenticcli.go`, `agenticcli/agenticcli_test.go`)
- Runner integration for agentic CLIs — Added `invokeAgenticCLI` to run the prompt through the external CLI, plus `skillFileFallback` to rewrite Skill-tool affordances for CLI sessions and `agenticWorktreeSnapshot` to detect out-of-band file edits via git fingerprinting; rejects non-local environments and `comments_only`/`ascii_only` gates that squad's edit tools cannot enforce externally (`runner/agentic.go`, `runner/agentic_test.go`)
- Binary-based credential detection — Added `AgenticCLIBinaries` map, `IsAgenticCLI` helper, and `APIKeySourceBinary` source so credential checks verify the CLI binary is on `PATH` instead of looking for an API key, enabling manifest fallback to API providers when the CLI is missing (`metrics/apikey.go`, `metrics/apikey_test.go`)
- Metrics support for whole-run turn counts — Added `Metrics.AddIterations` for CLI providers that report total turns at once rather than per loop pass (`metrics/metrics.go`)
- Configuration documentation for the new providers — Documented setup, model pinning, manifest fallback ranking, and behavioral differences from API providers (no tool surface, `$0` cost, readonly mapping, permission bypass, unsupported MCP forwarding) (`docs/configuration.md`)

**Changed:**

- Provider dispatch and normalization — `InvokeModel` now short-circuits to `invokeAgenticCLI` for CLI providers before the LangChain path, `buildLLM` rejects them as defense in depth, and `normalizeProvider` resolves the `claude` alias to `claude-code` (`runner/model.go`, `runner/model_provider_test.go`)
- Model precedence resolution — `ResolveModelPrecedence` short-circuits explicitly requested CLI providers so the config default model is never paired with the CLI; the model stays empty (using the CLI's own default) unless a manifest entry pins one (`runner/run.go`)
- Require-actionable guard — Auto-disabled for CLI providers running outside a git repo, since actionable-output detection relies on git working-tree fingerprints (`runner/run.go`)
- Cost reporting and supported providers — Added `claude-code` and `agy` to `SupportedProviders` and reports their cost as `$0.00 (subscription)` (`metrics/metrics.go`, `metrics/metrics_test.go`)
- Documentation and help text — Updated `README.md`, provider table, and the `--provider` flag description to list the new `claude-code` and `agy` providers (`README.md`, `cmd/squad/run.go`, `docs/configuration.md`)