### PR TITLE
build: bump go version to 1.26.6

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   goreleaser:

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -35,7 +35,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   govulncheck:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
   PYTHON_VERSION: 3.13.3
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,7 +36,7 @@ concurrency:
 
 # Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
   PYTHON_VERSION: 3.13.3
   RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 permissions:
   actions: read

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cowdogmoo/squad
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
**Key Changes:**

- Bumped Go toolchain version from 1.26.5 to 1.26.6 across all CI workflows and the module definition
- Kept CI environment and module declaration in sync to avoid version drift between build and runtime

**Changed:**

- CI workflow Go version - Updated `GO_VERSION` env var from 1.26.5 to 1.26.6 in `goreleaser.yaml`, `govulncheck.yaml`, `pre-commit.yaml`, `renovate.yaml`, and `tests.yaml`
- Module Go directive - Bumped `go 1.26.5` to `go 1.26.6` in `go.mod`