### PR TITLE
ci: run govulncheck on all PRs and tune renovate automerge cadence

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,16 @@
   ],
   postUpdateOptions: [
     'gomodTidy',
+    'gomodUpdateImportPaths',
   ],
+  constraints: {
+    go: '1.26',
+  },
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    labels: ['security'],
+    automerge: true,
+  },
   'pre-commit': {
     enabled: true,
   },
@@ -26,6 +35,15 @@
         'patch',
       ],
       automerge: true,
+    },
+    {
+      matchManagers: ['gomod'],
+      matchDepTypes: ['indirect'],
+      enabled: true,
+    },
+    {
+      matchPackageNames: ['github.com/moby/**'],
+      groupName: 'moby',
     },
   ],
 }

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,7 +1,10 @@
 ---
 name: Govulncheck
 on:
-  # Gate PRs that actually change dependencies.
+  # Runs on every PR (no paths filter) so it can be a required status check:
+  # a path-filtered required check never reports on non-dependency PRs and
+  # would block them from merging forever.
+  merge_group:
   pull_request:
     branches:
       - main
@@ -9,11 +12,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths:
-      - go.mod
-      - go.sum
-      - .hooks/govulncheck-scan.sh
-      - .github/workflows/govulncheck.yaml
   push:
     branches:
       - main

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,10 +6,10 @@ on:
     paths:
       - .github/renovate.json5
   schedule:
-    # Run every 4 hours. Renovate is the only thing that can merge automerge-
-    # enabled PRs, so the gap between "checks go green" and "next run" is how
-    # long a ready PR sits open.
-    - cron: "0 */4 * * *"
+    # Run hourly. Merging is delegated to GitHub via platformAutomerge +
+    # required status checks, so this cadence only bounds how fast new
+    # releases are picked up and conflicted branches get rebased.
+    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
**Key Changes:**

- Removed the paths filter from the govulncheck workflow so it reports on every PR, making it usable as a required status check that can't deadlock non-dependency PRs
- Delegated automerge to GitHub via platform automerge and required checks, tightening the Renovate schedule from every 4 hours to hourly
- Expanded Renovate coverage to indirect Go module dependencies, which previously went unbumped and left vulnerabilities that fail govulncheck

**Added:**

- Vulnerability alerting - Enabled `osvVulnerabilityAlerts` with a `vulnerabilityAlerts` rule that labels security PRs and automerges them
- Indirect dependency updates - Added a `gomod` package rule matching `indirect` dep types so transitive modules are updated instead of skipped
- Moby grouping - Added a `groupName` rule for `github.com/moby/**` so the API and client modules move together rather than as separate conflicting PRs
- Go toolchain pinning and import path rewrites - Added a `constraints.go` value of `1.26` and the `gomodUpdateImportPaths` post-update option so major version bumps rewrite import paths
- Merge queue support - Added the `merge_group` trigger to the govulncheck workflow

**Changed:**

- Govulncheck trigger scope - Dropped the `paths` filter on `go.mod`, `go.sum`, the scan hook, and the workflow file, with an inline comment explaining that a path-filtered required check never reports on unrelated PRs and blocks them permanently
- Renovate schedule - Changed the cron from `0 */4 * * *` to `0 * * * *`, with the comment rewritten to reflect that the cadence now only bounds release pickup and rebase latency rather than merge latency