### PR TITLE
fix: isolate claude-code runs from user settings.json files

### DIFF
--- a/agenticcli/agenticcli.go
+++ b/agenticcli/agenticcli.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -202,10 +203,39 @@ func NormalizeAntigravityModel(model string) string {
 	return m + "-low"
 }
 
+// SettingSourcesEnv opts a run back into the user's own Claude Code
+// settings.json files. Unset (the default) runs hermetically with no setting
+// sources; a comma-separated list ("user", "project", "local") passes that
+// list through; "inherit" omits the flag entirely, which is also the escape
+// hatch for a claude CLI predating --setting-sources.
+const SettingSourcesEnv = "SQUAD_CLAUDE_SETTING_SOURCES"
+
+// claudeSettingSourcesArgs isolates the run from the user's settings.json
+// files. Squad assembles the whole prompt, owns the tool policy, and already
+// bypasses the CLI's permission rules and MCP configuration, so inherited
+// settings only add non-determinism. Inherited hooks are worse than that: a
+// Stop hook answering "block" keeps a --print run going after the model has
+// already produced its answer, and the JSON envelope reports only the LAST
+// assistant message — so whatever the model says while arguing with the hook
+// silently replaces the run's real output.
+func claudeSettingSourcesArgs() []string {
+	return settingSourcesArgs(os.Getenv(SettingSourcesEnv))
+}
+
+// settingSourcesArgs maps the raw SettingSourcesEnv value onto the flag pair.
+func settingSourcesArgs(env string) []string {
+	sources := strings.TrimSpace(env)
+	if sources == "inherit" {
+		return nil
+	}
+	return []string{"--setting-sources", sources}
+}
+
 // claudeCommonArgs returns the claude flags shared by the single-shot and
-// live paths: system prompt, model, and the readonly tool restriction.
+// live paths: settings isolation, system prompt, model, and the readonly tool
+// restriction.
 func claudeCommonArgs(req Request) []string {
-	var args []string
+	args := claudeSettingSourcesArgs()
 	if req.SystemPrompt != "" {
 		args = append(args, "--append-system-prompt", req.SystemPrompt)
 	}

--- a/agenticcli/agenticcli_test.go
+++ b/agenticcli/agenticcli_test.go
@@ -46,6 +46,7 @@ func TestBuildArgs(t *testing.T) {
 			req:  Request{Provider: "claude-code", UserPrompt: "do the thing"},
 			wantArgs: []string{
 				"--print", "--output-format", "json", "--dangerously-skip-permissions",
+				"--setting-sources", "",
 			},
 			wantStdin: "do the thing",
 		},
@@ -57,6 +58,7 @@ func TestBuildArgs(t *testing.T) {
 			},
 			wantArgs: []string{
 				"--print", "--output-format", "json", "--dangerously-skip-permissions",
+				"--setting-sources", "",
 				"--append-system-prompt", "be brief",
 				"--model", "sonnet",
 				"--disallowed-tools", readOnlyDisallowedTools,
@@ -321,5 +323,33 @@ func TestRunNonZeroExit(t *testing.T) {
 	_, err := Run(context.Background(), Request{Provider: "claude-code", UserPrompt: "x", WorkDir: dir})
 	if err == nil || !strings.Contains(err.Error(), "auth expired") {
 		t.Fatalf("err = %v, want stderr tail included", err)
+	}
+}
+
+func TestSettingSourcesArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{name: "unset is hermetic", env: "", want: []string{"--setting-sources", ""}},
+		{name: "whitespace is hermetic", env: "  ", want: []string{"--setting-sources", ""}},
+		{name: "inherit omits the flag", env: "inherit", want: nil},
+		{name: "explicit list passes through", env: "user,project", want: []string{"--setting-sources", "user,project"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := settingSourcesArgs(tt.env)
+			if len(got) != len(tt.want) {
+				t.Fatalf("settingSourcesArgs(%q) = %q, want %q", tt.env, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("settingSourcesArgs(%q)[%d] = %q, want %q", tt.env, i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }

--- a/agenticcli/claude_live_test.go
+++ b/agenticcli/claude_live_test.go
@@ -298,6 +298,7 @@ func TestClaudeLiveArgs(t *testing.T) {
 	want := []string{
 		"--print", "--input-format", "stream-json", "--output-format", "stream-json",
 		"--verbose", "--permission-prompt-tool", "stdio", "--permission-mode", "default",
+		"--setting-sources", "",
 		"--append-system-prompt", "sys", "--model", "opus",
 		"--disallowed-tools", readOnlyDisallowedTools,
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -457,6 +457,18 @@ squad run --agent go-review --provider antigravity
 squad run --agent go-review --provider antigravity --model gemini-3.1-pro-high
 ```
 
+`claude-code` runs with `--setting-sources ""`, so the `claude` subprocess
+loads none of your `settings.json` files. Squad already assembles the whole
+prompt and bypasses the CLI's permission rules and MCP configuration, and
+inherited hooks corrupt the result: a `Stop` hook that answers `block` keeps a
+`--print` run alive after the model has produced its answer, and the CLI's
+JSON envelope returns only the *last* assistant message — so the model's
+argument with the hook replaces the run's real output. Set
+`SQUAD_CLAUDE_SETTING_SOURCES` to a comma-separated list (`user`, `project`,
+`local`) to load those sources anyway, or to `inherit` to drop the flag
+entirely (also the escape hatch for a `claude` CLI older than
+`--setting-sources`).
+
 Agent manifests can rank a CLI ahead of an API fallback; the CLI entry is
 selected only when its binary is on `PATH`:
 


### PR DESCRIPTION
**Key Changes:**

- `claude-code` runs now pass `--setting-sources ""` by default, so the `claude` subprocess loads none of the user's `settings.json` files
- Added `SQUAD_CLAUDE_SETTING_SOURCES` as an opt-back-in escape hatch, accepting a comma-separated source list or `inherit` to drop the flag entirely
- Prevents inherited hooks from corrupting run output — a `Stop` hook answering `block` keeps a `--print` run alive past the model's real answer, and the JSON envelope returns only the last assistant message

**Added:**

- Settings-isolation flag construction — `claudeSettingSourcesArgs`/`settingSourcesArgs` in `agenticcli/agenticcli.go` map the env var onto the flag pair, treating unset and whitespace-only values as hermetic and `inherit` as "omit the flag" (also the compatibility path for a `claude` CLI predating `--setting-sources`)
- Table-driven coverage for the env-var mapping across the unset, whitespace, `inherit`, and explicit-list cases - `agenticcli/agenticcli_test.go`
- Documentation of the isolation default, the hook-corruption rationale, and the `SQUAD_CLAUDE_SETTING_SOURCES` override - `docs/configuration.md`

**Changed:**

- `claudeCommonArgs` now seeds its argument slice from the setting-sources flags before appending the system prompt, model, and readonly tool restriction, so both the single-shot and live paths inherit the isolation
- Existing arg-construction expectations updated to include `--setting-sources ""` - `agenticcli/agenticcli_test.go` and `agenticcli/claude_live_test.go`