### PR TITLE
test: widen scheduler interval assertion window to deflake CI

### DIFF
--- a/routine/scheduler_test.go
+++ b/routine/scheduler_test.go
@@ -148,7 +148,7 @@ func TestSchedulerFiresOnInterval(t *testing.T) {
 	setupTempXDG(t)
 	store := NewStore()
 	ref := Ref{Scope: ScopeGlobal, ID: "fast"}
-	if _, err := store.Create(ref, &Routine{ID: "fast", Agent: "go", Schedule: "@every 200ms", Enabled: true}); err != nil {
+	if _, err := store.Create(ref, &Routine{ID: "fast", Agent: "go", Schedule: "@every 100ms", Enabled: true}); err != nil {
 		t.Fatal(err)
 	}
 	var (
@@ -179,13 +179,16 @@ func TestSchedulerFiresOnInterval(t *testing.T) {
 		_ = sched.Shutdown(shutCtx)
 	}()
 
+	// Generous ceiling: only proves the scheduler fires at all, so headroom
+	// matters more than precision — loaded CI runners have stalled >1.5s and
+	// flaked the old 2s window.
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		mu.Lock()
 		got := count
 		mu.Unlock()
-		t.Fatalf("expected 2 fires within 2s, got %d", got)
+		t.Fatalf("expected 2 fires within 10s, got %d", got)
 	}
 }
 


### PR DESCRIPTION
**Key Changes:**

- Raised the fire-window timeout in `TestSchedulerFiresOnInterval` from 2s to 10s so loaded CI runners that stall past 1.5s no longer fail a test whose only real assertion is "the scheduler fires"
- Halved the routine's schedule interval from `@every 200ms` to `@every 100ms`, so the two expected fires still land quickly on an unloaded machine despite the wider ceiling
- Documented the intent inline so the generous timeout reads as deliberate headroom rather than a precision assertion

**Added:**

- Rationale comment above the `select` block explaining that the test only proves the scheduler fires at all, so headroom matters more than precision

**Changed:**

- Scheduler interval test timing - In `routine/scheduler_test.go`, the test routine now uses a 100ms schedule and the `select` guard waits up to 10 seconds, with the failure message updated to match the new window