### PR TITLE
fix: propagate skill catalog paths to composed and task-spawned agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Skills are single-directory capabilities a running agent loads on demand. They f
 ```text
 skills/
 └── comment-scrub-playbook/
-    ├── SKILL.md             # required: identity, allowed_tools, instructions
+    ├── SKILL.md             # required: identity, allowed-tools, instructions
     └── references/          # optional: knowledge-base documents the skill cites
 ```
 

--- a/cmd/squad/pipeline.go
+++ b/cmd/squad/pipeline.go
@@ -51,12 +51,15 @@ func effectiveStageMode(topMode, stageMode string) string {
 // individual agents. It handles agent resolution, bundle building, budget
 // propagation, and model invocation.
 func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentDir string, cfg *config.Config, vars map[string]string, pipelineRunner *pl.Runner) func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
+	// Resolved once so every stage sees the same catalog-scope skill
+	// directories as a standalone run of the same agent.
+	catalogPaths := runner.ResolveSkillCatalogPaths(cfg)
 	return func(ctx context.Context, agentName, agentPrompt, wd, mode string, stageVars map[string]string) (string, *metrics.Metrics, error) {
 		mergedVars := mergeVars(vars, stageVars)
 
 		mode = effectiveStageMode(opts.Mode, mode)
 
-		bundle, err := buildAgentBundle(agentName, agentPrompt, wd, mode, mergedVars, agentsDir, composedAgentDir, cfg, pipelineRunner, opts.SkillOverrides)
+		bundle, err := buildAgentBundle(agentName, agentPrompt, wd, mode, mergedVars, agentsDir, composedAgentDir, cfg, pipelineRunner, opts.SkillOverrides, catalogPaths)
 		if err != nil {
 			return "", nil, err
 		}
@@ -92,7 +95,7 @@ func buildRunAgentFunc(opts *runner.RunOptions, agentsDir string, composedAgentD
 // buildAgentBundle builds the agent bundle, dispatching to inline or
 // external loading based on whether the named agent is registered as
 // an inline agent on the pipeline runner.
-func buildAgentBundle(agentName, prompt, wd, mode string, mergedVars map[string]string, agentsDir, composedAgentDir string, cfg *config.Config, pipelineRunner *pl.Runner, skillOverrides *agent.SkillOverrides) (*agent.Bundle, error) {
+func buildAgentBundle(agentName, prompt, wd, mode string, mergedVars map[string]string, agentsDir, composedAgentDir string, cfg *config.Config, pipelineRunner *pl.Runner, skillOverrides *agent.SkillOverrides, catalogPaths []string) (*agent.Bundle, error) {
 	if inlineCfg, ok := pipelineRunner.InlineAgents[agentName]; ok && inlineCfg != nil {
 		inlineAgent := &agent.InlineAgentConfig{
 			Name:         agentName,
@@ -123,6 +126,7 @@ func buildAgentBundle(agentName, prompt, wd, mode string, mergedVars map[string]
 	}
 	bundle, err := agent.BuildBundleWithOptions(resolvedAgentsDir, agentName, prompt, wd, mode, mergedVars, &agent.BundleOptions{
 		SkillOverrides: skillOverrides,
+		CatalogPaths:   catalogPaths,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build agent %s: %w", agentName, err)

--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -259,7 +259,7 @@ A common pattern: a `cart-checkout` skill calls `chrome-devtools-mcp` tools to d
 
 The open-standard core that Squad implements is `name`, `description`, and the SKILL.md body — the format that travels between runtimes. Claude Code has extended the same file format with product-specific frontmatter: `when_to_use`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `disallowed-tools`, `argument-hint`, `arguments`, `model`, `effort`, `context: fork`, `agent`, `hooks`, `paths`, `shell`. Claude Code also now exposes custom slash commands as skills.
 
-Squad treats these extensions as forward-compatible: skills that use them still parse (we do not reject unknown fields), but Squad honors only the open-standard core plus its own per-agent gating in `agent.yaml`. Practical implication: an open-standard-only skill runs everywhere; a skill that depends on `context: fork` or `` !`<command>` `` dynamic injection will work in Claude Code and behave as a plain SKILL.md elsewhere.
+Squad treats these extensions as forward-compatible: skills that use them still parse (we do not reject unknown fields). Of the extensions, Squad honors `allowed-tools` — enforced at tool dispatch as an intersection across every loaded skill, and lasting for the remainder of the run because the skill stack never pops (see [`skills.md`](./skills.md)). The rest are ignored, with per-agent gating handled by Squad's own `skills:` block in `agent.yaml`. Practical implication: an open-standard-only skill runs everywhere; a skill that depends on `context: fork` or `` !`<command>` `` dynamic injection will work in Claude Code and behave as a plain SKILL.md elsewhere.
 
 ### When a skill is the right choice
 
@@ -476,7 +476,7 @@ Squad implements the open [Agent Skills standard](https://agentskills.io) — th
 
 **Where the runtimes diverge.** The standard guarantees only the core fields above. Anthropic's own first-party platform does not sync skills between surfaces (claude.ai vs API vs Claude Code each have their own catalog), and Claude Code's product-specific extensions (`context: fork`, `argument-hint`, `` !`<command>` `` dynamic injection, etc.) are not portable. The honest summary: **a SKILL.md that uses only the open-standard core runs everywhere; product-specific frontmatter is ignored where unsupported.**
 
-Squad intentionally does not honor the `allowed-tools` frontmatter field that some Claude Code skills carry. Squad's per-agent tool gating handles that at a coarser level via `agent.yaml`.
+Squad honors the `allowed-tools` frontmatter field that some Claude Code skills carry: while a skill declaring it is loaded, tool calls outside the list are rejected at dispatch (intersection semantics when several skills are stacked; `Skill` itself is always exempt; `Bash(python:*)`-style specifiers degrade to the bare tool name). The clamp lasts from load until the run ends — the skill stack never pops — so only declare `allowed-tools` on skills meant to constrain everything downstream, never on knowledge skills that editing agents load. Coarser per-agent gating remains available via the `skills:` block in `agent.yaml`.
 
 **OpenAI Codex** also consumes the same standard via [Codex Skills](https://developers.openai.com/codex/skills/) — a skill checked into your repo can be run by Codex against the same SKILL.md file.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -104,6 +104,9 @@ While an agent is running, the `Skill(name)` tool delivers a skill's full body a
   ```
 
 - **Write / Edit / MultiEdit** stay strictly anchored to the working directory. Skills are reference material, not write targets.
+- **`allowed-tools`**, if the skill declares it, clamps which tools the agent may call. Enforcement happens at tool dispatch with intersection semantics: every skill on the stack must permit the tool, so one restrictive skill is enough to deny. A skill without the field imposes no restriction. `Skill` itself is always exempt — a restrictive skill can't lock the agent out of loading another — and a denied call returns a tool-result error to the model rather than aborting the run. Matching is by bare tool name; Claude Code's argument-scoped forms like `Bash(python:*)` degrade to plain `Bash`.
+
+The stack is push-only — nothing pops when a skill's task is "done", because there is no reliable done signal. A loaded skill's `allowed-tools` therefore clamps the run from the moment of loading until the run ends. Declare it only on skills meant to constrain everything downstream (a readonly analysis playbook, a look-don't-touch audit procedure); leave it off knowledge skills that editing agents load, or loading the skill silently strips their Write/Edit access for the rest of the run.
 
 Each `Skill(...)` call emits a `skill_loaded` event into `events.jsonl` for the run's session, so the trail of which skill the agent reached for is auditable. On `squad run --resume <id>`, the stack is rehydrated from those events — a resumed run picks up the skills the prior run loaded.
 
@@ -191,6 +194,7 @@ Skills are trusted code — they can direct an agent to run scripts in the skill
 - **Catalog sources are remote.** A compromised `squad skill update` fetches whatever the upstream now publishes. Pin to specific revisions in `cfg.Skills.Repositories` if that matters for your team.
 - **Skill-dir Read/Bash relaxation is one-way.** Even on the stack, Read / Grep cannot escape the skill directory itself — `../etc/passwd` from inside a skill still errors.
 - **Write / Edit are not relaxed.** A skill cannot mutate itself mid-run.
+- **`allowed-tools` is enforced — and permanent for the run.** A skill that declares it restricts every subsequent tool call until the run ends (intersection across the stack, never popped). See [The `Skill` tool](#the-skill-tool).
 
 ## Interop with Claude Code skills
 
@@ -198,7 +202,7 @@ The open standard is the open standard. A skill authored for Claude Code drops i
 
 Squad does not introduce squad-specific frontmatter fields. If you see `x-squad:` namespaced keys in a future SKILL.md, that's where private extensions would live; the standard fields stay untouched.
 
-We do not adopt the `allowed-tools` field some Claude Code skills carry. Squad's per-agent tool gating already handles that at a coarser level, and conflating the two would invent a squad-specific tool-name vocabulary the spec doesn't define.
+Squad honors the `allowed-tools` field some Claude Code skills carry: while a skill declaring it is on the stack, tool calls outside the list are rejected at dispatch. Matching is by bare tool name — Claude Code's argument-scoped `Bash(python:*)` form degrades to plain `Bash` — and because the skill stack never pops, the restriction holds for the remainder of the run, not just the skill's own steps (see [The `Skill` tool](#the-skill-tool)). Claude Code's other extensions (`context: fork`, `argument-hint`, `` !`<command>` `` dynamic injection, …) parse without error and are ignored.
 
 ## When to use a skill vs. an agent
 

--- a/runner/model.go
+++ b/runner/model.go
@@ -856,9 +856,13 @@ func buildTaskConfig(opts *RunOptions) *tools.TaskConfig {
 		Findings:      opts.Findings,
 		AgentName:     opts.AgentName,
 	}
+	// Resolved once so every Task child shares the same catalog-scope skill
+	// directories as the parent run.
+	catalogPaths := ResolveSkillCatalogPaths(opts.Config)
 	cfg.CallModel = func(ctx context.Context, agentsDir, agentName, prompt, workingDir, mode string) (string, *metrics.Metrics, error) {
 		childBundle, err := agent.BuildBundleWithOptions(agentsDir, agentName, prompt, workingDir, mode, opts.Vars, &agent.BundleOptions{
 			SkillOverrides: opts.SkillOverrides,
+			CatalogPaths:   catalogPaths,
 		})
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to build child agent bundle: %w", err)

--- a/runner/model_test.go
+++ b/runner/model_test.go
@@ -1755,14 +1755,14 @@ func TestRehydrateSkillStackToleratesMalformedEvents(t *testing.T) {
 }
 
 func TestResolveSkillCatalogPaths_Nil(t *testing.T) {
-	if got := resolveSkillCatalogPaths(nil); got != nil {
+	if got := ResolveSkillCatalogPaths(nil); got != nil {
 		t.Errorf("expected nil for nil config, got %v", got)
 	}
 }
 
 func TestResolveSkillCatalogPaths_Empty(t *testing.T) {
 	cfg := &config.Config{}
-	if got := resolveSkillCatalogPaths(cfg); got != nil {
+	if got := ResolveSkillCatalogPaths(cfg); got != nil {
 		t.Errorf("expected nil for empty config, got %v", got)
 	}
 }
@@ -1774,7 +1774,7 @@ func TestResolveSkillCatalogPaths_Local(t *testing.T) {
 	cfg := &config.Config{
 		Skills: config.SkillsConfig{LocalPaths: []string{local}},
 	}
-	paths := resolveSkillCatalogPaths(cfg)
+	paths := ResolveSkillCatalogPaths(cfg)
 	if len(paths) != 1 || paths[0] != local {
 		t.Fatalf("paths = %v, want [%q]", paths, local)
 	}

--- a/runner/run.go
+++ b/runner/run.go
@@ -635,12 +635,11 @@ func fillBaseURL(opts *RunOptions, match *agent.ModelPreference, bundle *agent.B
 	}
 }
 
-// prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
-// resolveSkillCatalogPaths returns the catalog-scope directories — local
+// ResolveSkillCatalogPaths returns the catalog-scope directories — local
 // paths and cached git repos — declared in cfg.Skills. Returns nil when
 // cfg is absent or has no skills sources, which is the common case for
 // agents that don't opt into the catalog mechanism.
-func resolveSkillCatalogPaths(cfg *config.Config) []string {
+func ResolveSkillCatalogPaths(cfg *config.Config) []string {
 	if cfg == nil {
 		return nil
 	}
@@ -655,6 +654,7 @@ func resolveSkillCatalogPaths(cfg *config.Config) []string {
 	return mgr.CatalogPaths()
 }
 
+// prepareBundle builds the agent bundle and handles bundle output. Returns nil bundle for dry-run.
 func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir string) (*agent.Bundle, error) {
 	agentDir, err := FindAgentDir(opts.Agent, opts.AgentsDir, opts.Config)
 	if err != nil {
@@ -666,7 +666,7 @@ func prepareBundle(cmd *cobra.Command, opts *RunOptions, prompt, workingDir stri
 
 	bundle, err := agent.BuildBundleWithOptions(agentsDir, opts.Agent, prompt, workingDir, opts.Mode, opts.Vars, &agent.BundleOptions{
 		SkillOverrides: opts.SkillOverrides,
-		CatalogPaths:   resolveSkillCatalogPaths(opts.Config),
+		CatalogPaths:   ResolveSkillCatalogPaths(opts.Config),
 	})
 	if err != nil {
 		return nil, err

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -1585,7 +1585,7 @@ func TestExecuteRun_InteractiveRequiresTTY(t *testing.T) {
 
 func TestResolveSkillCatalogPaths_NilConfig(t *testing.T) {
 	t.Parallel()
-	paths := resolveSkillCatalogPaths(nil)
+	paths := ResolveSkillCatalogPaths(nil)
 	if paths != nil {
 		t.Errorf("expected nil for nil config, got %v", paths)
 	}
@@ -1594,7 +1594,7 @@ func TestResolveSkillCatalogPaths_NilConfig(t *testing.T) {
 func TestResolveSkillCatalogPaths_EmptyConfig(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{}
-	paths := resolveSkillCatalogPaths(cfg)
+	paths := ResolveSkillCatalogPaths(cfg)
 	if paths != nil {
 		t.Errorf("expected nil for empty config, got %v", paths)
 	}

--- a/runner/shard.go
+++ b/runner/shard.go
@@ -81,7 +81,7 @@ func runSharded(ctx context.Context, cmd *cobra.Command, opts *RunOptions, bundl
 
 	bundleOpts := &agent.BundleOptions{
 		SkillOverrides: opts.SkillOverrides,
-		CatalogPaths:   resolveSkillCatalogPaths(opts.Config),
+		CatalogPaths:   ResolveSkillCatalogPaths(opts.Config),
 	}
 
 	// Bounded worker pool. MaxParallel == 1 is effectively sequential. Each


### PR DESCRIPTION
**Key Changes:**

- Export `ResolveSkillCatalogPaths` so composed pipeline stages and Task-spawned child agents resolve the same catalog-scope skill directories as a standalone `squad run`
- Document that Squad now honors the `allowed-tools` frontmatter field with intersection semantics across the (push-only) skill stack, replacing the prior "not adopted" stance
- Correct the SKILL.md frontmatter key reference in the README from `allowed_tools` to `allowed-tools`

**Changed:**

- Skill catalog propagation - `buildRunAgentFunc` in `cmd/squad/pipeline.go` now resolves catalog paths once and threads them through `buildAgentBundle` → `BundleOptions.CatalogPaths`, so composed-agent stages see the same skill directories as the parent run
- Task-child bundle construction - `buildTaskConfig` in `runner/model.go` resolves catalog paths once per run and forwards them via `BundleOptions.CatalogPaths` when Task spawns a child agent, matching parent-run behavior
- Symbol visibility - `resolveSkillCatalogPaths` renamed to exported `ResolveSkillCatalogPaths` in `runner/run.go` (callers updated in `runner/shard.go`, `runner/run_test.go`, `runner/model_test.go`) and the misplaced doc comment moved back onto `prepareBundle`
- `allowed-tools` interop documentation - `docs/agents-and-skills.md` and `docs/skills.md` now describe enforcement at tool dispatch, intersection across stacked skills, `Skill`-tool exemption, `Bash(python:*)` degrading to bare `Bash`, and the permanent-for-the-run clamp caused by the push-only stack; adds a security-note bullet warning against declaring `allowed-tools` on knowledge skills that editing agents load
- README skill layout example - fixed frontmatter key spelling to `allowed-tools`