### PR TITLE
feat: rename agy provider to antigravity with gemini model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ squad run --agent go-review --provider ollama --model qwen2.5-coder:7b-instruct
 
 # Run through an installed agentic CLI on its subscription (no API key required)
 squad run --agent go-review --provider claude-code   # Claude Code
-squad run --agent go-review --provider agy           # Augment CLI
+squad run --agent go-review --provider antigravity   # Google Antigravity CLI
 
 # Estimate cost without calling the model
 squad run --agent go-review --dry-run
@@ -192,7 +192,7 @@ Run `squad <subcommand> --help` for full flag documentation.
 | Flag                  | Description                                                       | Default       |
 | --------------------- | ----------------------------------------------------------------- | ------------- |
 | `--agent`             | Agent name (required)                                             | —             |
-| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, `claude-code`, `agy`, …) | config        |
+| `--provider`          | LLM provider (`openai`, `anthropic`, `gemini`, `ollama`, `claude-code`, `antigravity`, …) | config        |
 | `--model`             | Model identifier                                                  | config        |
 | `--working-dir`       | Target directory the agent operates on                            | current dir   |
 | `--max-cost`          | USD budget cap (0 = unlimited)                                    | `5.00`        |

--- a/agenticcli/agenticcli.go
+++ b/agenticcli/agenticcli.go
@@ -1,9 +1,9 @@
 // Package agenticcli drives locally installed agentic coding CLIs — Claude
-// Code (`claude`) and Augment's `agy` — in non-interactive print mode as
-// squad model providers. The CLI owns the entire agent loop: its own tools,
-// permission handling, and authentication (typically a subscription login).
-// Squad hands it the assembled prompt bundle, waits for the final report,
-// and never needs a provider API key.
+// Code (`claude`) and Google Antigravity's `agy` — in non-interactive print
+// mode as squad model providers. The CLI owns the entire agent loop: its own
+// tools, permission handling, and authentication (typically a subscription
+// login). Squad hands it the assembled prompt bundle, waits for the final
+// report, and never needs a provider API key.
 package agenticcli
 
 import (
@@ -12,15 +12,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/cowdogmoo/squad/logging"
 )
 
-// agyPrintTimeout overrides agy's 5-minute default print-mode wait, which is
-// far too short for a real agent run. Context cancellation still kills the
-// subprocess earlier when squad's own deadline fires.
-const agyPrintTimeout = "4h"
+// antigravityPrintTimeout overrides agy's 5-minute default print-mode wait,
+// which is far too short for a real agent run. Context cancellation still
+// kills the subprocess earlier when squad's own deadline fires.
+const antigravityPrintTimeout = "4h"
 
 // readOnlyDisallowedTools mirrors squad's readonly gate (Write/Edit/MultiEdit
 // rejected, reads and Bash allowed) in Claude Code's tool-permission terms.
@@ -28,24 +29,31 @@ const readOnlyDisallowedTools = "Write,Edit,MultiEdit,NotebookEdit"
 
 // Spec describes one supported agentic CLI.
 type Spec struct {
-	// Provider is the squad provider name ("claude-code", "agy").
+	// Provider is the squad provider name ("claude-code", "antigravity").
 	Provider string
 	// Binary is the executable looked up on PATH.
 	Binary string
 	// Install is a one-line install-and-login hint for missing-binary errors.
 	Install string
+	// EnforcesReadOnly reports whether the CLI has a native flag that
+	// actually blocks edits. Antigravity does not: its print mode runs with
+	// permissions auto-approved and `--mode plan` still writes files
+	// (verified against agy 1.1.13), so squad refuses readonly runs rather
+	// than silently dropping the guarantee.
+	EnforcesReadOnly bool
 }
 
 var specs = map[string]Spec{
 	"claude-code": {
-		Provider: "claude-code",
-		Binary:   "claude",
-		Install:  "npm install -g @anthropic-ai/claude-code, then run `claude` once to log in",
+		Provider:         "claude-code",
+		Binary:           "claude",
+		Install:          "npm install -g @anthropic-ai/claude-code, then run `claude` once to log in",
+		EnforcesReadOnly: true,
 	},
-	"agy": {
-		Provider: "agy",
+	"antigravity": {
+		Provider: "antigravity",
 		Binary:   "agy",
-		Install:  "https://docs.augmentcode.com/cli — then run `agy` once to log in",
+		Install:  "install the Antigravity CLI from https://antigravity.google, then run `agy` once to log in",
 	},
 }
 
@@ -58,7 +66,7 @@ func Lookup(provider string) (Spec, bool) {
 
 // Request carries one print-mode invocation.
 type Request struct {
-	// Provider selects the CLI ("claude-code" or "agy").
+	// Provider selects the CLI ("claude-code" or "antigravity").
 	Provider string
 	// Model is passed through to the CLI's --model flag; empty uses the
 	// CLI's own configured default, which is the common subscription case.
@@ -70,7 +78,7 @@ type Request struct {
 	// WorkDir is the directory the CLI runs in.
 	WorkDir string
 	// ReadOnly maps squad's readonly mode onto the CLI's native
-	// restriction flags.
+	// restriction flags. Run rejects it for CLIs that cannot enforce it.
 	ReadOnly bool
 }
 
@@ -89,6 +97,10 @@ func Run(ctx context.Context, req Request) (Result, error) {
 	spec, ok := Lookup(req.Provider)
 	if !ok {
 		return Result{}, fmt.Errorf("unknown agentic CLI provider: %q", req.Provider)
+	}
+	if req.ReadOnly && !spec.EnforcesReadOnly {
+		return Result{}, fmt.Errorf("provider %q cannot enforce read-only mode: the %s CLI's print mode auto-approves permissions and its plan mode does not block writes; use claude-code or an API provider for readonly runs",
+			spec.Provider, spec.Binary)
 	}
 	path, err := exec.LookPath(spec.Binary)
 	if err != nil {
@@ -121,23 +133,73 @@ func buildArgs(req Request) (args []string, stdin string) {
 		args = []string{"--print", "--output-format", "json", "--dangerously-skip-permissions"}
 		args = append(args, claudeCommonArgs(req)...)
 		return args, req.UserPrompt
-	case "agy":
+	case "antigravity":
 		// agy has no separate system-prompt flag; prepend it to the task.
-		prompt := req.UserPrompt
+		parts := make([]string, 0, 3)
 		if req.SystemPrompt != "" {
-			prompt = req.SystemPrompt + "\n\n" + req.UserPrompt
+			parts = append(parts, req.SystemPrompt)
 		}
-		args = []string{"--print", prompt, "--output-format", "json", "--print-timeout", agyPrintTimeout,
-			"--dangerously-skip-permissions"}
+		workDir := absWorkDir(req.WorkDir)
+		if workDir != "" {
+			parts = append(parts, workDirNote(workDir))
+		}
+		parts = append(parts, req.UserPrompt)
+		args = []string{"--print", strings.Join(parts, "\n\n"), "--output-format", "json",
+			"--print-timeout", antigravityPrintTimeout, "--dangerously-skip-permissions"}
+		if workDir != "" {
+			args = append(args, "--add-dir", workDir)
+		}
 		if req.Model != "" {
 			args = append(args, "--model", req.Model)
-		}
-		if req.ReadOnly {
-			args = append(args, "--mode", "plan")
 		}
 		return args, ""
 	}
 	return nil, ""
+}
+
+// workDirNote pins the agent to squad's working directory. Without it the
+// Antigravity backend roots the session in its own workspace (~/.gemini/
+// antigravity-cli/scratch), so relative file paths land there and
+// run_command executes in the backend's cwd — not in WorkDir, which the
+// child process's cwd does not influence (verified against agy 1.1.13).
+func workDirNote(workDir string) string {
+	return "## Working directory\n\n" +
+		"Your working directory for this task is " + workDir + ". " +
+		"Resolve every relative path against it and create or edit files only under it unless the task says otherwise. " +
+		"Your shell does NOT start there, so begin every shell command with: cd " + workDir
+}
+
+// absWorkDir best-effort resolves dir to an absolute path; the prompt and
+// --add-dir must not depend on a cwd the Antigravity backend ignores.
+func absWorkDir(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return dir
+	}
+	return abs
+}
+
+// NormalizeAntigravityModel maps a manifest Gemini model name onto
+// Antigravity's tiered model IDs. The CLI serves Gemini models with a
+// reasoning-effort suffix (gemini-3.1-pro-low, gemini-3.7-flash-high, …) and
+// rejects bare API names ("--model gemini-3.1-pro requires --effort"), so a
+// borrowed entry gets the CLI's cheapest tier appended; API-only -preview/
+// -latest suffixes are dropped first. Non-Gemini names pass through
+// untouched.
+func NormalizeAntigravityModel(model string) string {
+	if !strings.HasPrefix(strings.ToLower(model), "gemini-") {
+		return model
+	}
+	m := strings.TrimSuffix(model, "-preview")
+	m = strings.TrimSuffix(m, "-latest")
+	switch {
+	case strings.HasSuffix(m, "-low"), strings.HasSuffix(m, "-medium"), strings.HasSuffix(m, "-high"):
+		return m
+	}
+	return m + "-low"
 }
 
 // claudeCommonArgs returns the claude flags shared by the single-shot and
@@ -169,10 +231,13 @@ type claudeOutput struct {
 	} `json:"usage"`
 }
 
-// agyOutput is the envelope `agy --print --output-format json` prints.
-type agyOutput struct {
+// antigravityOutput is the envelope `agy --print --output-format json`
+// prints. Failures may carry the diagnostic in `error` with an empty
+// `response` (e.g. an invalid --model selection).
+type antigravityOutput struct {
 	Status   string `json:"status"`
 	Response string `json:"response"`
+	Error    string `json:"error"`
 	NumTurns int    `json:"num_turns"`
 	Usage    struct {
 		InputTokens  int64 `json:"input_tokens"`
@@ -192,8 +257,8 @@ func parseOutput(provider string, stdout []byte) (Result, error) {
 			return Result{Response: string(stdout)}, nil
 		}
 		return claudeResult(out)
-	case "agy":
-		var out agyOutput
+	case "antigravity":
+		var out antigravityOutput
 		if err := json.Unmarshal(stdout, &out); err != nil {
 			logging.Warn("agy output is not the expected JSON envelope (%v); using raw output", err)
 			return Result{Response: string(stdout)}, nil
@@ -205,7 +270,11 @@ func parseOutput(provider string, stdout []byte) (Result, error) {
 			Turns:        out.NumTurns,
 		}
 		if !strings.EqualFold(out.Status, "SUCCESS") {
-			return res, fmt.Errorf("agy run failed (status=%s): %s", out.Status, truncate(out.Response, 500))
+			detail := out.Error
+			if detail == "" {
+				detail = out.Response
+			}
+			return res, fmt.Errorf("antigravity run failed (status=%s): %s", out.Status, truncate(detail, 500))
 		}
 		return res, nil
 	}

--- a/agenticcli/agenticcli_test.go
+++ b/agenticcli/agenticcli_test.go
@@ -16,7 +16,8 @@ func TestLookup(t *testing.T) {
 		wantOK     bool
 	}{
 		{provider: "claude-code", wantBinary: "claude", wantOK: true},
-		{provider: "agy", wantBinary: "agy", wantOK: true},
+		{provider: "antigravity", wantBinary: "agy", wantOK: true},
+		{provider: "agy", wantOK: false}, // legacy alias resolves in runner.normalizeProvider
 		{provider: "anthropic", wantOK: false},
 		{provider: "", wantOK: false},
 	}
@@ -63,24 +64,25 @@ func TestBuildArgs(t *testing.T) {
 			wantStdin: "task",
 		},
 		{
-			name: "agy minimal",
-			req:  Request{Provider: "agy", UserPrompt: "task"},
+			name: "antigravity minimal",
+			req:  Request{Provider: "antigravity", UserPrompt: "task"},
 			wantArgs: []string{
 				"--print", "task", "--output-format", "json",
-				"--print-timeout", agyPrintTimeout, "--dangerously-skip-permissions",
+				"--print-timeout", antigravityPrintTimeout, "--dangerously-skip-permissions",
 			},
 		},
 		{
-			name: "agy system prompt prepended and readonly",
+			name: "antigravity system prompt and workdir rooting",
 			req: Request{
-				Provider: "agy", Model: "gpt5",
-				SystemPrompt: "be brief", UserPrompt: "task", ReadOnly: true,
+				Provider: "antigravity", Model: "gemini-3.7-flash-low",
+				SystemPrompt: "be brief", UserPrompt: "task", WorkDir: "/tmp/repo",
 			},
 			wantArgs: []string{
-				"--print", "be brief\n\ntask", "--output-format", "json",
-				"--print-timeout", agyPrintTimeout, "--dangerously-skip-permissions",
-				"--model", "gpt5",
-				"--mode", "plan",
+				"--print", "be brief\n\n" + workDirNote("/tmp/repo") + "\n\ntask",
+				"--output-format", "json",
+				"--print-timeout", antigravityPrintTimeout, "--dangerously-skip-permissions",
+				"--add-dir", "/tmp/repo",
+				"--model", "gemini-3.7-flash-low",
 			},
 		},
 		{
@@ -110,7 +112,7 @@ func TestBuildArgs(t *testing.T) {
 func TestParseOutput(t *testing.T) {
 	t.Parallel()
 	claudeSuccess := `{"is_error":false,"num_turns":3,"result":"done","usage":{"input_tokens":6,"cache_creation_input_tokens":100,"cache_read_input_tokens":200,"output_tokens":9},"type":"result"}`
-	agySuccess := `{"conversation_id":"abc","status":"SUCCESS","response":"done\n","num_turns":2,"usage":{"input_tokens":500,"output_tokens":40,"total_tokens":540}}`
+	antigravitySuccess := `{"conversation_id":"abc","status":"SUCCESS","response":"done\n","num_turns":2,"usage":{"input_tokens":500,"output_tokens":40,"total_tokens":540}}`
 
 	tests := []struct {
 		name       string
@@ -136,16 +138,21 @@ func TestParseOutput(t *testing.T) {
 			stdout: "plain text answer", wantResp: "plain text answer",
 		},
 		{
-			name: "agy success", provider: "agy", stdout: agySuccess,
+			name: "antigravity success", provider: "antigravity", stdout: antigravitySuccess,
 			wantResp: "done\n", wantInput: 500, wantOutput: 40, wantTurns: 2,
 		},
 		{
-			name: "agy failure status", provider: "agy",
+			name: "antigravity failure status", provider: "antigravity",
 			stdout:  `{"status":"ERROR","response":"boom","num_turns":1,"usage":{}}`,
 			wantErr: "status=ERROR",
 		},
 		{
-			name: "agy non-JSON falls back to raw", provider: "agy",
+			name: "antigravity failure detail in error field", provider: "antigravity",
+			stdout:  `{"status":"ERROR","response":"","error":"invalid model selection (--model \"gemini-3.1-pro\")","num_turns":0,"usage":{}}`,
+			wantErr: "invalid model selection",
+		},
+		{
+			name: "antigravity non-JSON falls back to raw", provider: "antigravity",
 			stdout: "plain", wantResp: "plain",
 		},
 		{
@@ -233,9 +240,38 @@ func TestRunSpawnsBinary(t *testing.T) {
 
 func TestRunMissingBinary(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	_, err := Run(context.Background(), Request{Provider: "agy", UserPrompt: "x", WorkDir: t.TempDir()})
+	_, err := Run(context.Background(), Request{Provider: "antigravity", UserPrompt: "x", WorkDir: t.TempDir()})
 	if err == nil || !strings.Contains(err.Error(), "requires the \"agy\" CLI on PATH") {
 		t.Fatalf("err = %v, want missing-binary error", err)
+	}
+}
+
+// TestRunReadOnlyRejectedForAntigravity pins the fail-loud behavior: the agy
+// CLI has no flag that actually blocks edits in print mode, so a readonly
+// request must error before the binary is even looked up.
+func TestRunReadOnlyRejectedForAntigravity(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no agy on PATH: the rejection must come first
+	_, err := Run(context.Background(), Request{Provider: "antigravity", UserPrompt: "x", ReadOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "cannot enforce read-only mode") {
+		t.Fatalf("err = %v, want read-only rejection", err)
+	}
+}
+
+func TestNormalizeAntigravityModel(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"gemini-3.1-pro":           "gemini-3.1-pro-low",
+		"gemini-3.1-pro-preview":   "gemini-3.1-pro-low",
+		"gemini-3-flash-latest":    "gemini-3-flash-low",
+		"gemini-3.7-flash-high":    "gemini-3.7-flash-high",
+		"gemini-3.7-flash-medium":  "gemini-3.7-flash-medium",
+		"claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
+		"gpt-oss-120b-medium":      "gpt-oss-120b-medium",
+	}
+	for in, want := range cases {
+		if got := NormalizeAntigravityModel(in); got != want {
+			t.Errorf("NormalizeAntigravityModel(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/agenticcli/claude_live_test.go
+++ b/agenticcli/claude_live_test.go
@@ -256,8 +256,8 @@ func TestRunLive_RejectsNonClaude(t *testing.T) {
 	cb := func(context.Context, string, json.RawMessage, string) (Decision, error) {
 		return Decision{Allow: true}, nil
 	}
-	if _, err := RunLive(context.Background(), LiveRequest{Request: Request{Provider: "agy"}, CanUseTool: cb}); err == nil {
-		t.Error("want error for agy provider")
+	if _, err := RunLive(context.Background(), LiveRequest{Request: Request{Provider: "antigravity"}, CanUseTool: cb}); err == nil {
+		t.Error("want error for antigravity provider")
 	}
 	if _, err := RunLive(context.Background(), LiveRequest{Request: Request{Provider: "claude-code"}}); err == nil {
 		t.Error("want error for nil CanUseTool")

--- a/cmd/squad/run.go
+++ b/cmd/squad/run.go
@@ -333,7 +333,7 @@ user_prompt will be used (if configured in the agent's manifest).`,
 	cmd.Flags().String("api-version", "", "API version (Azure/OpenAI-compatible)")
 	cmd.Flags().String("api-type", "", "API type (openai or azure)")
 	cmd.Flags().Bool("openai-compat-max-tokens", false, "Use max_tokens for OpenAI-compatible endpoints")
-	cmd.Flags().String("provider", "", "Model provider (openai, anthropic, gemini, ollama, claude-code, agy, etc)")
+	cmd.Flags().String("provider", "", "Model provider (openai, anthropic, gemini, ollama, claude-code, antigravity, etc)")
 	cmd.Flags().String("model", "", "Model name")
 	cmd.Flags().Float64("temperature", -1, "Sampling temperature (default from config)")
 	cmd.Flags().Int("max-tokens", -1, "Max output tokens (default from config)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,7 +321,7 @@ variables, or config file.
 | Ollama | supported | `http://localhost:11434/v1` (default) | optional | Local models; use `--num-ctx` for context size |
 | OpenAI-compatible | supported | provider-specific (required) | optional | Any `/v1/chat/completions` endpoint; use `--base-url` |
 | Claude Code CLI | supported | n/a | not needed | `claude-code`; runs the installed `claude` binary in print mode on your subscription |
-| Augment CLI | supported | n/a | not needed | `agy`; runs the installed `agy` binary in print mode on your subscription |
+| Antigravity CLI | supported | n/a | not needed | `antigravity` (alias `agy`); runs Google Antigravity's installed `agy` binary in print mode on your subscription |
 
 ### OpenAI
 
@@ -437,13 +437,13 @@ model:
 
 ### Agentic CLI providers (no API key)
 
-The `claude-code` and `agy` providers run an installed agentic CLI — Claude
-Code's `claude` or Augment's `agy` — in non-interactive print mode instead of
-calling a model API. The CLI brings its own tools, permissions, and
-authentication (typically a subscription login), so no API key or token is
-needed; squad assembles the agent's prompt bundle, hands it to the CLI in the
-working directory, and records the reported token usage and turn count from
-the CLI's JSON output.
+The `claude-code` and `antigravity` providers run an installed agentic CLI —
+Claude Code's `claude` or Google Antigravity's `agy` — in non-interactive
+print mode instead of calling a model API. The CLI brings its own tools,
+permissions, and authentication (typically a subscription login), so no API
+key or token is needed; squad assembles the agent's prompt bundle, hands it
+to the CLI in the working directory, and records the reported token usage and
+turn count from the CLI's JSON output.
 
 ```bash
 # Claude Code (uses the CLI's default model when --model is omitted)
@@ -452,8 +452,9 @@ squad run --agent go-review --provider claude-code
 # Pin a model alias understood by the CLI
 squad run --agent go-review --provider claude-code --model sonnet
 
-# Augment CLI
-squad run --agent go-review --provider agy
+# Antigravity CLI (`agy` is accepted as a legacy alias)
+squad run --agent go-review --provider antigravity
+squad run --agent go-review --provider antigravity --model gemini-3.1-pro-high
 ```
 
 Agent manifests can rank a CLI ahead of an API fallback; the CLI entry is
@@ -467,19 +468,35 @@ models:
     model: claude-sonnet-4-6
 ```
 
+When no CLI-specific entry pins a model, the CLI borrows the manifest entry
+of its backing API provider so agent tuning stays calibrated: `claude-code`
+uses the `anthropic` entry as-is, and `antigravity` uses the `gemini` entry
+mapped onto Antigravity's tiered model IDs (a bare `gemini-3.1-pro` becomes
+`gemini-3.1-pro-low`; `-preview`/`-latest` suffixes are dropped). Antigravity
+also serves Claude and GPT-OSS models, but those must be pinned explicitly
+with a `provider: antigravity` entry — squad never guesses that mapping.
+
 Behavior differences from API providers:
 
 - The CLI runs its own agent loop, so squad's tool surface, `--max-iterations`,
   `--temperature`, `--max-tokens`, and `--stream` do not apply.
 - Cost is reported as `$0` — usage is billed through the CLI's subscription.
-- `--mode readonly` maps to the CLI's native restrictions (`claude`:
-  edit tools disallowed; `agy`: plan mode).
+- `--mode readonly` maps to `claude`'s native restrictions (edit tools
+  disallowed). `antigravity` is rejected in readonly and plan mode: the agy
+  CLI's print mode auto-approves permissions and its plan mode does not block
+  writes, so squad fails loudly instead of pretending the guarantee holds.
 - Permission prompts are bypassed (`--dangerously-skip-permissions`), matching
   squad's unattended tool loop. The exception is `--interactive` with
   `claude-code`: squad then drives the CLI through its stream-json permission
   protocol, answering each edit-permission request from the sign-off gate, so
   file modifications stay locked until you approve the agent's plan at the
-  terminal. `agy` does not support `--interactive`.
+  terminal. `antigravity` does not support `--interactive` — headless agy
+  settles every choice itself and exposes no permission protocol for squad to
+  intercept.
+- Antigravity roots its session in its own workspace rather than the
+  invocation directory, so squad passes `--add-dir` and pins the working
+  directory in the prompt; the agent is told to `cd` there for shell commands
+  and resolve every relative path against it.
 - `environment` types other than `local`, `comments_only`, and `ascii_only`
   are rejected — those guarantees live in squad's own tool gates.
 - MCP servers from the manifest are not forwarded; configure them in the CLI.
@@ -536,7 +553,7 @@ When you integrate squad into a production workflow:
 
 - **Cap cost on every run.** Set `--max-cost` (or `run.max_cost` in the config file) to a sane USD ceiling. A budget cap is the only universally reliable stop.
 - **Pick an explicit `--auto-confirm` policy** for unattended execution. The default `abort` is correct for interactive runs; for routines, choose `yes` only when you've audited the agent's tool surface.
-- **Use `--interactive` when you want to review before anything changes.** The agent investigates, then presents a plan via the `ProposePlan` tool; `Write`/`Edit`/`MultiEdit` stay locked until you approve it at the terminal. Answer `yes` to approve, `no` to reject, or give feedback — anything else you type or paste (multi-line is fine; finish with an empty line or ctrl-d) goes back to the agent, which revises the plan and proposes again. One approval covers the whole run, including shards and Task-spawned child agents. Requires a TTY — non-TTY runs fail loudly rather than auto-approving, and the flag is not yet supported for composed agents or the `agy` provider. With `--provider claude-code` the gate rides the CLI's own permission protocol: instead of calling a `ProposePlan` tool, the agent writes its plan as a message, and squad presents that plan (plus the pending edit) for the same approve/reject/feedback review before any file modification is allowed.
+- **Use `--interactive` when you want to review before anything changes.** The agent investigates, then presents a plan via the `ProposePlan` tool; `Write`/`Edit`/`MultiEdit` stay locked until you approve it at the terminal. Answer `yes` to approve, `no` to reject, or give feedback — anything else you type or paste (multi-line is fine; finish with an empty line or ctrl-d) goes back to the agent, which revises the plan and proposes again. One approval covers the whole run, including shards and Task-spawned child agents. Requires a TTY — non-TTY runs fail loudly rather than auto-approving, and the flag is not supported for composed agents or the `antigravity` provider (headless agy has no permission protocol for squad to gate). With `--provider claude-code` the gate rides the CLI's own permission protocol: instead of calling a `ProposePlan` tool, the agent writes its plan as a message, and squad presents that plan (plus the pending edit) for the same approve/reject/feedback review before any file modification is allowed.
 - **Sandbox writes** with `--isolate worktree` (separate dir + branch) or the `environment: docker` execution backend ([docs/execution-backends.md](./execution-backends.md)) so a bad edit lands in a throwaway tree, not your working copy.
 - **Review `agent.yaml` and the prompt files like code.** The `Bash` tool runs arbitrary shell; treat every manifest change in PR review the same way you'd treat a change to a CI workflow.
 - **Never hard-code API keys** in `agent.yaml` or shell history. Use `$VAR` or `$(command)` token resolution to pull from a secret manager — see [Token resolution](#token-resolution) above.

--- a/metrics/apikey.go
+++ b/metrics/apikey.go
@@ -31,7 +31,7 @@ const (
 // credential detection checks that the binary is installed instead.
 var AgenticCLIBinaries = map[string]string{
 	"claude-code": "claude",
-	"agy":         "agy",
+	"antigravity": "agy",
 }
 
 // IsAgenticCLI reports whether provider runs through a local agentic CLI

--- a/metrics/apikey_test.go
+++ b/metrics/apikey_test.go
@@ -91,9 +91,9 @@ func TestKeyStatusAgenticCLIBinaryPresent(t *testing.T) {
 
 func TestKeyStatusAgenticCLIBinaryMissing(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	got := KeyStatus("agy", "")
+	got := KeyStatus("antigravity", "")
 	if got.State != APIKeyMissing || got.EnvVar != "agy CLI" || got.Source != APIKeySourceNone {
-		t.Fatalf("agy without binary = %+v, want missing agy CLI", got)
+		t.Fatalf("antigravity without binary = %+v, want missing agy CLI", got)
 	}
 }
 
@@ -104,9 +104,10 @@ func TestIsAgenticCLI(t *testing.T) {
 	}{
 		{"claude-code", true},
 		{" Claude-Code", true},
-		{"agy", true},
+		{"antigravity", true},
 		{"anthropic", false},
 		{"claude", false}, // alias resolution happens in runner.normalizeProvider
+		{"agy", false},    // ditto: the legacy name resolves there too
 		{"", false},
 	}
 	for _, tc := range cases {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -275,7 +275,7 @@ var SupportedProviders = []string{
 	"ollama",
 	"openai-compat",
 	"claude-code",
-	"agy",
+	"antigravity",
 }
 
 // providerMappings maps a squad provider name to the LiteLLM

--- a/runner/agentic.go
+++ b/runner/agentic.go
@@ -21,7 +21,7 @@ import (
 )
 
 // invokeAgenticCLI runs the prompt through a locally installed agentic CLI
-// (claude-code or agy) in non-interactive print mode. The CLI executes its
+// (claude-code or antigravity) in non-interactive print mode. The CLI executes its
 // own tool loop directly in the working directory with its own
 // authentication, so squad's executor, tool registry, MCP plumbing, and API
 // keys are all bypassed.

--- a/runner/agentic_test.go
+++ b/runner/agentic_test.go
@@ -41,8 +41,8 @@ func TestInvokeAgenticCLIRejectsEditGates(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := metrics.New("agy", "")
-			_, _, err := invokeAgenticCLI(context.Background(), &RunOptions{}, "agy", "", "sys", tt.bundle, m)
+			m := metrics.New("antigravity", "")
+			_, _, err := invokeAgenticCLI(context.Background(), &RunOptions{}, "antigravity", "", "sys", tt.bundle, m)
 			if err == nil || !strings.Contains(err.Error(), "cannot enforce comments_only/ascii_only") {
 				t.Fatalf("err = %v, want edit-gate rejection", err)
 			}
@@ -272,7 +272,7 @@ func TestAgenticWorktreeSnapshot(t *testing.T) {
 
 func TestBuildLLMRejectsAgenticCLIProviders(t *testing.T) {
 	t.Parallel()
-	for _, provider := range []string{"claude-code", "agy"} {
+	for _, provider := range []string{"claude-code", "antigravity"} {
 		_, err := buildLLM(context.Background(), &RunOptions{}, provider, "")
 		if err == nil || !strings.Contains(err.Error(), "agentic CLI provider") {
 			t.Errorf("buildLLM(%q) err = %v, want agentic-CLI rejection", provider, err)

--- a/runner/model.go
+++ b/runner/model.go
@@ -559,7 +559,7 @@ func buildLLM(ctx context.Context, opts *RunOptions, provider, model string) (ll
 		return buildGeminiLLM(ctx, opts, model)
 	case "openai-compat":
 		return buildOpenAICompatLLM(opts, "openai-compat", model)
-	case "claude-code", "agy":
+	case "claude-code", "antigravity":
 		// Defence in depth: these are dispatched in InvokeModel before the
 		// LangChain path; reaching here means a call path skipped that branch.
 		return nil, fmt.Errorf("provider %q is an agentic CLI provider and cannot be used as a LangChain model", provider)
@@ -655,6 +655,10 @@ func normalizeProvider(provider string) string {
 	// "claude" is the natural spelling for the Claude Code CLI provider.
 	case "claude":
 		return "claude-code"
+	// "agy" is the Antigravity CLI's binary name and was the provider's
+	// original squad name; older manifests and configs still say it.
+	case "agy":
+		return "antigravity"
 	}
 	return p
 }

--- a/runner/model_provider_test.go
+++ b/runner/model_provider_test.go
@@ -19,7 +19,8 @@ func TestNormalizeProviderGoogleAlias(t *testing.T) {
 		"claude":      "claude-code",
 		" Claude ":    "claude-code",
 		"claude-code": "claude-code",
-		"agy":         "agy",
+		"agy":         "antigravity",
+		"antigravity": "antigravity",
 	}
 	for in, want := range cases {
 		if got := normalizeProvider(in); got != want {

--- a/runner/run.go
+++ b/runner/run.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/cowdogmoo/squad/agent"
+	"github.com/cowdogmoo/squad/agenticcli"
 	"github.com/cowdogmoo/squad/config"
 	"github.com/cowdogmoo/squad/logging"
 	"github.com/cowdogmoo/squad/mcp"
@@ -401,33 +402,44 @@ func ResolveModelPrecedence(ctx context.Context, opts *RunOptions, bundle *agent
 }
 
 // applyAgenticCLIModel resolves the model for an explicitly requested agentic
-// CLI provider (claude-code, agy). The CLI authenticates locally, so the
-// credential-driven walk doesn't apply — and the config default model (rule 2)
-// belongs to a different API provider and must not be paired with the CLI.
-// Resolution order: a manifest entry pinned for this provider; for claude-code
-// only, the manifest's anthropic entry (the CLI executes the same models and
-// accepts full model names, and the agent's tuning — prompts, budgets, cost
-// multipliers — is calibrated against that pin, not whatever the CLI's default
-// happens to be); otherwise empty, letting the CLI use its own configured
-// default. agy never borrows the anthropic entry — its backend is not
-// Anthropic.
+// CLI provider (claude-code, antigravity). The CLI authenticates locally, so
+// the credential-driven walk doesn't apply — and the config default model
+// (rule 2) belongs to a different API provider and must not be paired with
+// the CLI. Resolution order: a manifest entry pinned for this provider; then
+// the manifest entry for the CLI's backing API provider — anthropic for
+// claude-code (the CLI executes the same models and accepts full model
+// names), gemini for antigravity (mapped onto the CLI's tiered IDs) — since
+// the agent's tuning (prompts, budgets, cost multipliers) is calibrated
+// against that pin, not whatever the CLI's default happens to be; otherwise
+// empty, letting the CLI use its own configured default.
 func applyAgenticCLIModel(ctx context.Context, opts *RunOptions, bundle *agent.Bundle, p string) {
-	for i := range bundle.Models {
-		if normalizeProvider(bundle.Models[i].Provider) == p {
-			opts.Model = bundle.Models[i].Model
-			break
-		}
-	}
-	if opts.Model == "" && p == "claude-code" {
-		for i := range bundle.Models {
-			if normalizeProvider(bundle.Models[i].Provider) == "anthropic" {
-				opts.Model = bundle.Models[i].Model
+	opts.Model = manifestModelFor(bundle, p)
+	if opts.Model == "" {
+		switch p {
+		case "claude-code":
+			if m := manifestModelFor(bundle, "anthropic"); m != "" {
+				opts.Model = m
 				logging.InfoContext(ctx, "using manifest anthropic model %q for claude-code CLI", opts.Model)
-				break
+			}
+		case "antigravity":
+			if m := manifestModelFor(bundle, "gemini"); m != "" {
+				opts.Model = agenticcli.NormalizeAntigravityModel(m)
+				logging.InfoContext(ctx, "using manifest gemini model %q as %q for the antigravity CLI", m, opts.Model)
 			}
 		}
 	}
 	logging.InfoContext(ctx, "using agentic CLI provider %s (model=%q)", p, opts.Model)
+}
+
+// manifestModelFor returns the model of the first manifest entry whose
+// provider normalizes to p, or "" when none is pinned.
+func manifestModelFor(bundle *agent.Bundle, p string) string {
+	for i := range bundle.Models {
+		if normalizeProvider(bundle.Models[i].Provider) == p {
+			return bundle.Models[i].Model
+		}
+	}
+	return ""
 }
 
 // applyExplicitModel handles rule 1: opts.Model was set explicitly. Fill in

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -788,8 +788,9 @@ func TestResolveModelPrecedence_ConfigTokenWinsOverManifestTop(t *testing.T) {
 // TestResolveModelPrecedence_AgenticCLI covers the agentic CLI branch:
 // claude-code borrows the manifest's anthropic model when no claude-code
 // entry pins one (both run the same models, and the agent's tuning is
-// calibrated against the anthropic pin), while agy never borrows — its
-// backend is not Anthropic.
+// calibrated against the anthropic pin), and antigravity borrows the
+// manifest's gemini model mapped onto the CLI's tiered IDs. Neither borrows
+// the other backend's entry.
 func TestResolveModelPrecedence_AgenticCLI(t *testing.T) {
 	anthropicOnly := []agent.ModelPreference{
 		{Model: "claude-sonnet-4-6", Provider: "anthropic"},
@@ -825,10 +826,44 @@ func TestResolveModelPrecedence_AgenticCLI(t *testing.T) {
 			wantModel: "",
 		},
 		{
-			name:      "agy does not borrow the anthropic entry",
-			provider:  "agy",
+			name:      "antigravity does not borrow the anthropic entry",
+			provider:  "antigravity",
 			models:    anthropicOnly,
 			wantModel: "",
+		},
+		{
+			name:     "antigravity borrows the gemini entry with tier normalization",
+			provider: "antigravity",
+			models: []agent.ModelPreference{
+				{Model: "claude-sonnet-4-6", Provider: "anthropic"},
+				{Model: "gemini-3.1-pro", Provider: "gemini"},
+			},
+			wantModel: "gemini-3.1-pro-low",
+		},
+		{
+			name:     "antigravity keeps an already-tiered gemini entry verbatim",
+			provider: "antigravity",
+			models: []agent.ModelPreference{
+				{Model: "gemini-3.7-flash-high", Provider: "gemini"},
+			},
+			wantModel: "gemini-3.7-flash-high",
+		},
+		{
+			name:     "manifest antigravity entry wins over gemini entry",
+			provider: "antigravity",
+			models: []agent.ModelPreference{
+				{Model: "gemini-3.1-pro", Provider: "gemini"},
+				{Model: "claude-opus-4-6-thinking", Provider: "antigravity"},
+			},
+			wantModel: "claude-opus-4-6-thinking",
+		},
+		{
+			name:     "agy alias resolves to antigravity and borrows gemini",
+			provider: "agy",
+			models: []agent.ModelPreference{
+				{Model: "gemini-3-flash-preview", Provider: "google"},
+			},
+			wantModel: "gemini-3-flash-low",
 		},
 	}
 	for _, tc := range tests {

--- a/runner/signoff_claude_test.go
+++ b/runner/signoff_claude_test.go
@@ -241,16 +241,17 @@ func TestClaudeSignOffGate_UnitBranches(t *testing.T) {
 }
 
 // TestApplyProviderConstraints_InteractiveAgenticCLI pins the narrowed
-// fail-fast: agy + --interactive is still rejected before the session opens,
-// while claude-code + --interactive proceeds to the live path.
+// fail-fast: antigravity + --interactive is still rejected before the session
+// opens (headless agy auto-settles choices and exposes no permission
+// protocol), while claude-code + --interactive proceeds to the live path.
 func TestApplyProviderConstraints_InteractiveAgenticCLI(t *testing.T) {
 	t.Parallel()
 	cmd := &cobra.Command{}
 	bundle := &agent.Bundle{}
 
-	err := applyProviderConstraints(cmd, &RunOptions{Interactive: true, Provider: "agy"}, bundle, t.TempDir())
+	err := applyProviderConstraints(cmd, &RunOptions{Interactive: true, Provider: "antigravity"}, bundle, t.TempDir())
 	if err == nil || !strings.Contains(err.Error(), "not supported with agentic CLI provider") {
-		t.Errorf("agy: err = %v, want the fail-fast rejection", err)
+		t.Errorf("antigravity: err = %v, want the fail-fast rejection", err)
 	}
 	if err := applyProviderConstraints(cmd, &RunOptions{Interactive: true, Provider: "claude-code"}, bundle, t.TempDir()); err != nil {
 		t.Errorf("claude-code: err = %v, want nil (live path supported)", err)


### PR DESCRIPTION
**Key Changes:**

- Renamed the `agy` squad provider to `antigravity` throughout the codebase, keeping `agy` as a legacy alias resolved in `runner.normalizeProvider`
- Added Gemini model borrowing for the Antigravity CLI, mapping bare Gemini names onto the CLI's tiered model IDs (e.g. `gemini-3.1-pro` → `gemini-3.1-pro-low`)
- Made read-only mode fail loudly for Antigravity since its print mode auto-approves permissions and its plan mode does not block writes
- Pinned Antigravity's working directory via `--add-dir` and an in-prompt note so the agent operates in squad's target directory instead of its own backend workspace

**Added:**

- `EnforcesReadOnly` field on `agenticcli.Spec` so providers that cannot honor read-only mode are rejected before the CLI is even looked up - `agenticcli/agenticcli.go`
- `NormalizeAntigravityModel` helper that appends the CLI's cheapest tier to bare Gemini names and strips API-only `-preview`/`-latest` suffixes, with `manifestModelFor` factored out for reuse across borrowing branches - `agenticcli/agenticcli.go`, `runner/run.go`
- `workDirNote` and `absWorkDir` helpers that pin the Antigravity agent to squad's working directory in both the prompt and the `--add-dir` flag, plus surfacing the CLI's `error` field on failure envelopes - `agenticcli/agenticcli.go`
- Test coverage for read-only rejection, Antigravity model normalization, Gemini-entry borrowing with tier normalization, and the `agy` legacy alias resolving to `antigravity` - `agenticcli/agenticcli_test.go`, `runner/run_test.go`, `runner/model_provider_test.go`

**Changed:**

- Provider identity migrated from `agy` to `antigravity` across specs, flag help, docs, metrics, agentic-CLI dispatch, and signoff constraints; `agy` continues to resolve via `normalizeProvider` for existing manifests and configs - `agenticcli/`, `cmd/squad/run.go`, `metrics/`, `runner/`, `docs/configuration.md`, `README.md`
- `applyAgenticCLIModel` extended so Antigravity borrows the manifest's `gemini` entry (mapped through `NormalizeAntigravityModel`) mirroring how `claude-code` borrows the `anthropic` entry, keeping agent tuning calibrated to the pinned model - `runner/run.go`
- `antigravityOutput` envelope now carries an `error` field and surfaces it in failure messages when `response` is empty (e.g. invalid `--model` selection) - `agenticcli/agenticcli.go`
- Install hint updated to point at `https://antigravity.google` and documentation reworded to describe the CLI as Google Antigravity throughout - `agenticcli/agenticcli.go`, `docs/configuration.md`, `README.md`

**Removed:**

- `--mode plan` flag from the Antigravity invocation, since it does not actually block writes - `agenticcli/agenticcli.go`
- References to the CLI as "Augment's `agy`" from package docs, configuration guide, and README in favor of the Google Antigravity branding - `agenticcli/agenticcli.go`, `docs/configuration.md`, `README.md`