### PR TITLE
feat: resolve claude-code model from manifest anthropic entry

### DIFF
--- a/agenticcli/claude_live.go
+++ b/agenticcli/claude_live.go
@@ -232,6 +232,7 @@ type liveEvent struct {
 	Subtype   string        `json:"subtype"`
 	SessionID string        `json:"session_id"`
 	RequestID string        `json:"request_id"`
+	Model     string        `json:"model"`
 	Request   *controlEvent `json:"request"`
 	Message   *streamedMsg  `json:"message"`
 }
@@ -266,7 +267,10 @@ func (s *liveSession) handle(line []byte) error {
 		if ev.Subtype == "init" {
 			s.sessionID = ev.SessionID
 			s.protoErrs = 0
-			logging.InfoContext(s.ctx, "claude live session started (session_id=%s)", ev.SessionID)
+			// The init event carries the model the CLI resolved (flag >
+			// env > settings > built-in default) — the only reliable
+			// source when no --model was passed.
+			logging.InfoContext(s.ctx, "claude live session started (session_id=%s model=%s)", ev.SessionID, ev.Model)
 		}
 	case "assistant":
 		s.protoErrs = 0

--- a/runner/run.go
+++ b/runner/run.go
@@ -376,20 +376,8 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 		applyExplicitModel(opts, bundle)
 		return "", nil
 	}
-	// An explicitly requested agentic CLI provider (claude-code, agy)
-	// authenticates through the local CLI, so the credential-driven walk
-	// below doesn't apply — and the config default model (rule 2) belongs
-	// to a different API provider and must not be paired with the CLI. The
-	// model may stay empty: the CLI then uses its own configured default,
-	// unless the manifest pins one for this provider.
 	if p := normalizeProvider(opts.Provider); metrics.IsAgenticCLI(p) {
-		for i := range bundle.Models {
-			if normalizeProvider(bundle.Models[i].Provider) == p {
-				opts.Model = bundle.Models[i].Model
-				break
-			}
-		}
-		logging.InfoContext(ctx, "using agentic CLI provider %s (model=%q)", p, opts.Model)
+		applyAgenticCLIModel(ctx, opts, bundle, p)
 		return "", nil
 	}
 	if warn, ok := applyConfigDefault(ctx, opts, bundle); ok {
@@ -410,6 +398,36 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 	}
 	applyLegacyBundleFallback(opts, bundle)
 	return "", nil
+}
+
+// applyAgenticCLIModel resolves the model for an explicitly requested agentic
+// CLI provider (claude-code, agy). The CLI authenticates locally, so the
+// credential-driven walk doesn't apply — and the config default model (rule 2)
+// belongs to a different API provider and must not be paired with the CLI.
+// Resolution order: a manifest entry pinned for this provider; for claude-code
+// only, the manifest's anthropic entry (the CLI executes the same models and
+// accepts full model names, and the agent's tuning — prompts, budgets, cost
+// multipliers — is calibrated against that pin, not whatever the CLI's default
+// happens to be); otherwise empty, letting the CLI use its own configured
+// default. agy never borrows the anthropic entry — its backend is not
+// Anthropic.
+func applyAgenticCLIModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle, p string) {
+	for i := range bundle.Models {
+		if normalizeProvider(bundle.Models[i].Provider) == p {
+			opts.Model = bundle.Models[i].Model
+			break
+		}
+	}
+	if opts.Model == "" && p == "claude-code" {
+		for i := range bundle.Models {
+			if normalizeProvider(bundle.Models[i].Provider) == "anthropic" {
+				opts.Model = bundle.Models[i].Model
+				logging.InfoContext(ctx, "using manifest anthropic model %q for claude-code CLI", opts.Model)
+				break
+			}
+		}
+	}
+	logging.InfoContext(ctx, "using agentic CLI provider %s (model=%q)", p, opts.Model)
 }
 
 // applyExplicitModel handles rule 1: opts.Model was set explicitly. Fill in

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -785,6 +785,73 @@ func TestResolveModelPrecedence_ConfigTokenWinsOverManifestTop(t *testing.T) {
 	}
 }
 
+// TestResolveModelPrecedence_AgenticCLI covers the agentic CLI branch:
+// claude-code borrows the manifest's anthropic model when no claude-code
+// entry pins one (both run the same models, and the agent's tuning is
+// calibrated against the anthropic pin), while agy never borrows — its
+// backend is not Anthropic.
+func TestResolveModelPrecedence_AgenticCLI(t *testing.T) {
+	anthropicOnly := []agent.ModelPreference{
+		{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+		{Model: "gpt-4.1-mini", Provider: "openai"},
+	}
+	tests := []struct {
+		name      string
+		provider  string
+		models    []agent.ModelPreference
+		wantModel string
+	}{
+		{
+			name:      "claude-code borrows anthropic entry",
+			provider:  "claude-code",
+			models:    anthropicOnly,
+			wantModel: "claude-sonnet-4-6",
+		},
+		{
+			name:     "manifest claude-code entry wins over anthropic entry",
+			provider: "claude-code",
+			models: []agent.ModelPreference{
+				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+				{Model: "opus", Provider: "claude-code"},
+			},
+			wantModel: "opus",
+		},
+		{
+			name:     "no anthropic entry leaves model empty for CLI default",
+			provider: "claude-code",
+			models: []agent.ModelPreference{
+				{Model: "gpt-4.1-mini", Provider: "openai"},
+			},
+			wantModel: "",
+		},
+		{
+			name:      "agy does not borrow the anthropic entry",
+			provider:  "agy",
+			models:    anthropicOnly,
+			wantModel: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &RunOptions{Provider: tc.provider}
+			bundle := &agent.Bundle{Models: tc.models}
+			warn, err := ResolveModelPrecedence(context.Background(), opts, bundle)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if warn != "" {
+				t.Fatalf("unexpected warning: %q", warn)
+			}
+			if opts.Model != tc.wantModel {
+				t.Fatalf("expected model %q, got %q", tc.wantModel, opts.Model)
+			}
+			if opts.Provider != tc.provider {
+				t.Fatalf("provider changed: expected %q, got %q", tc.provider, opts.Provider)
+			}
+		})
+	}
+}
+
 func runAndAssertBundle(t *testing.T, opts *RunOptions, wantModel, wantProvider string) {
 	t.Helper()
 	cmd := &cobra.Command{}


### PR DESCRIPTION
**Key Changes:**

- claude-code CLI now borrows the manifest's anthropic model when no claude-code-specific entry is pinned, keeping agent tuning calibrated against the intended model
- Extracted agentic CLI model resolution into a dedicated `applyAgenticCLIModel` function for clarity and testability
- Live session logging now surfaces the model the CLI actually resolved via the init event

**Added:**

- Manifest anthropic fallback for claude-code - Added `applyAgenticCLIModel` in `runner/run.go` which resolves the model via provider-specific pin first, then falls back to the manifest anthropic entry for claude-code only (since both run the same models), while agy never borrows since its backend is not Anthropic
- Model field on live events - Added a `Model` field to `liveEvent` in `agenticcli/claude_live.go` to capture the model resolved by the CLI's init event, the only reliable source when no `--model` is passed
- Test coverage for agentic CLI resolution - Added `TestResolveModelPrecedence_AgenticCLI` in `runner/run_test.go` covering claude-code borrowing the anthropic entry, claude-code-specific entries winning, empty-model CLI defaults, and agy declining to borrow

**Changed:**

- Agentic CLI branch in `ResolveModelPrecedence` - Refactored the inline provider-matching loop into a call to the new `applyAgenticCLIModel` helper in `runner/run.go`
- Session start logging - Updated the "claude live session started" log message in `agenticcli/claude_live.go` to include the resolved model alongside the session ID