### PR TITLE
fix: enable strict constraints filtering in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,10 @@
   constraints: {
     go: '1.26',
   },
+  // Without strict filtering the go constraint is advisory only: a digest
+  // bump can pull a dep whose go.mod demands a newer Go and break CI
+  // (k8s.io/kube-openapi -> go 1.27, PR #233).
+  constraintsFiltering: 'strict',
   osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {
     labels: ['security'],


### PR DESCRIPTION
**Key Changes:**

- Enabled `constraintsFiltering: 'strict'` so the declared `go: '1.26'` constraint actually filters candidate dependency versions instead of being advisory only
- Prevents digest bumps from pulling dependencies whose `go.mod` requires a newer Go toolchain and breaking CI, as happened with `k8s.io/kube-openapi` requiring go 1.27 in PR #233
- Documented the failure mode inline so the setting is not removed as redundant with the existing `constraints` block

**Added:**

- Strict constraint filtering plus an explanatory comment citing the concrete regression that motivated it — `.github/renovate.json5`