### PR TITLE
fix: disable major and digest updates for Go indirect deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,18 @@
       enabled: true,
     },
     {
+      // Indirect deps only get minor/patch bumps. A Go major changes the
+      // module path (/v2, .v5) and nothing here imports the new path, so the
+      // bump is reverted by `go mod tidy` (PRs #247-#250). Digest bumps of
+      // pseudo-versioned modules bypass constraintsFiltering and can drag in
+      // a newer Go requirement (k8s.io/kube-openapi -> go 1.27, PRs #233,
+      // #258).
+      matchManagers: ['gomod'],
+      matchDepTypes: ['indirect'],
+      matchUpdateTypes: ['major', 'digest'],
+      enabled: false,
+    },
+    {
       matchPackageNames: ['github.com/moby/**'],
       groupName: 'moby',
     },


### PR DESCRIPTION
**Key Changes:**

- Added a Renovate package rule that turns off `major` and `digest` updates for Go indirect dependencies, leaving minor/patch bumps enabled
- Documented the two concrete failure modes behind the rule so the exclusion is not mistaken for an arbitrary pin

**Added:**

- Renovate `packageRules` entry in `.github/renovate.json5` matching the `gomod` manager, `indirect` depType, and `major`/`digest` update types with `enabled: false`, placed directly after the existing rule that enables indirect updates so it narrows that rule rather than replacing it
- Inline comment recording the rationale: a Go major bump changes the module path (`/v2`, `.v5`) and, since nothing in the repo imports the new path, `go mod tidy` reverts it (PRs #247-#250); digest bumps of pseudo-versioned modules bypass `constraintsFiltering` and can pull in a newer Go requirement (`k8s.io/kube-openapi` raising the requirement to go 1.27, PRs #233, #258)