### PR TITLE
fix: drop manual go constraint in favor of go.mod-derived version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,12 +10,16 @@
     'gomodTidy',
     'gomodUpdateImportPaths',
   ],
-  constraints: {
-    go: '1.26',
-  },
-  // Without strict filtering the go constraint is advisory only: a digest
-  // bump can pull a dep whose go.mod demands a newer Go and break CI
-  // (k8s.io/kube-openapi -> go 1.27, PR #233).
+  // No explicit constraints.go: the toolchain used for `go mod tidy` and the
+  // strict filter below both derive from go.mod's `go` directive. A manual
+  // value is also run through strict-semver validation during filtering,
+  // and "1.26" fails it, logging "Invalid constraint used with strict
+  // constraintsFiltering" for every Go dep while contributing nothing.
+  //
+  // Strict filtering drops candidate releases whose own go.mod demands a
+  // newer Go than ours; without it a bump can break CI (k8s.io/kube-openapi
+  // -> go 1.27, PR #233). It cannot see pseudo-versions, hence the indirect
+  // digest exclusion in packageRules.
   constraintsFiltering: 'strict',
   osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {


### PR DESCRIPTION
**Key Changes:**

- Removed the hardcoded `constraints.go: '1.26'` value from the Renovate config, letting both `go mod tidy` and release filtering derive the Go version from go.mod's `go` directive instead
- Documented that the manual value was actively harmful: it fails Renovate's strict-semver validation, emitting "Invalid constraint used with strict constraintsFiltering" for every Go dependency while providing no benefit
- Retained `constraintsFiltering: 'strict'` with expanded rationale covering both what it protects against and its known blind spot

**Changed:**

- Comment block above `constraintsFiltering` in `.github/renovate.json5` - rewritten to explain why no explicit constraint is set, what strict filtering does (drops candidate releases whose go.mod demands a newer Go, preventing breakage like k8s.io/kube-openapi -> go 1.27 in PR #233), and why the indirect digest exclusion in `packageRules` is still needed (strict filtering cannot see pseudo-versions)

**Removed:**

- Manual Go version constraint - deleted the `constraints` object pinning `go: '1.26'` from `.github/renovate.json5`, eliminating the per-dependency validation warnings it caused and removing a value that would need manual maintenance on every Go version bump