### PR TITLE
feat: discover skills from Claude Code plugin manifests

### DIFF
--- a/docs/agents-and-skills.md
+++ b/docs/agents-and-skills.md
@@ -201,6 +201,20 @@ squad skill add myteam https://github.com/example/squad-skills.git
 squad skill update       # pull latest
 ```
 
+Catalog discovery is manifest-aware. A catalog directory is normally scanned
+one level deep (`<dir>/<name>/SKILL.md`), but when the directory carries a
+Claude Code plugin manifest (`.claude-plugin/plugin.json`), Squad also scans
+the manifest's declared skill roots — the `skills` list plus the format's
+default `skills/` directory. That makes nested category layouts like
+`cooking/<skill>/SKILL.md` discoverable as long as the plugin declares them:
+
+```json
+{ "name": "my-catalog", "skills": ["./cooking", "./testing"] }
+```
+
+A malformed manifest or a declared root that escapes the catalog directory is
+reported as a load warning; discovery of the remaining skills continues.
+
 ### Per-agent skill control
 
 Filter which skills an agent can see in `agent.yaml`:

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,120 @@
+// Package plugin parses the subset of the Claude Code plugin format that
+// Squad consumes. A plugin is a directory whose optional manifest at
+// .claude-plugin/plugin.json declares the components it ships; Squad reads
+// the manifest as a content-declaration layer on top of its filesystem
+// discovery. Unknown manifest fields are ignored so newer plugins keep
+// parsing, mirroring the tolerance skill.Manifest applies to SKILL.md
+// frontmatter.
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// ManifestDir is the directory that holds a plugin's manifest.
+	ManifestDir = ".claude-plugin"
+	// ManifestFile is the manifest filename inside ManifestDir.
+	ManifestFile = "plugin.json"
+	// DefaultSkillsDir is the component directory the plugin format scans
+	// for skills even when the manifest declares no explicit roots.
+	DefaultSkillsDir = "skills"
+)
+
+// Manifest is the subset of .claude-plugin/plugin.json that Squad reads.
+type Manifest struct {
+	Name        string `json:"name"`
+	Version     string `json:"version,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Skills lists additional skill roots relative to the plugin root. Per
+	// the plugin format these extend (not replace) the default skills/
+	// directory.
+	Skills PathList `json:"skills,omitempty"`
+}
+
+// PathList unmarshals the plugin format's string-or-array shorthand for
+// path-valued fields.
+type PathList []string
+
+// UnmarshalJSON accepts either a single JSON string or an array of strings.
+func (p *PathList) UnmarshalJSON(data []byte) error {
+	var one string
+	if err := json.Unmarshal(data, &one); err == nil {
+		*p = PathList{one}
+		return nil
+	}
+	var many []string
+	if err := json.Unmarshal(data, &many); err != nil {
+		return fmt.Errorf("expected string or array of strings: %w", err)
+	}
+	*p = PathList(many)
+	return nil
+}
+
+// ManifestPath returns the manifest location for a plugin rooted at root.
+func ManifestPath(root string) string {
+	return filepath.Join(root, ManifestDir, ManifestFile)
+}
+
+// Load reads and parses the manifest for the plugin rooted at root. A
+// missing manifest returns an error satisfying errors.Is(err, fs.ErrNotExist)
+// so callers can treat manifest-less directories as ordinary directories.
+func Load(root string) (*Manifest, error) {
+	data, err := os.ReadFile(ManifestPath(root))
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", ManifestPath(root), err)
+	}
+	return &m, nil
+}
+
+// SkillRoots resolves the manifest's declared skill roots against root and
+// returns them as absolute paths. The default skills/ directory is included
+// first when it exists, matching the format's extend-not-replace semantics.
+// Entries that are absolute or escape root are rejected; valid entries are
+// still returned alongside the joined error so one bad path never hides the
+// rest.
+func (m *Manifest) SkillRoots(root string) ([]string, error) {
+	var roots []string
+	seen := map[string]bool{}
+	add := func(p string) {
+		if p == root || seen[p] {
+			return
+		}
+		seen[p] = true
+		roots = append(roots, p)
+	}
+
+	if info, err := os.Stat(filepath.Join(root, DefaultSkillsDir)); err == nil && info.IsDir() {
+		add(filepath.Join(root, DefaultSkillsDir))
+	}
+
+	var errs []error
+	for _, entry := range m.Skills {
+		if entry == "" {
+			continue
+		}
+		if filepath.IsAbs(entry) {
+			errs = append(errs, fmt.Errorf("skill root %q: absolute paths are not allowed", entry))
+			continue
+		}
+		clean := filepath.Clean(filepath.FromSlash(entry))
+		if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			errs = append(errs, fmt.Errorf("skill root %q: path escapes plugin root", entry))
+			continue
+		}
+		if clean == "." {
+			continue // the plugin root itself is already scanned by callers
+		}
+		add(filepath.Join(root, clean))
+	}
+	return roots, errors.Join(errs...)
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,151 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeManifest creates <root>/.claude-plugin/plugin.json with content.
+func writeManifest(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ManifestDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ManifestFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPathListUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "single string", input: `"./skills"`, want: []string{"./skills"}},
+		{name: "array", input: `["./a", "./b"]`, want: []string{"./a", "./b"}},
+		{name: "empty array", input: `[]`, want: nil},
+		{name: "number rejected", input: `42`, wantErr: true},
+		{name: "mixed array rejected", input: `["./a", 1]`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p PathList
+			err := json.Unmarshal([]byte(tt.input), &p)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", p)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(p) != len(tt.want) {
+				t.Fatalf("got %v, want %v", p, tt.want)
+			}
+			for i := range p {
+				if p[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", p, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadMissingManifest(t *testing.T) {
+	_, err := Load(t.TempDir())
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadMalformedManifest(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, `{"name": "broken",`)
+	if _, err := Load(root); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestLoadParsesSubset(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, `{
+		"name": "squad-skills",
+		"version": "0.1.0",
+		"description": "d",
+		"skills": ["./cooking", "./music"],
+		"unknownField": {"ignored": true}
+	}`)
+	m, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Name != "squad-skills" || m.Version != "0.1.0" {
+		t.Fatalf("unexpected manifest: %+v", m)
+	}
+	if len(m.Skills) != 2 {
+		t.Fatalf("skills = %v", m.Skills)
+	}
+}
+
+func TestSkillRoots(t *testing.T) {
+	root := t.TempDir()
+	for _, d := range []string{"cooking", "music", DefaultSkillsDir} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m := &Manifest{Skills: PathList{"./cooking", "./music", "./cooking", ".", ""}}
+	roots, err := m.SkillRoots(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		filepath.Join(root, DefaultSkillsDir), // default dir first, exists
+		filepath.Join(root, "cooking"),
+		filepath.Join(root, "music"),
+	}
+	if len(roots) != len(want) {
+		t.Fatalf("roots = %v, want %v", roots, want)
+	}
+	for i := range roots {
+		if roots[i] != want[i] {
+			t.Fatalf("roots = %v, want %v", roots, want)
+		}
+	}
+}
+
+func TestSkillRootsRejectsEscapes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "ok"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manifest{Skills: PathList{"../outside", "/abs/path", "./nested/../../escape", "./ok"}}
+	roots, err := m.SkillRoots(root)
+	if err == nil {
+		t.Fatal("expected error for escaping roots")
+	}
+	if len(roots) != 1 || roots[0] != filepath.Join(root, "ok") {
+		t.Fatalf("valid roots should survive escapes: %v", roots)
+	}
+}
+
+func TestSkillRootsNoDefaultDir(t *testing.T) {
+	root := t.TempDir() // no skills/ dir on disk
+	m := &Manifest{Skills: PathList{"./cooking"}}
+	roots, err := m.SkillRoots(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 || roots[0] != filepath.Join(root, "cooking") {
+		t.Fatalf("roots = %v", roots)
+	}
+}

--- a/skill/catalog.go
+++ b/skill/catalog.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/cowdogmoo/squad/config"
+	"github.com/cowdogmoo/squad/plugin"
 )
 
 // Scope identifies where a skill manifest lives. Scope ordering is meaningful:
@@ -134,14 +135,39 @@ func Discover(repoRoot string, catalogDirs ...string) (*Catalog, error) {
 		if dir == "" {
 			continue
 		}
-		if err := c.scanDir(dir, ScopeCatalog, dir); err != nil {
-			return nil, fmt.Errorf("scan catalog skills at %s: %w", dir, err)
+		for _, root := range c.catalogRoots(dir) {
+			if err := c.scanDir(root, ScopeCatalog, dir); err != nil {
+				return nil, fmt.Errorf("scan catalog skills at %s: %w", root, err)
+			}
 		}
 	}
 
 	c.resolveCollisions()
 	c.sortStable()
 	return c, nil
+}
+
+// catalogRoots expands a catalog directory into the set of roots to scan.
+// A plain directory scans as itself. A directory carrying a Claude Code
+// plugin manifest (.claude-plugin/plugin.json) additionally scans the
+// plugin's declared skill roots — the manifest is the declaration layer for
+// nested layouts the fixed-depth scan cannot see, such as category dirs
+// (cooking/<skill>/SKILL.md). A malformed manifest or invalid declared root
+// becomes a LoadError, never a discovery failure.
+func (c *Catalog) catalogRoots(dir string) []string {
+	roots := []string{dir}
+	m, err := plugin.Load(dir)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			c.loadErrors = append(c.loadErrors, LoadError{Path: plugin.ManifestPath(dir), Err: err})
+		}
+		return roots
+	}
+	declared, err := m.SkillRoots(dir)
+	if err != nil {
+		c.loadErrors = append(c.loadErrors, LoadError{Path: plugin.ManifestPath(dir), Err: err})
+	}
+	return append(roots, declared...)
 }
 
 // scanDir loads skills from dir. The Agent Skills spec defines a skill as a

--- a/skill/catalog_test.go
+++ b/skill/catalog_test.go
@@ -673,3 +673,70 @@ func TestFindRepoRoot(t *testing.T) {
 		t.Errorf("FindRepoRoot outside a repo = %q, want %q", got, noRepo)
 	}
 }
+
+// TestDiscoverCatalogPluginManifestRoots verifies that a catalog dir carrying
+// a Claude Code plugin manifest also scans the manifest's declared skill
+// roots, so nested category layouts (cooking/<skill>/SKILL.md) are found.
+func TestDiscoverCatalogPluginManifestRoots(t *testing.T) {
+	withGlobalSkillsDir(t)
+	catalogDir := t.TempDir()
+
+	pluginDir := filepath.Join(catalogDir, ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name": "cat", "skills": ["./groupa", "./groupb"]}`
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeSkill(t, filepath.Join(catalogDir, "groupa"), "alpha", "nested alpha", "body")
+	writeSkill(t, filepath.Join(catalogDir, "groupb"), "beta", "nested beta", "body")
+	writeSkill(t, catalogDir, "gamma", "flat gamma", "body") // depth-1 scan still works
+
+	cat, err := Discover("", catalogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := entryNames(cat.Visible())
+	sort.Strings(names)
+	want := []string{"alpha", "beta", "gamma"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("visible = %v, want %v", names, want)
+	}
+	for _, e := range cat.Visible() {
+		if e.Scope != ScopeCatalog {
+			t.Fatalf("%s scope = %v, want catalog", e.Name(), e.Scope)
+		}
+		if e.Origin != catalogDir {
+			t.Fatalf("%s origin = %q, want %q", e.Name(), e.Origin, catalogDir)
+		}
+	}
+}
+
+// TestDiscoverCatalogMalformedPluginManifest verifies a broken plugin.json
+// surfaces as a LoadError while depth-1 discovery keeps working.
+func TestDiscoverCatalogMalformedPluginManifest(t *testing.T) {
+	withGlobalSkillsDir(t)
+	catalogDir := t.TempDir()
+
+	pluginDir := filepath.Join(catalogDir, ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{broken`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSkill(t, catalogDir, "gamma", "flat gamma", "body")
+
+	cat, err := Discover("", catalogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names := entryNames(cat.Visible()); len(names) != 1 || names[0] != "gamma" {
+		t.Fatalf("visible = %v, want [gamma]", names)
+	}
+	if len(cat.LoadErrors()) != 1 {
+		t.Fatalf("load errors = %v, want exactly one for the manifest", cat.LoadErrors())
+	}
+}

--- a/ui/registry/registry.go
+++ b/ui/registry/registry.go
@@ -74,8 +74,9 @@ func New() *Registry {
 // redirected to /dev/null — the TUI reads progress from the session dir
 // the subprocess writes, not its streams.
 //
-// Returns the assigned Launched record (Status will be Running) and any
-// startup error.
+// Returns a snapshot of the assigned Launched record (Status will be
+// Running) and any startup error. The snapshot does not update as the
+// subprocess runs; poll Get for current state.
 func (r *Registry) Launch(workingDir string, args []string) (*Launched, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("launch: empty args")
@@ -104,10 +105,11 @@ func (r *Registry) Launch(workingDir string, args []string) (*Launched, error) {
 		Status:    StatusRunning,
 	}
 	r.all[id] = lr
+	snapshot := *lr
 	r.mu.Unlock()
 
 	go r.reap(lr)
-	return lr, nil
+	return &snapshot, nil
 }
 
 // reap waits for the subprocess to exit and records the outcome.
@@ -129,17 +131,17 @@ func (r *Registry) reap(lr *Launched) {
 func (r *Registry) Stop(id string) error {
 	r.mu.Lock()
 	lr, ok := r.all[id]
-	r.mu.Unlock()
 	if !ok {
+		r.mu.Unlock()
 		return fmt.Errorf("unknown launch: %s", id)
 	}
-	if lr.Status != StatusRunning {
+	running := lr.Status == StatusRunning
+	proc := lr.Cmd.Process
+	r.mu.Unlock()
+	if !running || proc == nil {
 		return nil
 	}
-	if lr.Cmd.Process == nil {
-		return nil
-	}
-	return lr.Cmd.Process.Signal(syscall.SIGTERM)
+	return proc.Signal(syscall.SIGTERM)
 }
 
 // All returns a snapshot of every launched subprocess, newest first.


### PR DESCRIPTION
**Key Changes:**

- Added a `plugin` package that parses the subset of the Claude Code plugin format Squad consumes (`.claude-plugin/plugin.json`), resolving declared skill roots while rejecting absolute paths and roots that escape the plugin directory
- Made catalog discovery manifest-aware so nested category layouts like `cooking/<skill>/SKILL.md` become discoverable, with malformed manifests and invalid roots degrading to load warnings instead of failing discovery
- Fixed data races in the UI launch registry by returning a snapshot from `Launch` and holding the mutex while reading launch state in `Stop`

**Added:**

- Plugin manifest parsing - New `plugin/plugin.go` defines `Manifest` (name, version, description, skills) with a `PathList` type that accepts the format's string-or-array shorthand, ignores unknown fields so newer plugins keep parsing, and exposes `Load`/`ManifestPath` where a missing manifest returns an `fs.ErrNotExist`-compatible error so manifest-less directories stay ordinary directories
- Skill root resolution - `Manifest.SkillRoots` resolves declared roots to absolute paths, includes the default `skills/` directory first to match the format's extend-not-replace semantics, deduplicates entries, and returns valid roots alongside a joined error so one bad path never hides the rest
- Manifest-aware catalog expansion - `Catalog.catalogRoots` in `skill/catalog.go` expands a catalog directory into itself plus any manifest-declared roots, recording parse and validation failures as `LoadError` entries
- Test coverage - `plugin/plugin_test.go` covers `PathList` unmarshaling, missing and malformed manifests, root resolution, and escape rejection; `skill/catalog_test.go` adds cases proving nested roots are discovered with the correct scope and origin, and that a broken `plugin.json` yields exactly one load error while depth-1 discovery still works
- Documentation - `docs/agents-and-skills.md` explains manifest-aware catalog discovery with a sample `skills` declaration and the load-warning behavior

**Changed:**

- Launch registry concurrency - `Registry.Launch` now returns a copy of the `Launched` record rather than the live pointer that the reaper goroutine mutates, and `Registry.Stop` reads status and process handle under the mutex before signaling, eliminating unsynchronized reads; the `Launch` doc comment notes the snapshot is not live and callers should poll `Get`