### PR TITLE
feat: collapse empty stub runs and add slash command menu

### DIFF
--- a/ui/app/app.go
+++ b/ui/app/app.go
@@ -433,6 +433,30 @@ func (a App) currentRuns() []sidebar.Run {
 	return a.static
 }
 
+// visibleRuns returns currentRuns minus empty stubs, plus how many stubs
+// were hidden. The selected run always stays visible so focus never
+// points at a row the sidebar doesn't show.
+func (a App) visibleRuns() ([]sidebar.Run, int) {
+	runs := a.currentRuns()
+	out := make([]sidebar.Run, 0, len(runs))
+	hidden := 0
+	for _, r := range runs {
+		if isStub(r) && r.ID != a.selected {
+			hidden++
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, hidden
+}
+
+// isStub reports whether a run is an empty leftover session: exited in
+// under a second without recording a single event. There's nothing to
+// inspect, so the sidebar collapses these into a "· N empty" count.
+func isStub(r sidebar.Run) bool {
+	return !r.Alive && r.Elapsed < time.Second && r.LastEvent == ""
+}
+
 // rediscover scans sessionsRoot for any session dirs not yet known and
 // adds a fresh Tailer for each. Called from the frame loop at most every
 // rediscoverEvery; cost is one ReadDir.
@@ -883,8 +907,10 @@ func (a *App) handleRegionKey(m tea.KeyMsg) (tea.Cmd, bool) {
 	return nil, false
 }
 
+// cycleSelection moves selection through the visible run list only —
+// hidden stubs are skipped, matching what the sidebar shows.
 func (a *App) cycleSelection(delta int) {
-	runs := a.currentRuns()
+	runs, _ := a.visibleRuns()
 	if len(runs) == 0 {
 		return
 	}
@@ -903,8 +929,8 @@ func (a *App) cycleSelection(delta int) {
 // a brief onboarding hint instead of an empty `(no runs)` label so the
 // column has a visible identity from first launch.
 func (a App) renderSidebar(width int) string {
-	runs := a.currentRuns()
-	if len(runs) == 0 {
+	runs, hidden := a.visibleRuns()
+	if len(runs) == 0 && hidden == 0 {
 		return style.Title.Render("RUNS") + "\n\n" +
 			style.Faint.Render("  no runs yet") + "\n" +
 			style.Faint.Render("  type /run to launch")
@@ -913,7 +939,8 @@ func (a App) renderSidebar(width int) string {
 		Runs:        runs,
 		Selected:    a.selected,
 		Width:       width,
-		MaxPerGroup: 12,
+		MaxPerGroup: 8,
+		EmptyCount:  hidden,
 	})
 }
 

--- a/ui/app/app_test.go
+++ b/ui/app/app_test.go
@@ -400,3 +400,48 @@ func TestIndicatorForAllStates(t *testing.T) {
 		}
 	}
 }
+
+func TestVisibleRunsCollapsesStubs(t *testing.T) {
+	a := New([]sidebar.Run{
+		{ID: "a", Agent: "alpha", State: sidebar.StateWorking, Alive: true, Elapsed: time.Minute},
+		{ID: "b", Agent: "beta", State: sidebar.StateCompleted, Elapsed: 2 * time.Minute},
+		{ID: "stub1", Agent: "beta", State: sidebar.StateCompleted},
+		{ID: "stub2", Agent: "beta", State: sidebar.StateFailed},
+	})
+	vis, hidden := a.visibleRuns()
+	if hidden != 2 {
+		t.Errorf("hidden: got %d, want 2", hidden)
+	}
+	if len(vis) != 2 || vis[0].ID != "a" || vis[1].ID != "b" {
+		t.Errorf("visible: got %+v, want runs a and b", vis)
+	}
+}
+
+func TestVisibleRunsKeepsSelectedStub(t *testing.T) {
+	// New() selects the first run — a stub here. Selection must never
+	// point at a row the sidebar doesn't show.
+	a := New([]sidebar.Run{
+		{ID: "stub", Agent: "beta", State: sidebar.StateCompleted},
+		{ID: "b", Agent: "beta", State: sidebar.StateCompleted, Elapsed: time.Minute},
+	})
+	vis, hidden := a.visibleRuns()
+	if hidden != 0 || len(vis) != 2 {
+		t.Errorf("selected stub must stay visible: got %d visible, %d hidden", len(vis), hidden)
+	}
+}
+
+func TestCycleSelectionSkipsStubs(t *testing.T) {
+	a := New([]sidebar.Run{
+		{ID: "a", Agent: "alpha", State: sidebar.StateWorking, Alive: true, Elapsed: time.Minute},
+		{ID: "stub", Agent: "beta", State: sidebar.StateCompleted},
+		{ID: "b", Agent: "beta", State: sidebar.StateCompleted, Elapsed: time.Minute},
+	})
+	a.cycleSelection(+1)
+	if a.Selected() != "b" {
+		t.Errorf("cycle should skip the stub: got %q, want %q", a.Selected(), "b")
+	}
+	a.cycleSelection(+1)
+	if a.Selected() != "a" {
+		t.Errorf("wrap: got %q, want %q", a.Selected(), "a")
+	}
+}

--- a/ui/pane/composer.go
+++ b/ui/pane/composer.go
@@ -36,6 +36,17 @@ type Composer struct {
 // enough that the slice never balloons.
 const historyMax = 100
 
+// slashCommands mirrors the host app's command dispatch table
+// (app.handleCommand). Rendered as the live-filtered menu above the
+// input while the buffer starts with "/" — keep in sync when adding
+// a command there.
+var slashCommands = []struct{ name, args, desc string }{
+	{"run", "", "open the launch form"},
+	{"preset", "save|load|list|delete [NAME]", "manage launch presets"},
+	{"help", "", "commands and keys"},
+	{"quit", "", "exit squad"},
+}
+
 // NewComposer returns a Composer with sensible defaults: 1-line visible
 // height when empty (grows to MaxHeight as the user types), no line
 // numbers, placeholder hint, prompt arrow.
@@ -180,12 +191,64 @@ func (c *Composer) fitHeight() {
 }
 
 // View renders the composer. Width/height come from the host; if width is
-// 0 we trust the textarea's existing size (set via WindowSizeMsg).
+// 0 we trust the textarea's existing size (set via WindowSizeMsg). While
+// the buffer is a slash command, the matching-command menu renders above
+// the input so the user never has to remember command names.
 func (c Composer) View(width, _ int) string {
 	if width > 0 {
 		c.ta.SetWidth(width - 2)
 	}
+	if menu := c.slashMenu(); menu != "" {
+		return menu + "\n" + c.ta.View()
+	}
 	return c.ta.View()
+}
+
+// slashMenu returns the command menu for the current buffer, or "" when
+// the buffer isn't a partial slash command. "/pr" lists commands whose
+// name starts with "pr"; once a full name plus a space is typed, only
+// that command's usage line stays as an inline argument reminder.
+// Multi-line buffers get no menu — a slash inside prose isn't a command.
+func (c Composer) slashMenu() string {
+	text := trimLeftSpace(c.ta.Value())
+	if !strings.HasPrefix(text, "/") || strings.Contains(text, "\n") {
+		return ""
+	}
+	token := text[1:]
+	hasArgs := false
+	if i := strings.IndexByte(token, ' '); i >= 0 {
+		token, hasArgs = token[:i], true
+	}
+
+	type row struct{ left, desc string }
+	var rows []row
+	maxLeft := 0
+	for _, cmd := range slashCommands {
+		if hasArgs && cmd.name != token {
+			continue
+		}
+		if !hasArgs && !strings.HasPrefix(cmd.name, token) {
+			continue
+		}
+		left := "/" + cmd.name
+		if cmd.args != "" {
+			left += " " + cmd.args
+		}
+		if len(left) > maxLeft {
+			maxLeft = len(left)
+		}
+		rows = append(rows, row{left, cmd.desc})
+	}
+	if len(rows) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, r := range rows {
+		pad := strings.Repeat(" ", maxLeft-len(r.left)+2)
+		lines = append(lines, "  "+style.Hint.Render(r.left)+pad+style.Secondary.Render(r.desc))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // Height returns the composer's current rendered row count. The host uses

--- a/ui/pane/composer_test.go
+++ b/ui/pane/composer_test.go
@@ -2,6 +2,7 @@ package pane
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -174,4 +175,58 @@ func composerValue(t *testing.T, v View) string {
 		t.Fatalf("expected Composer, got %T", v)
 	}
 	return c.Value()
+}
+
+func TestComposerSlashMenu(t *testing.T) {
+	cases := []struct {
+		name    string
+		buffer  string
+		want    []string
+		exclude []string
+		empty   bool
+	}{
+		{
+			name:   "bare slash lists all commands",
+			buffer: "/",
+			want:   []string{"/run", "/preset", "/help", "/quit"},
+		},
+		{
+			name:    "prefix filters the list",
+			buffer:  "/pre",
+			want:    []string{"/preset"},
+			exclude: []string{"/run", "/help", "/quit"},
+		},
+		{
+			name:    "typed args keep only the usage line",
+			buffer:  "/preset lo",
+			want:    []string{"/preset"},
+			exclude: []string{"/run"},
+		},
+		{name: "plain prompt has no menu", buffer: "fix the bug", empty: true},
+		{name: "unknown command has no menu", buffer: "/xyz", empty: true},
+		{name: "multi-line buffer has no menu", buffer: "/run\nsecond line", empty: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewComposer()
+			c.SetValue(tc.buffer)
+			menu := c.slashMenu()
+			if tc.empty {
+				if menu != "" {
+					t.Fatalf("expected no menu for %q, got:\n%s", tc.buffer, menu)
+				}
+				return
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(menu, w) {
+					t.Errorf("menu for %q missing %q:\n%s", tc.buffer, w, menu)
+				}
+			}
+			for _, e := range tc.exclude {
+				if strings.Contains(menu, e) {
+					t.Errorf("menu for %q should not contain %q:\n%s", tc.buffer, e, menu)
+				}
+			}
+		})
+	}
 }

--- a/ui/sidebar/sidebar.go
+++ b/ui/sidebar/sidebar.go
@@ -63,6 +63,10 @@ type Snapshot struct {
 	// MaxPerGroup truncates each group with a "… N more" footer. 0 = no
 	// truncation.
 	MaxPerGroup int
+	// EmptyCount is how many empty stub runs the caller filtered out
+	// before building the Snapshot. Rendered as a trailing faint line so
+	// the hidden rows stay accounted for; 0 renders nothing.
+	EmptyCount int
 }
 
 // Bucket partitions runs into the default group set: Working / Needs Input /
@@ -110,14 +114,28 @@ func Render(s Snapshot) string {
 	}
 
 	if len(groups) == 0 {
-		return style.Faint.Render("  (no runs)")
+		out := style.Faint.Render("  (no runs)")
+		if s.EmptyCount > 0 {
+			out += "\n" + hiddenLine(s.EmptyCount)
+		}
+		return out
 	}
 
 	var sections []string
 	for _, g := range groups {
 		sections = append(sections, renderGroup(g, s.Selected, s.MaxPerGroup, width))
 	}
-	return strings.Join(sections, "\n\n")
+	out := strings.Join(sections, "\n\n")
+	if s.EmptyCount > 0 {
+		out += "\n\n" + hiddenLine(s.EmptyCount)
+	}
+	return out
+}
+
+// hiddenLine is the trailing "· N empty" footer accounting for stub runs
+// the caller collapsed out of the list.
+func hiddenLine(n int) string {
+	return style.Faint.Render(fmt.Sprintf("  · %d empty hidden", n))
 }
 
 func renderGroup(g Group, selected string, maxPerGroup, width int) string {
@@ -140,8 +158,14 @@ func renderGroup(g Group, selected string, maxPerGroup, width int) string {
 
 func renderRow(r Run, selected bool, width int) string {
 	glyph, glyphStyle := glyphFor(r.State, r.Alive)
+	// Exited runs render dim so the alive ones carry the visual weight —
+	// with dozens of terminal rows, full-brightness names drown the list.
 	agentStyle := style.Body
 	elapsedStyle := style.Secondary
+	if !r.Alive {
+		agentStyle = style.Secondary
+		elapsedStyle = style.Faint
+	}
 	prefix := "  "
 	if selected {
 		prefix = style.Hint.Render("› ")

--- a/ui/sidebar/sidebar_test.go
+++ b/ui/sidebar/sidebar_test.go
@@ -161,3 +161,21 @@ func compareGolden(t *testing.T, name, got string) {
 		t.Errorf("golden mismatch for %s\nwant:\n%s\ngot:\n%s", name, wantStr, got)
 	}
 }
+
+func TestRenderEmptyCountFooter(t *testing.T) {
+	out := stripANSI(Render(Snapshot{
+		Runs:       []Run{{ID: "a", Agent: "x", State: StateCompleted, Elapsed: time.Minute}},
+		Width:      30,
+		EmptyCount: 3,
+	}))
+	if !strings.Contains(out, "· 3 empty hidden") {
+		t.Errorf("expected empty-hidden footer, got:\n%s", out)
+	}
+}
+
+func TestRenderEmptyCountWithNoGroups(t *testing.T) {
+	out := stripANSI(Render(Snapshot{Width: 30, EmptyCount: 2}))
+	if !strings.Contains(out, "(no runs)") || !strings.Contains(out, "· 2 empty hidden") {
+		t.Errorf("no-groups render should still account for hidden stubs, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
**Key Changes:**

- Collapse empty leftover sessions in the sidebar into a "· N empty hidden" footer so short-lived stubs no longer clutter the run list
- Add a live-filtered slash command menu above the composer input so users can discover commands without memorizing them
- Dim exited runs in the sidebar so alive runs carry the visual weight in dense lists

**Added:**

- Stub filtering logic - Introduced `visibleRuns` and `isStub` in `ui/app/app.go` to hide empty sessions (exited under a second with no recorded events) while always keeping the selected run visible so focus never points at an unshown row
- Slash command menu - Added `slashCommands` table and `slashMenu` rendering in `ui/pane/composer.go` that filters commands by prefix, shows usage lines once arguments are typed, and suppresses the menu for multi-line or non-command buffers
- Empty-count footer - Added `EmptyCount` field to `Snapshot` and a `hiddenLine` helper in `ui/sidebar/sidebar.go` to account for collapsed stubs in both populated and empty render states
- Test coverage - Added tests for stub collapsing, selected-stub retention, selection cycling that skips stubs, slash menu filtering across buffer states, and empty-count footer rendering

**Changed:**

- Selection cycling - Updated `cycleSelection` to iterate over `visibleRuns` instead of `currentRuns` so navigation skips hidden stubs, matching what the sidebar displays
- Sidebar rendering - Updated `renderSidebar` to render the empty-count footer, tightened `MaxPerGroup` from 12 to 8, and dimmed exited run rows via `Secondary`/`Faint` styles in `renderRow`